### PR TITLE
feat: add unzip to azure devops agent image

### DIFF
--- a/infrastructure/images/azure-devops-agent/Dockerfile
+++ b/infrastructure/images/azure-devops-agent/Dockerfile
@@ -9,6 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     git \
     iputils-ping \
     jq \
+    unzip \
     lsb-release \
     software-properties-common && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Many of the installers used in azure devops steps require unzip to be installed it seems. 
Adding it to the base image

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
