### PR TITLE
Output terraform version in action log

### DIFF
--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -108,7 +108,9 @@ runs:
       shell: bash
       if: always()
       working-directory: ${{ inputs.working_directory }}
-      run: terraform validate -no-color
+      run: |
+        terraform version
+        terraform validate -no-color
 
     - name: Terraform Plan
       id: plan


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Output terraform binary version used in action run

## Related Issue(s)
- #1424 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the workflow to display the current Terraform version before validation, offering clearer log context and aiding troubleshooting without altering the existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->