### PR TITLE
feat: add a dedicated rg to host the resources managed by the promrules operator

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/prometheusrulegroups.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/prometheusrulegroups.tf
@@ -1,0 +1,8 @@
+// A resource group to host the PrometheusRuleGroups managed by the dis-promrulegroups-operator
+resource "azurerm_resource_group" "promctl" {
+  name     = "prom-rule-groups-rg"
+  location = "norwayeast"
+  tags = {
+    "app" = "dis-promrulegroups-operator"
+  }
+}


### PR DESCRIPTION
## Description
Create a dedicated resource group to host the PrometheusRuleGroups managed by the operator.

## Related Issue(s)
- #1103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new resource group for managing PrometheusRuleGroups.
	- The resource group is named "prom-rule-groups-rg" and located in "norwayeast" with appropriate application tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->