### PR TITLE
chore: fix default labels for toil issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/toil.yml
+++ b/.github/ISSUE_TEMPLATE/toil.yml
@@ -1,6 +1,6 @@
 name: Toil
 description: Create a none user-story issue (chore, tech issue, backend issue).
-labels: ["kind/chore", "status/draft"]
+labels: ["kind/chore", "kind/toil", "status/triage"]
 projects: Altinn/177
 body:
   - type: markdown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the `status/triage` instead of `status/draft`. Don't feel the need to differentiate on this. 

Toil issues in addition to `kind/chore` (to match the org labels and practices) gets `kind/toil`

