### PR TITLE
enable --web.enable-remote-write-receiver flag on prometheus-server

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -15,6 +15,7 @@ prometheus:
         azure.workload.identity/use: "true"
     externalLabels:
       cluster: "${cluster_name}"
+    enableRemoteWriteReceiver: true
     remoteWrite:
       - url: "${remote_write_endpoint}"
         azureAd:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to enable remote write capabilities in the Prometheus monitoring system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->