### PR TITLE
fix: add temporary_name_for_rotation to default_node_pool config

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -15,6 +15,7 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
       max_surge                     = "10%"
       node_soak_duration_in_minutes = 0
     }
+    temporary_name_for_rotation = "tmpdefault"
   }
 
   workload_identity_enabled = true


### PR DESCRIPTION
To fix apply error:

`Error: `temporary_name_for_rotation` must be specified when updating any of the following properties ["default_node_pool.0.name" "default_node_pool.0.host_encryption_enabled" "default_node_pool.0.node_public_ip_enabled" "default_node_pool.0.fips_enabled" "default_node_pool.0.kubelet_config" "default_node_pool.0.linux_os_config" "default_node_pool.0.max_pods" "default_node_pool.0.only_critical_addons_enabled" "default_node_pool.0.os_disk_size_gb" "default_node_pool.0.os_disk_type" "default_node_pool.0.pod_subnet_id" "default_node_pool.0.snapshot_id" "default_node_pool.0.ultra_ssd_enabled" "default_node_pool.0.vnet_subnet_id" "default_node_pool.0.vm_size" "default_node_pool.0.zones"]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure Update**
  - Added temporary name rotation configuration for Kubernetes cluster node pool
  - Supports infrastructure management and potential cluster upgrades

<!-- end of auto-generated comment: release notes by coderabbit.ai -->