### PR TITLE
chore: Use default tf_version from Action

### DIFF
--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -62,7 +62,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: 1.10.5
 
   deploy:
     name: Deploy
@@ -83,4 +82,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: 1.10.5

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -82,4 +82,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -35,7 +35,6 @@ env:
   ENVIRONMENT: test
   TF_STATE_NAME: altinn-apim-test-rg.tfstate
   TF_PROJECT: ./infrastructure/adminservices-test/altinn-apim-test-rg
-  TF_VERSION: "1.10.5"
   ARM_CLIENT_ID: ${{ vars.TF_AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: 1ce8e9af-c2d6-44e7-9c5e-099a308056fe
 
@@ -63,7 +62,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: ${{ env.TF_VERSION }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -90,7 +90,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: 1.10.5
 
   deploy:
     name: Deploy
@@ -139,4 +138,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: 1.10.5

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -62,7 +62,6 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          tf_version: 1.10.5
 
   deploy:
     name: Deploy
@@ -83,4 +82,3 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: 1.10.5


### PR DESCRIPTION
Continuation of: https://github.com/Altinn/altinn-platform/pull/1399
Although I guess I could have done it in the previous one since It's actually possible to merge into master with failed checks,