### PR TITLE
fix: add missing nodeSelector config

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -34,6 +34,8 @@ prometheus:
     resources:
       requests:
         memory: 8Gi
+    nodeSelector:
+      prometheus: true
     priorityClassName: "system-cluster-critical"
     retention: 1d
     storageSpec:


### PR DESCRIPTION
Forgot to add the nodeSelector config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated Prometheus deployment configuration to allow specific node selection for Prometheus instances
	- Added node label criteria for Prometheus scheduling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->