### PR TITLE
chore: put prometheus in a on demand node pool

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -117,15 +117,15 @@ resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
   vm_size               = "Standard_D3_v2"
   auto_scaling_enabled  = false
   node_count            = 1
-  priority              = "Spot" # Spot since we are still testing
-  eviction_policy       = "Delete"
-  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  # priority              = "Spot" # Spot since we are still testing
+  # eviction_policy       = "Delete"
+  # spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
   node_labels = {
-    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    # "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
     prometheus : true
   }
   node_taints = [
-    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+    # "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
     "workload=prometheus:NoSchedule",
   ]
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -23,10 +23,10 @@ prometheus:
           sdk:
             tenantId: "${tenant_id}"
     tolerations:
-      - key: "kubernetes.azure.com/scalesetpriority"
-        operator: "Equal"
-        value: "spot"
-        effect: "NoSchedule"
+    #  - key: "kubernetes.azure.com/scalesetpriority"
+    #    operator: "Equal"
+    #    value: "spot"
+    #    effect: "NoSchedule"
       - key: "workload"
         operator: "Equal"
         value: "prometheus"


### PR DESCRIPTION
The K6 cluster is being used more frequently now so it makes sense to have a little bit more reliability