### PR TITLE
fix: azurerm_role_assignment expects the serviceprincipal's object_id not the id

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus.tf
@@ -55,5 +55,5 @@ resource "azuread_application_federated_identity_credential" "prometheus" {
 resource "azurerm_role_assignment" "monitoring_metrics_publisher" {
   scope                = azurerm_monitor_workspace.k6tests_amw.default_data_collection_endpoint_id
   role_definition_name = "Monitoring Metrics Publisher"
-  principal_id         = azuread_service_principal.prometheus.id
+  principal_id         = azuread_service_principal.prometheus.object_id
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `principal_id` attribute in the role assignment for monitoring metrics publisher to ensure correct identification.

- **Chores**
	- Maintained existing configurations for other resources, ensuring stability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->