### PR TITLE
Configure Prometheus to remote write to AMW

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_data.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_data.tf
@@ -1,0 +1,1 @@
+# data "azurerm_client_config" "current" {}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k6_operator.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k6_operator.tf
@@ -1,4 +1,5 @@
 resource "helm_release" "k6_operator" {
+  depends_on       = [azurerm_kubernetes_cluster.k6tests]
   name             = "k6-operator"
   namespace        = "k6-operator-system"
   create_namespace = true

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus.tf
@@ -20,3 +20,26 @@ resource "helm_release" "kube_prometheus_stack" {
     cluster_name = "${azurerm_kubernetes_cluster.k6tests.name}" })}"
   ]
 }
+
+resource "azuread_application" "prometheus" {
+  display_name     = "adminservicestest-k6tests-prometheus"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "prometheus" {
+  client_id = azuread_application.prometheus.client_id
+}
+
+resource "azuread_application_federated_identity_credential" "prometheus" {
+  application_id = azuread_application.prometheus.id
+  display_name   = "adminservicestest-k6tests-prometheus"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = azurerm_kubernetes_cluster.k6tests.oidc_issuer_url
+  subject        = "system:serviceaccount:monitoring:kube-prometheus-stack-prometheus"
+}
+
+resource "azurerm_role_assignment" "monitoring_metrics_publisher" {
+  scope                = azurerm_monitor_workspace.k6tests_amw.default_data_collection_endpoint_id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azuread_service_principal.prometheus.id
+}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -6,9 +6,21 @@ grafana:
   enabled: false
 prometheus:
   enabled: true
+  serviceAccount:
+    annotations:
+      azure.workload.identity/client-id: "${client_id}"
   prometheusSpec:
+    podMetadata:
+      labels:
+        azure.workload.identity/use: "true"
     externalLabels:
       cluster: "${cluster_name}"
+    remoteWrite:
+      - url: "${remote_write_endpoint}"
+        azureAd:
+          cloud: "AzurePublic"
+          sdk:
+            tenantId: "${tenant_id}"
     priorityClassName: "system-cluster-critical"
     retention: 1d
     storageSpec:


### PR DESCRIPTION
## Related Issue(s)
- #1154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced Azure AD integration for enhanced security in monitoring configurations.
	- Added support for Azure workload identity in Prometheus service configuration.
- **Improvements**
	- Expanded Helm release parameters to include Azure AD application details.
	- Enhanced remote write capabilities with Azure AD settings for Prometheus.
- **Configuration Updates**
	- New data source for Azure client configuration added.
	- New resources for Azure AD application, service principal, and role assignments created.
	- Established dependencies to ensure proper order of operations in infrastructure provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->