### PR TITLE
fix: add these to the config to prevent drift

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -8,6 +8,11 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
     name       = "default"
     node_count = 1
     vm_size    = "Standard_D2_v2"
+    upgrade_settings { # Adding these to keep plans clean
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
   }
 
   workload_identity_enabled = true
@@ -30,6 +35,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot" {
   eviction_policy       = "Delete"
   spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
   node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
     spot : true
   }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
 }


### PR DESCRIPTION
This should prevent the Terraform plan from being polluted.