### PR TITLE
chore: Pin terraform version to 1.10.5

### DIFF
--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -62,7 +62,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: "1.10.5"
 
   deploy:
     name: Deploy
@@ -83,4 +82,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: "1.10.5"

--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -62,6 +62,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_version: 1.10.5
 
   deploy:
     name: Deploy
@@ -82,3 +83,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_version: 1.10.5

--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -62,7 +62,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: latest
+          tf_version: "1.10.5"
 
   deploy:
     name: Deploy
@@ -83,4 +83,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: latest
+          tf_version: "1.10.5"

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -35,7 +35,6 @@ env:
   ENVIRONMENT: test
   TF_STATE_NAME: altinn-apim-test-rg.tfstate
   TF_PROJECT: ./infrastructure/adminservices-test/altinn-apim-test-rg
-  TF_VERSION: "1.10.5"
   ARM_CLIENT_ID: ${{ vars.TF_AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: 1ce8e9af-c2d6-44e7-9c5e-099a308056fe
 
@@ -63,7 +62,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: ${{ env.TF_VERSION }}
 
   deploy:
     name: Deploy
@@ -84,4 +82,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -35,6 +35,7 @@ env:
   ENVIRONMENT: test
   TF_STATE_NAME: altinn-apim-test-rg.tfstate
   TF_PROJECT: ./infrastructure/adminservices-test/altinn-apim-test-rg
+  TF_VERSION: "1.10.5"
   ARM_CLIENT_ID: ${{ vars.TF_AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: 1ce8e9af-c2d6-44e7-9c5e-099a308056fe
 
@@ -62,6 +63,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_version: ${{ env.TF_VERSION }}
 
   deploy:
     name: Deploy
@@ -82,3 +84,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -90,6 +90,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_version: 1.10.5
 
   deploy:
     name: Deploy
@@ -138,3 +139,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_version: 1.10.5

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -90,7 +90,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: latest
+          tf_version: "1.10.5"
 
   deploy:
     name: Deploy
@@ -139,4 +139,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: latest
+          tf_version: "1.10.5"

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -90,7 +90,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: "1.10.5"
 
   deploy:
     name: Deploy
@@ -139,4 +138,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: "1.10.5"

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -62,7 +62,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: "1.10.5"
 
   deploy:
     name: Deploy
@@ -83,4 +82,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: "1.10.5"

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -62,6 +62,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_version: 1.10.5
 
   deploy:
     name: Deploy
@@ -82,3 +83,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_version: 1.10.5

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -62,7 +62,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: latest
+          tf_version: "1.10.5"
 
   deploy:
     name: Deploy
@@ -83,4 +83,4 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: latest
+          tf_version: "1.10.5"

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -39,7 +39,7 @@ inputs:
     default: tfstate
   tf_version:
     description: Terraform Version
-    default: 1.10.5
+    default: ~1.10.5
   tf_log_level:
     description: Terraform Log level
     default: INFO

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -39,7 +39,7 @@ inputs:
     default: tfstate
   tf_version:
     description: Terraform Version
-    default: 1.7.4
+    default: 1.10.5
   tf_log_level:
     description: Terraform Log level
     default: INFO

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -39,7 +39,7 @@ inputs:
     default: tfstate
   tf_version:
     description: Terraform Version
-    default: 1.10.5
+    default: ~1.10.5
   tf_log_level:
     description: Terraform Log level
     default: INFO

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -39,7 +39,7 @@ inputs:
     default: tfstate
   tf_version:
     description: Terraform Version
-    default: 1.7.4
+    default: 1.10.5
   tf_log_level:
     description: Terraform Log level
     default: INFO


### PR DESCRIPTION
The latest version seems to have introduced a bug.
Example of a plan failure: https://github.com/Altinn/altinn-platform/actions/runs/13675431246/job/38234920477
Tested on another PR and it works when we downgrade the TF version: https://github.com/Altinn/altinn-platform/actions/runs/13675763649/job/38235845698
The PR I had the issue in initially: https://github.com/Altinn/altinn-platform/pull/1398

Semver ranges are supported too: https://github.com/hashicorp/setup-terraform?tab=readme-ov-file#inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment automation to use a fixed Terraform version for planning and execution.
  - Adjusted default configuration settings in deployment actions to promote consistent and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->