### PR TITLE
fix: remove linux/arm64 platform from docker build

### DIFF
--- a/.github/workflows/azdevops-agent-pr.yml
+++ b/.github/workflows/azdevops-agent-pr.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           context: ./infrastructure/images/azure-devops-agent
           push: false
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ github.repository }}/azure-devops-agent:test
         env:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}

--- a/.github/workflows/azdevops-agent-release.yml
+++ b/.github/workflows/azdevops-agent-release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           context: ./infrastructure/images/azure-devops-agent
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/${{ steps.vars.outputs.reponame }}/azure-devops-agent:v${{ steps.vars.outputs.version }}
         env:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
we use only the linux/amd64 platform in azure devops.
linux/arm64 seems to break during upgrade to ubuntu:24.04, removing it for now

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Azure DevOps agent workflow configurations to build Docker images only for `linux/amd64` platform
	- Removed support for `linux/arm64` architecture in build and release workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->