### PR TITLE
Fix bug in products pipeline

### DIFF
--- a/.github/workflows/products-deploy.yml
+++ b/.github/workflows/products-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Terraform Initialize
-        uses: altinn/altinn-platform/actions/terraform/plan@bugfix/product-tf-pipeline
+        uses: altinn/altinn-platform/actions/terraform/plan@main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/products-deploy.yml
+++ b/.github/workflows/products-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Terraform Initialize
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: altinn/altinn-platform/actions/terraform/plan@bugfix/product-tf-pipeline
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -149,9 +149,10 @@ runs:
         ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
         ${{ env.DELIMITER }}1
         )
-        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 205500)
+        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 200000)
         echo "PLAN<<${{ env.DELIMITER }}2" >> $GITHUB_ENV
-        echo '[maybe truncated]' >> $GITHUB_ENV
+        echo '[Lines containing Refreshing state removed]' >> $GITHUB_ENV
+        echo '[Maybe further truncated see logs for complete plan output]' >> $GITHUB_ENV
         echo "${plan}" >> $GITHUB_ENV
         echo >> $GITHUB_ENV
         echo "${{ env.DELIMITER }}2" >> $GITHUB_ENV

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -149,7 +149,7 @@ runs:
         ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
         ${{ env.DELIMITER }}1
         )
-        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 95500)
+        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 205500)
         echo "PLAN<<${{ env.DELIMITER }}2" >> $GITHUB_ENV
         echo '[maybe truncated]' >> $GITHUB_ENV
         echo "${plan}" >> $GITHUB_ENV

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -145,12 +145,11 @@ runs:
     - name: truncate terraform plan result
       shell: bash
       run: |
-        plan=$(cat <<${{ env.DELIMITER }}
+        plan=$(cat <<${{ env.DELIMITER }}1
         ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
-        ${{ env.DELIMITER }}
+        ${{ env.DELIMITER }}1
         )
-        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 65500)
-        echo "${plan}"
+        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 95500)
         echo "PLAN<<${{ env.DELIMITER }}2" >> $GITHUB_ENV
         echo '[maybe truncated]' >> $GITHUB_ENV
         echo "${plan}" >> $GITHUB_ENV

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -139,6 +139,24 @@ runs:
         name: ${{ env.ARTIFACT_KEY }}
         path: ${{ inputs.working_directory }}/tfplan.out
 
+    - name: generate random delimiter
+      shell: bash
+      run: echo "DELIMITER=$(uuidgen)" >> $GITHUB_ENV
+    - name: truncate terraform plan result
+      shell: bash
+      run: |
+        plan=$(cat <<${{ env.DELIMITER }}
+        ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
+        ${{ env.DELIMITER }}
+        )
+        plan=$(echo "${plan}" | grep -v 'Refreshing state' | tail --bytes 65500)
+        echo "${plan}"
+        echo "PLAN<<${{ env.DELIMITER }}2" >> $GITHUB_ENV
+        echo '[maybe truncated]' >> $GITHUB_ENV
+        echo "${plan}" >> $GITHUB_ENV
+        echo >> $GITHUB_ENV
+        echo "${{ env.DELIMITER }}2" >> $GITHUB_ENV
+
     - name: Generate Terraform Summary
       id: action_summary
       uses: actions/github-script@v7
@@ -166,7 +184,7 @@ runs:
           <details><summary>Show Plan</summary>
           
           \`\`\`\n
-          ${{ steps.plan.outputs.stdout }}
+          ${{ env.PLAN }}
           \`\`\`
           
           </details>

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -145,7 +145,6 @@ runs:
       if: always()
       env:
         VALIDATE_OUTPUT: ${{ steps.validate.outputs.stdout }}
-        PLAN_OUTPUT: ${{ steps.plan.outputs.stdout }}
       with:
         github-token: ${{ inputs.gh_token }}
         script: |
@@ -167,7 +166,7 @@ runs:
           <details><summary>Show Plan</summary>
           
           \`\`\`\n
-          ${process.env.PLAN_OUTPUT}
+          ${{ steps.plan.outputs.stdout }}
           \`\`\`
           
           </details>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If plan output exceeds githubs maximum the pipeline will fail with an error `Argument list too long`.
This change will remove Refreshin state lines from the plan output and only leave the last 200000 bytes of the output.
This still might be to big but currently the whole output is allowed. If we see this error later we can adjust the number of bytes that are included.

## Related Issue(s)
- #884

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
