### PR TITLE
Replace last occurrence of steps.plan.outputs.stdout in summary build

### DIFF
--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -269,7 +269,7 @@ runs:
           <details><summary>Show Plan</summary>
 
           \`\`\`\n
-          ${{ steps.plan.outputs.stdout }}
+          ${{ env.PLAN }}
           \`\`\`
 
           </details>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Overlooked one other reference to `steps.plan.outputs.stdout` in a summary step

## Related Issue(s)
- #884 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
