### PR TITLE
fix: Change authorization from Azure RBAC to Kubernetes RBAC

### DIFF
--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -52,6 +52,34 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+        # TODO: This needs a review once I'm done with the PoC
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      # TODO: This needs a review once I'm done with the PoC
+      - name: Populate kubeconfig with k6 context
+        id: populate_kubeconfig_with_k6_context
+        shell: bash
+        run: |
+          if ! az aks install-cli; then
+            echo "Failed to install kubectl CLI"
+            exit 1
+          fi
+
+          if ! az aks get-credentials --resource-group k6tests-rg --name k6tests-cluster; then
+            echo "Failed to populate kubeconfig"
+            exit 1
+          fi
+
+          if ! kubelogin convert-kubeconfig -l azurecli; then
+            echo "Failed to convert kubeconfig"
+            exit 1
+          fi
+
       - name: Terraform Plan
         uses: altinn/altinn-platform/actions/terraform/plan@main
         with:
@@ -73,6 +101,34 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      # TODO: This needs a review once I'm done with the PoC
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      # TODO: This needs a review once I'm done with the PoC
+      - name: Populate kubeconfig with k6 context
+        id: populate_kubeconfig_with_k6_context
+        shell: bash
+        run: |
+          if ! az aks install-cli; then
+            echo "Failed to install kubectl CLI"
+            exit 1
+          fi
+
+          if ! az aks get-credentials --resource-group k6tests-rg --name k6tests-cluster; then
+            echo "Failed to populate kubeconfig"
+            exit 1
+          fi
+
+          if ! kubelogin convert-kubeconfig -l azurecli; then
+            echo "Failed to convert kubeconfig"
+            exit 1
+          fi
 
       - name: Terraform Apply
         uses: altinn/altinn-platform/actions/terraform/apply@main

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -29,7 +29,7 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
   azure_active_directory_role_based_access_control {
     # tenant_id = "" # Optional
     admin_group_object_ids = ["c9c317cc-aec0-4c8b-bdad-b54333686e8a"]
-    azure_rbac_enabled     = true
+    azure_rbac_enabled     = false
   }
 
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_providers.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_providers.tf
@@ -24,9 +24,6 @@ provider "azurerm" {
 */
 provider "helm" {
   kubernetes {
-    host                   = azurerm_kubernetes_cluster.k6tests.kube_config[0].host
-    client_certificate     = base64decode(azurerm_kubernetes_cluster.k6tests.kube_config[0].client_certificate)
-    client_key             = base64decode(azurerm_kubernetes_cluster.k6tests.kube_config[0].client_key)
-    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.k6tests.kube_config[0].cluster_ca_certificate)
+    config_path = "~/.kube/config"
   }
 }


### PR DESCRIPTION
## Description
It was supposed to be Kubernetes RBAC, not Azure RBAC.

I had to add the proper roles to the SP to get this to work as the kubernetes auth now works differently than before (hence the need to tweak the helm provider and those extra steps on the github action).

## Related Issue(s)
- #1216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Infrastructure Updates**
	- Updated GitHub Actions workflow for Altinn Monitor Test resource group deployment with new authentication and configuration steps.
	- Modified Azure Kubernetes Service (AKS) configuration.
		- Disabled Azure RBAC.
	- Updated Helm provider configuration to simplify connection settings by using a local kubeconfig file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->