### PR TITLE
feat: create a dedicated pool for prometheus and beef up the instance

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -54,3 +54,22 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot" {
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
   ]
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
+  name                  = "prometheus"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D3_v2"
+  auto_scaling_enabled  = false
+  node_count            = 1
+  priority              = "Spot" # Spot since we are still testing
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    prometheus : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+    "workload=prometheus:NoSchedule",
+  ]
+}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -22,6 +22,18 @@ prometheus:
           cloud: "AzurePublic"
           sdk:
             tenantId: "${tenant_id}"
+    tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
+      - key: "workload"
+        operator: "Equal"
+        value: "prometheus"
+        effect: "NoSchedule"
+    resources:
+      requests:
+        memory: 8Gi
     priorityClassName: "system-cluster-critical"
     retention: 1d
     storageSpec:
@@ -29,4 +41,4 @@ prometheus:
         spec:
           resources:
             requests:
-              storage: 5Gi
+              storage: 15Gi


### PR DESCRIPTION
Dagfinn is running more resource intensive tests and Prometheus is starting to struggle.
![image](https://github.com/user-attachments/assets/43cb1741-6014-4a87-a8d3-376fc6d9f39f)

This PR adds a dedicated node(pool) for Prometheus, sets memory requests and increases the storage requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Infrastructure**
	- Added a dedicated Prometheus node pool to the Kubernetes cluster.
	- Configured node pool with spot pricing and specific workload labels.
	- Updated Prometheus service configuration with enhanced resource allocation and scheduling tolerations.
	- Increased Prometheus storage claim from 5Gi to 15Gi.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->