### PR TITLE
chore: bump prometheus retention to 8d

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -37,7 +37,7 @@ prometheus:
     nodeSelector:
       prometheus: "true"
     priorityClassName: "system-cluster-critical"
-    retention: 6h
+    retention: 8d
     storageSpec:
       volumeClaimTemplate:
         spec:


### PR DESCRIPTION
Bumping the retention to 8d and testing an SLO based on 7d of metrics.
## Related Issue(s)
- #1160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended the monitoring data retention period from 6 hours to 8 days, offering improved historical insights.
  - Introduced a new scheduling rule for improved workload placement, enhancing overall service reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->