### PR TITLE
chore: import existing ns and add code to support new namespaces

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_namespaces.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_namespaces.tf
@@ -1,0 +1,70 @@
+import {
+  to = kubernetes_namespace.dialogporten
+  id = "dialogporten"
+}
+
+resource "kubernetes_namespace" "dialogporten" {
+  metadata {
+    name = "dialogporten"
+  }
+}
+
+import {
+  to = kubernetes_namespace.correspondence
+  id = "correspondence"
+}
+
+resource "kubernetes_namespace" "correspondence" {
+  metadata {
+    name = "correspondence"
+  }
+}
+
+
+import {
+  to = kubernetes_namespace.core
+  id = "core"
+}
+
+resource "kubernetes_namespace" "core" {
+  metadata {
+    name = "core"
+  }
+}
+
+
+import {
+  to = kubernetes_namespace.authentication
+  id = "authentication"
+}
+
+resource "kubernetes_namespace" "authentication" {
+  metadata {
+    name = "authentication"
+  }
+}
+
+import {
+  to = kubernetes_namespace.platform
+  id = "platform"
+}
+
+resource "kubernetes_namespace" "platform" {
+  metadata {
+    name = "platform"
+  }
+}
+
+locals {
+  subset_namespaces = setsubtract(
+    [for v in var.k8s_rbac : v["namespace"]],
+    ["dialogporten", "correspondence", "core", "authentication", "platform"]
+  )
+}
+
+resource "kubernetes_namespace" "namespace" {
+  for_each = local.subset_namespaces
+  metadata {
+    name = each.value
+  }
+}


### PR DESCRIPTION
Eventually it will probably be easier to just nuke the infrastructure and re-deploy.
Let's cleanup first tho.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced infrastructure management to support dedicated namespace setups.
  - Introduced five distinct namespaces: `dialogporten`, `correspondence`, `core`, `authentication`, and `platform` for improved deployment segmentation.
  - Enabled dynamic provisioning for additional namespaces through configuration-driven automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->