### PR TITLE
Add traefik config for grafana.altinn.cloud fwd

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
@@ -10,7 +10,7 @@ spec:
   redirectRegex:
     permanent: true
     regex: ^http(|s)://(.*)grafana.(.*)altinn.(no|cloud)(.*)
-    replacement:  https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com$${5}
+    replacement:  https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com\${5}
 YAML
 }
 

--- a/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
@@ -10,7 +10,7 @@ spec:
   redirectRegex:
     permanent: true
     regex: ^http(|s)://(.*)grafana.(.*)altinn.(no|cloud)(.*)
-    replacement:  https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com${5}
+    replacement:  https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com$${5}
 YAML
 }
 

--- a/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
@@ -10,7 +10,7 @@ spec:
   redirectRegex:
     permanent: true
     regex: ^http(|s)://(.*)grafana.(.*)altinn.(no|cloud)(.*)
-    replacement:  https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com\${5}
+    replacement:  'https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com${5}'
 YAML
 }
 

--- a/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
@@ -10,7 +10,7 @@ spec:
   redirectRegex:
     permanent: true
     regex: ^http(|s)://(.*)grafana.(.*)altinn.(no|cloud)(.*)
-    replacement:  'https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com${5}'
+    replacement: https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com$${5}
 YAML
 }
 

--- a/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/grafana-altinn-cloud.tf
@@ -1,0 +1,38 @@
+resource "kubectl_manifest" "grafana_altinn_cloud_middleware" {
+  depends_on = [kubectl_manifest.flux_traefik_kustomization]
+  yaml_body  = <<YAML
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-central-grafana
+  namespace: traefik
+spec:
+  redirectRegex:
+    permanent: true
+    regex: ^http(|s)://(.*)grafana.(.*)altinn.(no|cloud)(.*)
+    replacement:  https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com${5}
+YAML
+}
+
+resource "kubectl_manifest" "grafana_altinn_cloud_ingressroute" {
+  depends_on = [kubectl_manifest.grafana_altinn_cloud_middleware]
+  yaml_body  = <<YAML
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: redirect-to-central-grafana
+  namespace: traefik
+spec:
+  entryPoints:
+  - https
+  routes:
+  - kind: Rule
+    match: Host(`grafana.altinn.cloud`) || Host(`dev.grafana.altinn.cloud`) && PathPrefix(`/`)
+    middlewares:
+    - name: redirect-to-central-grafana
+      namespace: traefik
+    services:
+    - kind: TraefikService
+      name: noop@internal
+YAML
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add forwarder for grafana.altinn.cloud to Azure managed grafana


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added Traefik middleware and IngressRoute configuration for Grafana in the Altinn cloud environment.
	- Implemented URL redirection for Grafana domains using Kubernetes manifests.
	- Configured HTTPS routing for `grafana.altinn.cloud` and `dev.grafana.altinn.cloud`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->