### PR TITLE
chore: build only linux/amd64 image

### DIFF
--- a/.github/workflows/k6-action-image-release.yml
+++ b/.github/workflows/k6-action-image-release.yml
@@ -30,3 +30,4 @@ jobs:
       image_name: k6-action-image
       tag_prefix: k6-action-image-
       workdir: ./infrastructure/images/k6-action
+      platforms: linux/amd64


### PR DESCRIPTION
Same problem as in here: https://github.com/Altinn/altinn-platform/pull/1445, ref: [here](https://github.com/Altinn/altinn-platform/actions/runs/14102989368/attempts/1)
I thought it would be easy to build the image, then login, then push.
It doesn't look like the Github Action supports it atm tho.
Restricting the platforms as a quick fix until we find an alternative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated build and release process to specify the image’s target platform (linux/amd64) for enhanced consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->