### PR TITLE
fix: add a few more permissions to reflect the current script requirements

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -38,7 +38,7 @@ resource "kubernetes_cluster_role_v1" "sp_access" {
   rule {
     api_groups = [""]
     resources  = ["configmaps"]
-    verbs      = ["create", "update"]
+    verbs      = ["create", "update", "delete"]
   }
   rule {
     api_groups = ["bitnami.com"]
@@ -48,7 +48,17 @@ resource "kubernetes_cluster_role_v1" "sp_access" {
   rule {
     api_groups = ["k6.io"]
     resources  = ["testruns"]
-    verbs      = ["create", "update"]
+    verbs      = ["create", "update", "get", "watch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods/log"]
+    verbs      = ["get", "list"]
   }
 }
 


### PR DESCRIPTION
To fit the [current script](https://raw.githubusercontent.com/Altinn/dialogporten/8f5ce91209f5417eba04e60d8ce6c170f9969a16/tests/k6/tests/scripts/run-test-in-k8s.sh)'s needs.

I'm working on a Github Action that can be re-used by multiple teams.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Permissions Update**
	- Enhanced Kubernetes role permissions for service principal access
	- Added ability to delete configmaps
	- Expanded access to test runs with additional operations
	- Introduced new permissions for viewing pods and pod logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->