### PR TITLE
fix: should be a boolean

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_pyrra.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_pyrra.tf
@@ -8,6 +8,6 @@ resource "helm_release" "pyrra" {
   version          = "0.14.2"
   set {
     name  = "genericRules.enabled"
-    value = "true"
+    value = true
   }
 }


### PR DESCRIPTION
I've noticed that the generic rules are not being generated. I wonder if it's because the value is supposed to be a boolean instead of a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised an internal configuration value to ensure parameters are interpreted correctly, enhancing system stability and consistency. This adjustment operates behind the scenes and does not introduce any visible changes to the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->