### PR TITLE
fix: should be a string

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -35,7 +35,7 @@ prometheus:
       requests:
         memory: 8Gi
     nodeSelector:
-      prometheus: true
+      prometheus: "true"
     priorityClassName: "system-cluster-critical"
     retention: 1d
     storageSpec:


### PR DESCRIPTION
`Error: cannot patch "kube-prometheus-stack-prometheus" with kind Prometheus: Prometheus.monitoring.coreos.com "kube-prometheus-stack-prometheus" is invalid: spec.nodeSelector.prometheus: Invalid value: "boolean": spec.nodeSelector.prometheus in body must be of type string: "boolean"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Modified Prometheus node selector configuration from boolean to string value
	- This change may impact Kubernetes scheduler node selection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->