### PR TITLE
Fix quote escape bug in products pipeline

### DIFF
--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -155,7 +155,7 @@ runs:
         echo "<details><summary>Validation Output</summary>" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`\n" >> $GITHUB_STEP_SUMMARY
-        echo "${{ steps.validate.outputs.stdout }}" >> $GITHUB_STEP_SUMMARY
+        echo '${{ steps.validate.outputs.stdout }}' >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "</details>" >> $GITHUB_STEP_SUMMARY
@@ -166,7 +166,7 @@ runs:
         echo "<details><summary>Show Plan</summary>" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`\n" >> $GITHUB_STEP_SUMMARY
-        echo "${{ steps.plan.outputs.stdout }}" >> $GITHUB_STEP_SUMMARY
+        echo '${{ steps.plan.outputs.stdout }}' >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "</details>" >> $GITHUB_STEP_SUMMARY

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -143,6 +143,9 @@ runs:
       id: action_summary
       shell: bash
       if: always()
+      env:
+        VALIDATE_OUTPUT: ${{ steps.validate.outputs.stdout }}
+        PLAN_OUTPUT: ${{ steps.plan.outputs.stdout }}
       working-directory: ${{ inputs.working_directory }}
       run: |
         echo "#"" Terraform ${{ inputs.oidc_type }} ${{ inputs.oidc_value }}" >> $GITHUB_STEP_SUMMARY
@@ -155,7 +158,7 @@ runs:
         echo "<details><summary>Validation Output</summary>" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`\n" >> $GITHUB_STEP_SUMMARY
-        echo '${{ steps.validate.outputs.stdout }}' >> $GITHUB_STEP_SUMMARY
+        echo "${VALIDATE_OUTPUT}" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "</details>" >> $GITHUB_STEP_SUMMARY
@@ -166,7 +169,7 @@ runs:
         echo "<details><summary>Show Plan</summary>" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`\n" >> $GITHUB_STEP_SUMMARY
-        echo '${{ steps.plan.outputs.stdout }}' >> $GITHUB_STEP_SUMMARY
+        echo "${PLAN_OUTPUT}" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "</details>" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Double quotes in output from terraform plan made build up of the workflow summary ending the quote and actually trying to access files. This lead to the workflow exiting with an error. Using single quotes hopefully resolves this issue

## Related Issue(s)
- #872

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
