### PR TITLE
chore: Add Azure Kubernetes Service Cluster User Role to AltinnPlatform-K6-Cluster-Users

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -1,3 +1,9 @@
+resource "azurerm_role_assignment" "azure_kubernetes_service_cluster_user_role" {
+  scope                = azurerm_kubernetes_cluster.k6tests.id
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
+  principal_id         = "b95b1fc9-7f21-49c3-8932-07161cd9ac5a"
+}
+
 resource "kubernetes_cluster_role_v1" "dev_access" {
   metadata {
     name = "dev-access"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced access control by introducing a new role assignment for Azure Kubernetes Service, streamlining role-based permissions within the infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->