### PR TITLE
Add tf outputs

### DIFF
--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -116,8 +116,8 @@ runs:
       shell: bash
       run: |
         terraform apply -input=false -auto-approve ${{ inputs.tf_args }} tfplan.out
-        echo "outputs=$(terraform output -json)" >> $GITHUB_ENV
-        echo "result=${{ fromJson(env.outputs) }}" >> $GITHUB_OUTPUT
+        terraform output -json > tf_output.json
+        echo "result=$(cat tf_output.json)" >> $GITHUB_OUTPUT
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -116,8 +116,6 @@ runs:
       shell: bash
       run: |
         terraform apply -input=false -auto-approve ${{ inputs.tf_args }} tfplan.out
-        terraform output -json > tf_output.json
-        echo "result=$(cat tf_output.json)" >> $GITHUB_OUTPUT
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -116,6 +116,7 @@ runs:
       shell: bash
       run: |
         terraform apply -input=false -auto-approve ${{ inputs.tf_args }} tfplan.out
+        terraform output -json >> tf_output.json
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -1,5 +1,10 @@
 name: Terraform Plan
 description: Run terraform plan
+outputs:
+  result:
+    description: object contain all outputs from terraform apply
+    value: ${{ steps.apply.outputs.result }}
+
 inputs:
   working_directory:
     description: The directory where the Terraform project is located.
@@ -111,6 +116,8 @@ runs:
       shell: bash
       run: |
         terraform apply -input=false -auto-approve ${{ inputs.tf_args }} tfplan.out
+        echo "outputs=$(terraform output -json)" >> $GITHUB_ENV
+        echo "result=${{ fromJson(env.outputs) }}" >> $GITHUB_OUTPUT
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -1,10 +1,5 @@
 name: Terraform Plan
 description: Run terraform plan
-outputs:
-  result:
-    description: object contain all outputs from terraform apply
-    value: ${{ steps.apply.outputs.result }}
-
 inputs:
   working_directory:
     description: The directory where the Terraform project is located.

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -51,6 +51,9 @@ inputs:
   tf_args:
     description: Terraform arguments
     required: false
+  tf_output_file:
+    description: JSON file for dumping tf state output
+    default: tf_output.json
 
 runs:
   using: composite
@@ -116,7 +119,7 @@ runs:
       shell: bash
       run: |
         terraform apply -input=false -auto-approve ${{ inputs.tf_args }} tfplan.out
-        terraform output -json >> tf_output.json
+        terraform output -json >> ${{ inputs.tf_output_file }}
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}


### PR DESCRIPTION
Terrafrom outputs get written to default file `tf_outputs.json` or provided `tf_output_file` param 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
