### PR TITLE
feat: enable a few more container insights data collection tables

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -19,13 +19,13 @@ resource "azurerm_monitor_data_collection_rule" "k6tests" {
   }
 
   data_flow {
-    streams      = ["Microsoft-ContainerLog", ]
+    streams      = ["Microsoft-ContainerLog", "KubeEvents", "KubePodInventory", "KubeNodeInventory"]
     destinations = ["ciworkspace"]
   }
 
   data_sources {
     extension {
-      streams        = ["Microsoft-ContainerLog", ]
+      streams        = ["Microsoft-ContainerLog", "KubeEvents", "KubePodInventory", "KubeNodeInventory"]
       extension_name = "ContainerInsights"
       extension_json = jsonencode({
         "dataCollectionSettings" : {


### PR DESCRIPTION
Enabling a few more tables to check the types of data I get.
I've tested that the logs are correctly being sent to the LAW and I was able to query them from within Grafana.
The devex is not that great as I'm filtering by container id instead of pod name for example.
I'm also interested in seeing if we can get metrics around the nodes running the workloads which can be useful when running more demanding tests.
## Related Issue(s)
- #1262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced monitoring capabilities by expanding data collection to include Kubernetes events, pod inventories, and node inventories alongside container logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->