### PR TITLE
Only run products pipeline when files relating to it has changed

### DIFF
--- a/.github/workflows/products-deploy.yml
+++ b/.github/workflows/products-deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/products-deploy.yml
+      - actions/terraform/apply/**
+      - actions/terraform/plan/**
+      - infrastructure/products/**
+      - products.yaml
   workflow_dispatch:
     inputs:
       log_level:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To avoid having pending workflows when other parts of the repo is updated we should limit when the products pipeline is executed

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
