### PR TITLE
Set owner to lowercase in blobstorage permissions condition

### DIFF
--- a/infrastructure/products/azure_arm.tf
+++ b/infrastructure/products/azure_arm.tf
@@ -261,7 +261,7 @@ resource "azurerm_role_assignment" "product_readers_storage_blob_owner" {
    ${local.write_operations}
    OR 
    (
-    @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringStartsWith 'github.com/${local.configuration.admin.github.owner}/${lower(local.configuration.admin.github.repository)}/'
+    @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringStartsWith 'github.com/${lower(local.configuration.admin.github.owner)}/${lower(local.configuration.admin.github.repository)}/'
    )
   )
   EOT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reader user has no access as folder is in lowercase but condition is in upper case

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
