### PR TITLE
bugfix: dis-apim image fails to build with both amd64 and arm64

### DIFF
--- a/.github/workflows/dis-apim-release.yml
+++ b/.github/workflows/dis-apim-release.yml
@@ -30,4 +30,5 @@ jobs:
       release_latest: true
       tag_prefix: dis-apim-
       image_name: dis-apim-operator
+      platforms: "linux/amd64"
       workdir: ./services/dis-apim-operator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
suspect the buildtime for arm64 make the GH token expire. [ref](https://github.com/Altinn/altinn-platform/actions/runs/13895918389/job/38876669500)

The scan build only takes 3 minutes, the amd and arm takes >20 minutes.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release build process by explicitly targeting the Linux/AMD64 architecture for enhanced consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->