### PR TITLE
Reader - List cluster admin cred action.

### DIFF
--- a/infrastructure/products/azure_arm.tf
+++ b/infrastructure/products/azure_arm.tf
@@ -57,6 +57,11 @@ data "azurerm_role_definition" "azure_kubernetes_service_cluster_user_role" {
   role_definition_id = "4abbcc35-e782-43d8-92c5-2d3f1bd2253f"
 }
 
+# https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#containers
+data "azurerm_role_definition" "azure_kubernetes_service_cluster_admin_role" {
+  role_definition_id = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
+}
+
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resources
 data "azurerm_resource_group" "tfstate" {
   name = var.arm_resource_group_name
@@ -197,6 +202,14 @@ resource "azurerm_role_assignment" "reader_azure_kubernetes_service_cluster_user
   scope                            = azurerm_management_group.parent.id
   principal_id                     = azuread_service_principal.reader.object_id
   role_definition_name             = data.azurerm_role_definition.azure_kubernetes_service_cluster_user_role.name
+  skip_service_principal_aad_check = true
+}
+
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment
+resource "azurerm_role_assignment" "reader_azure_kubernetes_service_cluster_admin_role" {
+  scope                            = azurerm_management_group.parent.id
+  principal_id                     = azuread_service_principal.reader.object_id
+  role_definition_name             = data.azurerm_role_definition.azure_kubernetes_service_cluster_admin_role.name
   skip_service_principal_aad_check = true
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add reder to [Azure Kubernetes Service Cluster Admin Role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/containers#azure-kubernetes-service-cluster-admin-role)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced role management for Azure Kubernetes Service (AKS) clusters by introducing a dedicated admin role. This update improves overall security and operational control by allowing a clear separation of administrative permissions without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->