### PR TITLE
Configure renovate to group minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,17 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "terraform",
+        "gomod"
+      ],
+      "groupName": "{{manager}} non-major dependencies",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupSlug": "{{manager}}-minor-patch"
+    }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To reduce the number of renovate PRs I suggest we group minor and patch updates into the same PR.
Major updates will still be in separate PRs

## Documentation
https://docs.renovatebot.com/configuration-options/#packagerules
