### PR TITLE
Add broker/corr as grafan editors

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -38,12 +38,23 @@ resource "azurerm_role_assignment" "grafana_identity_reader" {
 }
 
 locals {
-  altinn_30_developers      = "416302ed-fbab-41a4-8c8d-61f486fa79ca"
-  altinn_30_developers_prod = "2d962017-75cf-47f2-a76e-50591fbf7fe9"
-  altinn_30_operations      = "143ed28a-6e6d-4ca0-8273-eecb9c1665ba"
-  altinn_30_operations_prod = "5a5ed585-9f7c-4b94-80af-9ceee8124db3"
-  grafana_editor            = [local.altinn_30_developers, local.altinn_30_developers_prod]
-  grafana_admin             = [local.altinn_30_operations, local.altinn_30_operations_prod]
+  altinn_30_developers                    = "416302ed-fbab-41a4-8c8d-61f486fa79ca"
+  altinn_30_developers_prod               = "2d962017-75cf-47f2-a76e-50591fbf7fe9"
+  altinn_30_broker_test_developers        = "9b99f951-3873-4310-8baf-464b4da43f26"
+  altinn_30_broker_prod_developers        = "7708786a-aa50-4ce8-9f7f-e85459357de1"
+  altinn_30_correspondence_prod_developer = "89627577-7e88-446b-a64b-699a9208343c"
+  altinn_30_correspondence_test_developer = "12b73376-8726-493c-8d27-aa87e5213e6b"
+  altinn_30_operations                    = "143ed28a-6e6d-4ca0-8273-eecb9c1665ba"
+  altinn_30_operations_prod               = "5a5ed585-9f7c-4b94-80af-9ceee8124db3"
+  grafana_editor = [
+    local.altinn_30_developers,
+    local.altinn_30_developers_prod,
+    local.altinn_30_broker_test_developers,
+    local.altinn_30_broker_prod_developers,
+    local.altinn_30_correspondence_prod_developer,
+    local.altinn_30_correspondence_test_developer
+  ]
+  grafana_admin = [local.altinn_30_operations, local.altinn_30_operations_prod]
 }
 
 resource "azurerm_role_assignment" "grafana_admin" {
@@ -56,7 +67,7 @@ resource "azurerm_role_assignment" "grafana_admin" {
 }
 
 resource "azurerm_role_assignment" "grafana_editors" {
-  for_each                         = { for value in local.grafana_editor : value => value if value != null }
+  for_each                         = { for value in altinn_30_broker_prod_developerslocal.grafana_editor : value => value if value != null }
   scope                            = azurerm_dashboard_grafana.grafana.id
   role_definition_name             = "Grafana Editor"
   principal_id                     = each.value

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -38,21 +38,21 @@ resource "azurerm_role_assignment" "grafana_identity_reader" {
 }
 
 locals {
-  altinn_30_developers                    = "416302ed-fbab-41a4-8c8d-61f486fa79ca"
-  altinn_30_developers_prod               = "2d962017-75cf-47f2-a76e-50591fbf7fe9"
-  altinn_30_broker_test_developers        = "9b99f951-3873-4310-8baf-464b4da43f26"
   altinn_30_broker_prod_developers        = "7708786a-aa50-4ce8-9f7f-e85459357de1"
+  altinn_30_broker_test_developers        = "9b99f951-3873-4310-8baf-464b4da43f26"
   altinn_30_correspondence_prod_developer = "89627577-7e88-446b-a64b-699a9208343c"
   altinn_30_correspondence_test_developer = "12b73376-8726-493c-8d27-aa87e5213e6b"
+  altinn_30_developers                    = "416302ed-fbab-41a4-8c8d-61f486fa79ca"
+  altinn_30_developers_prod               = "2d962017-75cf-47f2-a76e-50591fbf7fe9"
   altinn_30_operations                    = "143ed28a-6e6d-4ca0-8273-eecb9c1665ba"
   altinn_30_operations_prod               = "5a5ed585-9f7c-4b94-80af-9ceee8124db3"
   grafana_editor = [
-    local.altinn_30_developers,
-    local.altinn_30_developers_prod,
-    local.altinn_30_broker_test_developers,
     local.altinn_30_broker_prod_developers,
+    local.altinn_30_broker_test_developers,
     local.altinn_30_correspondence_prod_developer,
     local.altinn_30_correspondence_test_developer
+    local.altinn_30_developers,
+    local.altinn_30_developers_prod,
   ]
   grafana_admin = [local.altinn_30_operations, local.altinn_30_operations_prod]
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -50,9 +50,9 @@ locals {
     local.altinn_30_broker_prod_developers,
     local.altinn_30_broker_test_developers,
     local.altinn_30_correspondence_prod_developer,
-    local.altinn_30_correspondence_test_developer
+    local.altinn_30_correspondence_test_developer,
     local.altinn_30_developers,
-    local.altinn_30_developers_prod,
+    local.altinn_30_developers_prod
   ]
   grafana_admin = [local.altinn_30_operations, local.altinn_30_operations_prod]
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -67,7 +67,7 @@ resource "azurerm_role_assignment" "grafana_admin" {
 }
 
 resource "azurerm_role_assignment" "grafana_editors" {
-  for_each                         = { for value in altinn_30_broker_prod_developerslocal.grafana_editor : value => value if value != null }
+  for_each                         = { for value in local.grafana_editor : value => value if value != null }
   scope                            = azurerm_dashboard_grafana.grafana.id
   role_definition_name             = "Grafana Editor"
   principal_id                     = each.value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add broker and correspondence developers as grafana editors to grafana.altinn.cloud


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded user groups for Grafana dashboard access, including new developer roles.
	- Enhanced permissions for additional developer groups with editor access.

- **Bug Fixes**
	- Ensured consistent application of error handling across role assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->