### PR TITLE
feat: Add RBAC rules for devs and SPs

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_providers.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_providers.tf
@@ -27,3 +27,7 @@ provider "helm" {
     config_path = "~/.kube/config"
   }
 }
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -1,0 +1,87 @@
+resource "kubernetes_cluster_role_v1" "dev_access" {
+  metadata {
+    name = "dev-access"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["get", "list", "watch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["k6.io"]
+    resources  = ["testruns"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["list", "watch"]
+  }
+  rule {
+    api_groups = ["bitnami.com"]
+    resources  = ["sealedsecrets"]
+    verbs      = ["list", "watch", "delete"]
+  }
+}
+
+resource "kubernetes_cluster_role_v1" "sp_access" {
+  metadata {
+    name = "github-sp-access"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["create", "update"]
+  }
+  rule {
+    api_groups = ["bitnami.com"]
+    resources  = ["sealedsecrets"]
+    verbs      = ["create", "update"]
+  }
+  rule {
+    api_groups = ["k6.io"]
+    resources  = ["testruns"]
+    verbs      = ["create", "update"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "dialogporten_dev_access" {
+  metadata {
+    name      = "dev-access"
+    namespace = "dialogporten"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "dev-access"
+  }
+  subject {
+    kind      = "Group"
+    namespace = "dialogporten"
+    name      = "c403060d-5c8a-41b0-8c19-84fa60d0ce18"
+  }
+}
+
+resource "kubernetes_role_binding_v1" "dialogporten_sp_access" {
+  metadata {
+    name      = "github-sp-access"
+    namespace = "dialogporten"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "github-sp-access"
+  }
+  subject {
+    kind      = "Group"
+    namespace = "dialogporten"
+    name      = "b22b612d-9dc5-4f8b-8816-e551749bd19c"
+  }
+}


### PR DESCRIPTION
Still in discovery phase so this might change in the future. Particularly, I'm still not sure I like managing k8s resources via Terraform.

## Related Issue(s)
- #1217  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added Kubernetes provider configuration for infrastructure management.
	- Implemented Role-Based Access Control (RBAC) for Kubernetes cluster.
	- Created two Cluster Roles with specific resource permissions: `dev_access` and `sp_access`.
	- Established Role Bindings for different user groups in the Dialogporten namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->