### PR TITLE
chore: cleanup k6 infra deployment

### DIFF
--- a/.github/workflows/k6tests-rg-deploy.yml
+++ b/.github/workflows/k6tests-rg-deploy.yml
@@ -1,0 +1,204 @@
+name: k6tests-rg
+
+on:
+  pull_request:
+    types:
+      - opened
+      - closed
+      - synchronize
+      - reopened
+    branches:
+      - main
+    paths:
+      - .github/workflows/k6tests-rg-deploy.yml
+      - actions/terraform/apply/**
+      - actions/terraform/plan/**
+      - infrastructure/adminservices-test/k6tests-rg/**
+  workflow_dispatch:
+    inputs:
+      log_level:
+        required: true
+        description: Terraform Log Level
+        default: INFO
+        type: choice
+        options:
+          - TRACE
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+
+env:
+  ENVIRONMENT: test
+  TF_STATE_NAME: k6tests-rg.tfstate
+  TF_PROJECT: ./infrastructure/adminservices-test/k6tests-rg
+  TF_FOUNDATIONAL_MODULE: module.foundational
+  ARM_CLIENT_ID: ${{ vars.TF_AZURE_CLIENT_ID }}
+  ARM_SUBSCRIPTION_ID: 1ce8e9af-c2d6-44e7-9c5e-099a308056fe
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Plan
+    environment: reader
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Azure login
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Get k6tests_cluster_name and k6tests_resource_group_name from Terraform output
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
+        id: get_outputs_from_terraform
+        shell: bash
+        run: |
+          if ! terraform output k6tests_cluster_name; then
+            echo "Failed to get cluster name from terraform output"
+            exit 1
+          fi
+          echo "CLUSTER_NAME=$(terraform output k6tests_cluster_name)" >> "$GITHUB_OUTPUT"
+
+          if ! terraform output k6tests_resource_group_name; then
+            echo "Failed to get resource group name from terraform output"
+            exit 1
+          fi
+          echo "RESOURCE_GROUP_NAME=$(terraform output k6tests_resource_group_name)" >> "$GITHUB_OUTPUT"
+
+      - name: Populate kubeconfig with k6 context
+        id: populate_kubeconfig_with_k6_context
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
+        shell: bash
+        env:
+          CLUSTER_NAME: ${{ steps.get_outputs_from_terraform.outputs.CLUSTER_NAME }}
+          RESOURCE_GROUP_NAME: ${{ steps.get_outputs_from_terraform.outputs.RESOURCE_GROUP_NAME }}
+        run: |
+          if ! az aks install-cli; then
+            echo "Failed to install kubectl CLI"
+            exit 1
+          fi
+
+          if ! az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME --context k6tests-cluster --overwrite-existing; then
+            echo "Failed to populate kubeconfig"
+            exit 1
+          fi
+
+          if ! kubelogin convert-kubeconfig -l azurecli; then
+            echo "Failed to convert kubeconfig"
+            exit 1
+          fi
+
+      - name: Terraform Plan Foundational Module
+        uses: altinn/altinn-platform/actions/terraform/plan@main
+        if: contains(github.event.pull_request.labels.*.name, 'partial-plan-apply')
+        with:
+          working_directory: ${{ env.TF_PROJECT }}
+          oidc_type: environment
+          oidc_value: ${{ env.ENVIRONMENT }}
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_version: ${{ env.TF_VERSION }}
+          tf_args: -target=${{ env.TF_FOUNDATIONAL_MODULE }}
+
+      - name: Terraform Plan
+        uses: altinn/altinn-platform/actions/terraform/plan@main
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
+        with:
+          working_directory: ${{ env.TF_PROJECT }}
+          oidc_type: environment
+          oidc_value: ${{ env.ENVIRONMENT }}
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_version: ${{ env.TF_VERSION }}
+
+  deploy:
+    name: Deploy
+    environment: test
+    if: github.ref == 'refs/heads/main' && github.event.pull_request.merged == true
+    needs: plan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Azure login
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Get k6tests_cluster_name and k6tests_resource_group_name from Terraform output
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
+        id: get_outputs_from_terraform
+        shell: bash
+        run: |
+          if ! terraform output k6tests_cluster_name; then
+            echo "Failed to get cluster name from terraform output"
+            exit 1
+          fi
+          echo "CLUSTER_NAME=$(terraform output k6tests_cluster_name)" >> "$GITHUB_OUTPUT"
+
+          if ! terraform output k6tests_resource_group_name; then
+            echo "Failed to get resource group name from terraform output"
+            exit 1
+          fi
+          echo "RESOURCE_GROUP_NAME=$(terraform output k6tests_resource_group_name)" >> "$GITHUB_OUTPUT"
+
+      - name: Populate kubeconfig with k6 context
+        id: populate_kubeconfig_with_k6_context
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
+        shell: bash
+        run: |
+          if ! az aks install-cli; then
+            echo "Failed to install kubectl CLI"
+            exit 1
+          fi
+
+          if ! az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME --context k6tests-cluster --overwrite-existing; then
+            echo "Failed to populate kubeconfig"
+            exit 1
+          fi
+
+          if ! kubelogin convert-kubeconfig -l azurecli; then
+            echo "Failed to convert kubeconfig"
+            exit 1
+          fi
+
+      - name: Terraform Apply Foundational Module
+        uses: altinn/altinn-platform/actions/terraform/apply@main
+        if: contains(github.event.pull_request.labels.*.name, 'partial-plan-apply')
+        with:
+          working_directory: ${{ env.TF_PROJECT }}
+          oidc_type: environment
+          oidc_value: ${{ env.ENVIRONMENT }}
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_version: ${{ env.TF_VERSION }}
+          tf_args: -target=${{ env.TF_FOUNDATIONAL_MODULE }}
+
+      - name: Terraform Apply
+        uses: altinn/altinn-platform/actions/terraform/apply@main
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
+        with:
+          working_directory: ${{ env.TF_PROJECT }}
+          oidc_type: environment
+          oidc_value: ${{ env.ENVIRONMENT }}
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_version: ${{ env.TF_VERSION }}

--- a/infrastructure/adminservices-test/k6tests-rg/README.md
+++ b/infrastructure/adminservices-test/k6tests-rg/README.md
@@ -1,0 +1,1 @@
+# Infrastructure for K6 tests cluster

--- a/infrastructure/adminservices-test/k6tests-rg/data.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/data.tf
@@ -1,0 +1,21 @@
+data "azurerm_kubernetes_cluster" "k6tests" {
+  depends_on          = [module.foundational]
+  name                = module.foundational.k6tests_cluster_name
+  resource_group_name = module.foundational.k6tests_resource_group_name
+}
+
+# Meh, not sure I like this one.
+# It should be predicatable but there should be a better way.
+data "azurerm_monitor_data_collection_endpoint" "k6tests" {
+  depends_on          = [module.foundational]
+  name                = "k6tests-amw${random_string.suffix.result}"
+  resource_group_name = "MA_k6tests-amw_norwayeast_managed"
+}
+
+data "azurerm_monitor_data_collection_rule" "k6tests" {
+  depends_on          = [module.foundational]
+  name                = "k6tests-dcr${random_string.suffix.result}"
+  resource_group_name = module.foundational.k6tests_resource_group_name
+}
+
+data "azurerm_client_config" "current" {}

--- a/infrastructure/adminservices-test/k6tests-rg/locals.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/locals.tf
@@ -1,0 +1,51 @@
+locals {
+  tenant_id = data.azurerm_client_config.current.tenant_id
+
+  k8s_admin_group_object_ids = ["c9c317cc-aec0-4c8b-bdad-b54333686e8a"]
+  k8s_users_group_object_id  = "b95b1fc9-7f21-49c3-8932-07161cd9ac5a"
+
+  log_analytics_workspace_daily_quota_gb    = 5
+  log_analytics_workspace_retention_in_days = 30
+
+  k8s_rbac = {
+
+    authentication = {
+      namespace = "authentication"
+      dev_group = "5c42ac79-86e2-46d0-85d3-ae751dd5f057"
+      sp_group  = "328cbe61-aeb1-4782-bb36-d288c69b4f15"
+    }
+
+    core = {
+      namespace = "core"
+      dev_group = "4dde4651-a9ca-4df1-9e05-216272284c7d"
+      sp_group  = "e87d6f10-6fc0-4a09-a9b0-e8c994ed4052"
+    }
+
+    correspondence = {
+      namespace = "correspondence"
+      dev_group = "954a4d24-8c7e-4382-9861-2b5d1a515253"
+      sp_group  = "e36ca3b3-f495-45a5-bca4-4fc83424633f"
+    }
+
+    dialogporten = {
+      namespace = "dialogporten",
+      dev_group = "c403060d-5c8a-41b0-8c19-84fa60d0ce18"
+      sp_group  = "b22b612d-9dc5-4f8b-8816-e551749bd19c"
+    }
+  }
+  namespaces                  = toset([for v in local.k8s_rbac : v["namespace"]])
+  k6tests_cluster_name        = data.azurerm_kubernetes_cluster.k6tests.name
+  k6tests_resource_group_name = module.foundational.k6tests_resource_group_name
+  oidc_issuer_url             = data.azurerm_kubernetes_cluster.k6tests.oidc_issuer_url
+
+  # Hacky, the value doesn't exist in the provider.
+  # Opened an issue+PR: https://github.com/hashicorp/terraform-provider-azurerm/issues/29290
+  # This can be removed once a new release of the provider is released.
+  dce_metrics_ingestion_endpoint = replace(
+    data.azurerm_monitor_data_collection_endpoint.k6tests.logs_ingestion_endpoint,
+    "ingest",
+    "metrics.ingest"
+  )
+  dcr_immutable_id      = data.azurerm_monitor_data_collection_rule.k6tests.immutable_id
+  remote_write_endpoint = "${local.dce_metrics_ingestion_endpoint}/dataCollectionRules/${local.dcr_immutable_id}/streams/Microsoft-PrometheusMetrics/api/v1/write?api-version=2023-04-24"
+}

--- a/infrastructure/adminservices-test/k6tests-rg/main.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/main.tf
@@ -1,0 +1,34 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+}
+
+module "foundational" {
+  source     = "./modules/foundational"
+  tenant_id  = local.tenant_id
+  namespaces = local.namespaces
+
+  k8s_admin_group_object_ids = local.k8s_admin_group_object_ids
+  k8s_users_group_object_id  = local.k8s_users_group_object_id
+
+  log_analytics_workspace_daily_quota_gb    = local.log_analytics_workspace_daily_quota_gb
+  log_analytics_workspace_retention_in_days = local.log_analytics_workspace_retention_in_days
+
+  suffix = "-${random_string.suffix.result}"
+}
+
+module "services" {
+  depends_on = [module.foundational]
+  source     = "./modules/services"
+
+  tenant_id = local.tenant_id
+
+  k8s_rbac = local.k8s_rbac
+
+  k6tests_cluster_name = local.k6tests_cluster_name
+  oidc_issuer_url      = local.oidc_issuer_url
+
+  remote_write_endpoint = local.remote_write_endpoint
+
+  suffix = "-${random_string.suffix.result}"
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
@@ -1,0 +1,75 @@
+resource "azurerm_kubernetes_cluster" "k6tests" {
+  name                = "k6tests-cluster${var.suffix}"
+  location            = azurerm_resource_group.k6tests.location
+  resource_group_name = azurerm_resource_group.k6tests.name
+  dns_prefix          = "k6tests-cluster${var.suffix}"
+
+  workload_identity_enabled = true
+  oidc_issuer_enabled       = true
+  identity {
+    type = "SystemAssigned"
+  }
+
+  local_account_disabled            = true
+  role_based_access_control_enabled = true
+  azure_active_directory_role_based_access_control {
+    tenant_id              = var.tenant_id
+    admin_group_object_ids = var.k8s_admin_group_object_ids
+    azure_rbac_enabled     = false
+  }
+
+  oms_agent {
+    log_analytics_workspace_id      = azurerm_log_analytics_workspace.k6tests.id
+    msi_auth_for_monitoring_enabled = true
+  }
+
+  automatic_upgrade_channel = "stable"
+
+  default_node_pool {
+    name                 = "default"
+    auto_scaling_enabled = true
+    min_count            = 1
+    max_count            = 3
+    vm_size              = "Standard_D3_v2"
+    temporary_name_for_rotation = "tmpdefault"
+    max_pods = 200
+
+    upgrade_settings { # Adding these to keep plans clean
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot" {
+  name                  = "spot"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_DS2_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 10
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  max_pods              = 200
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
+  name                  = "prometheus"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D3_v2"
+  auto_scaling_enabled  = false
+  node_count            = 1
+  node_labels = {
+    workload : "prometheus"
+  }
+  node_taints = ["workload=prometheus:NoSchedule"]
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/monitoring.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/monitoring.tf
@@ -1,0 +1,71 @@
+resource "azurerm_monitor_workspace" "k6tests" {
+  name                = "k6tests-amw${var.suffix}"
+  resource_group_name = azurerm_resource_group.k6tests.name
+  location            = azurerm_resource_group.k6tests.location
+}
+
+resource "azurerm_log_analytics_workspace" "k6tests" {
+  name                = "k6tests-law${var.suffix}"
+  location            = azurerm_resource_group.k6tests.location
+  resource_group_name = azurerm_resource_group.k6tests.name
+  daily_quota_gb      = var.log_analytics_workspace_daily_quota_gb
+  retention_in_days   = var.log_analytics_workspace_retention_in_days
+}
+
+locals {
+  streams = [
+    "Microsoft-ContainerLog",
+    "Microsoft-KubeEvents",
+    "Microsoft-KubePodInventory",
+    "Microsoft-KubeNodeInventory"
+  ]
+
+  # https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-data-collection-configure?tabs=cli#configuration-file
+  data_collection_settings = {
+    "dataCollectionSettings" : {
+      "interval" : "1m",
+      "namespaceFilteringMode" : "Include",
+      "namespaces" : concat(
+        ["platform"],  # This can probably be removed once we "onboard ourselves"; else the code is here for other "system namespaces" we may care about
+        var.namespaces # Team namespaces
+      ),
+      "enableContainerLogV2" : false
+    }
+  }
+}
+
+resource "azurerm_monitor_data_collection_rule" "k6tests" {
+  name                = "k6tests-dcr${var.suffix}"
+  resource_group_name = azurerm_resource_group.k6tests.name
+  location            = azurerm_resource_group.k6tests.location
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.k6tests.id
+      name                  = "ciworkspace"
+    }
+  }
+
+  data_flow {
+    streams      = local.streams
+    destinations = ["ciworkspace"]
+  }
+
+  data_sources {
+    extension {
+      streams        = local.streams
+      extension_name = "ContainerInsights"
+      extension_json = jsonencode(local.data_collection_settings)
+      name           = "ContainerInsightsExtension"
+    }
+  }
+
+  description = "DCR for Azure Monitor Container Insights"
+}
+
+resource "azurerm_monitor_data_collection_rule_association" "k6tests" {
+  name                    = "ContainerInsightsExtension"
+  target_resource_id      = azurerm_kubernetes_cluster.k6tests.id
+  data_collection_rule_id = azurerm_monitor_data_collection_rule.k6tests.id
+  description             = "Association of container insights data collection rule. Deleting this association will break the data collection for this AKS Cluster."
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/outputs.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/outputs.tf
@@ -1,0 +1,7 @@
+output "k6tests_cluster_name" {
+  value = azurerm_kubernetes_cluster.k6tests.name
+}
+
+output "k6tests_resource_group_name" {
+  value = azurerm_resource_group.k6tests.name
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/rbac.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/rbac.tf
@@ -1,0 +1,5 @@
+resource "azurerm_role_assignment" "azure_kubernetes_service_cluster_user_role" {
+  scope                = azurerm_kubernetes_cluster.k6tests.id
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
+  principal_id         = var.k8s_users_group_object_id
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/rg.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/rg.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "k6tests" {
+  name     = "k6tests-rg${var.suffix}"
+  location = "norwayeast"
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/variables.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/variables.tf
@@ -1,0 +1,32 @@
+variable "suffix" {
+  type = string
+}
+
+variable "tenant_id" {
+  type = string
+}
+
+variable "namespaces" {
+  type        = list(string)
+  default     = []
+  description = "Namespaces to include in the azurerm_monitor_data_collection_rule dataCollectionSettings"
+}
+
+variable "k8s_admin_group_object_ids" {
+  type        = list(string)
+  description = "A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster."
+}
+variable "k8s_users_group_object_id" {
+  type        = string
+  description = "Group to assign the Azure Kubernetes Service Cluster User Role to"
+}
+
+variable "log_analytics_workspace_daily_quota_gb" {
+  type        = number
+  description = "The workspace daily quota for ingestion in GB."
+}
+
+variable "log_analytics_workspace_retention_in_days" {
+  type        = number
+  description = "The workspace data retention in days. Possible values are between 30 and 730"
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/configs.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/configs.tf
@@ -1,0 +1,69 @@
+locals {
+  namespaces = concat(
+    ["platform"], [
+      for v
+      in var.k8s_rbac :
+      v["namespace"]
+  ])
+
+  deploy_envs = [
+    {
+      name : "at22",
+      env_type : "dev",
+      suffix : "cloud"
+    },
+    {
+      name : "at23",
+      env_type : "dev",
+      suffix : "cloud"
+    },
+    {
+      name : "at24",
+      env_type : "dev",
+      suffix : "cloud"
+    },
+    {
+      name : "yt01",
+      env_type : "perf",
+      suffix : "cloud"
+    },
+    {
+      name : "tt02",
+      env_type : "staging",
+      suffix : "no"
+    },
+    {
+      name : "prod",
+      env_type : "prod",
+      suffix : "no"
+    },
+  ]
+
+  # Hacky-ish, might be easier to deploy to a single namespace and have a controller syncing into other namespaces
+  namespaces_deployenvs = distinct(flatten(
+    [for n in local.namespaces :
+      [for d in local.deploy_envs :
+        {
+          namespace  = n
+          deploy_env = d
+        }
+      ]
+    ]
+  ))
+}
+
+resource "kubernetes_config_map_v1" "deploy_environments_manifests" {
+  depends_on = [kubernetes_namespace.namespace]
+  for_each = {
+    for entry in local.namespaces_deployenvs :
+    "${entry.namespace}.${entry.deploy_env.name}"
+    => entry
+  }
+  metadata {
+    name      = "deploy-environments-${each.value.deploy_env.name}"
+    namespace = each.value.namespace
+  }
+  data = {
+    BASE_URL = each.value.deploy_env.name == "prod" ? "https://platform.altinn.no" : "https://platform.${each.value.deploy_env.name}.altinn.${each.value.deploy_env.suffix}"
+  }
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/k6_operator.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/k6_operator.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "k6_operator" {
+  depends_on       = [helm_release.prometheus_operator_crds]
+  name             = "k6-operator"
+  namespace        = "k6-operator-system"
+  create_namespace = true
+  repository       = "https://grafana.github.io/helm-charts"
+  chart            = "k6-operator"
+  version          = "3.11.1"
+  values           = [file("${path.module}/k6_operator_values.yaml")]
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/k6_operator_values.yaml
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/k6_operator_values.yaml
@@ -1,0 +1,7 @@
+installCRDs: true
+
+namespace:
+  create: false
+
+prometheus:
+  enabled: true

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/kube_prometheus.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/kube_prometheus.tf
@@ -1,0 +1,62 @@
+# TODO: Don't really like this hardcoded name.
+resource "azuread_application" "prometheus" {
+  display_name     = "adminservicestest-k6tests-prometheus${var.suffix}"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "prometheus" {
+  client_id = azuread_application.prometheus.client_id
+}
+
+# TODO: Don't really like this hardcoded name.
+resource "azuread_application_federated_identity_credential" "prometheus" {
+  application_id = azuread_application.prometheus.id
+  display_name   = "adminservicestest-k6tests-prometheus${var.suffix}"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = var.oidc_issuer_url
+  subject        = "system:serviceaccount:monitoring:kube-prometheus-stack-prometheus"
+}
+
+resource "helm_release" "prometheus_operator_crds" {
+  name       = "prometheus-operator-crds"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus-operator-crds"
+  version    = "18.0.1"
+}
+
+resource "helm_release" "kube_prometheus_stack" {
+  depends_on = [
+    azuread_application.prometheus,
+    helm_release.prometheus_operator_crds,
+  ]
+  name             = "kube-prometheus-stack"
+  namespace        = "monitoring"
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  skip_crds        = true
+  version          = "70.0.2"
+
+  values = [
+    "${templatefile(
+      "${path.module}/kube_prometheus_stack_values.tftpl",
+      {
+        cluster_name          = "${var.k6tests_cluster_name}",
+        client_id             = "${azuread_application.prometheus.client_id}",
+        tenant_id             = "${var.tenant_id}",
+        remote_write_endpoint = "${var.remote_write_endpoint}"
+      }
+    )}"
+  ]
+}
+
+data "azurerm_monitor_data_collection_rule" "prometheus" {
+  name                = "k6tests-amw${var.suffix}"
+  resource_group_name = "MA_k6tests-amw_norwayeast_managed"
+}
+
+resource "azurerm_role_assignment" "monitoring_metrics_publisher" {
+  scope                = data.azurerm_monitor_data_collection_rule.prometheus.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azuread_service_principal.prometheus.object_id
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/kube_prometheus_stack_values.tftpl
@@ -1,0 +1,42 @@
+crds:
+  enabled: false
+alertmanager:
+  enabled: true
+grafana:
+  enabled: false
+prometheus:
+  enabled: true
+  serviceAccount:
+    annotations:
+      azure.workload.identity/client-id: "${client_id}"
+  prometheusSpec:
+    podMetadata:
+      labels:
+        azure.workload.identity/use: "true"
+    externalLabels:
+      cluster: "${cluster_name}"
+    enableRemoteWriteReceiver: true
+    remoteWrite:
+      - url: "${remote_write_endpoint}"
+        azureAd:
+          cloud: "AzurePublic"
+          sdk:
+            tenantId: "${tenant_id}"
+    tolerations:
+      - key: "workload"
+        operator: "Equal"
+        value: "prometheus"
+        effect: "NoSchedule"
+    resources:
+      requests:
+        memory: 8Gi
+    nodeSelector:
+      workload: "prometheus"
+    priorityClassName: "system-cluster-critical"
+    retention: 8d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 64Gi

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/namespaces.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/namespaces.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_namespace" "namespace" {
+  for_each = toset(
+    concat(
+      ["platform"],
+      [for v in var.k8s_rbac : v["namespace"]]
+    )
+  )
+  metadata {
+    name = each.value
+  }
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/pyrra.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/pyrra.tf
@@ -1,0 +1,12 @@
+resource "helm_release" "pyrra" {
+  name             = "pyrra"
+  namespace        = "pyrra-system"
+  create_namespace = true
+  repository       = "https://rlex.github.io/helm-charts"
+  chart            = "pyrra"
+  version          = "0.14.2"
+  set {
+    name  = "genericRules.enabled"
+    value = "true"
+  }
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/rbac.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/rbac.tf
@@ -1,0 +1,103 @@
+resource "kubernetes_cluster_role_v1" "dev_access" {
+  metadata {
+    name = "dev-access"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["get", "list", "watch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["k6.io"]
+    resources  = ["testruns"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["list", "watch"]
+  }
+  rule {
+    api_groups = ["bitnami.com"]
+    resources  = ["sealedsecrets"]
+    verbs      = ["list", "watch", "delete"]
+  }
+}
+
+resource "kubernetes_cluster_role_v1" "sp_access" {
+  metadata {
+    name = "github-sp-access"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["create", "update", "delete", "get"]
+  }
+  rule {
+    api_groups = ["bitnami.com"]
+    resources  = ["sealedsecrets"]
+    verbs      = ["create", "update"]
+  }
+  rule {
+    api_groups = ["k6.io"]
+    resources  = ["testruns"]
+    verbs      = ["create", "update", "get", "list", "watch", "delete"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods/log"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "dev_access" {
+  depends_on = [kubernetes_namespace.namespace]
+  for_each   = var.k8s_rbac
+
+  metadata {
+    name      = "dev-access"
+    namespace = each.value.namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "dev-access"
+  }
+  subject {
+    kind      = "Group"
+    namespace = each.value.namespace
+    name      = each.value.dev_group
+  }
+}
+
+resource "kubernetes_role_binding_v1" "sp_access" {
+  depends_on = [kubernetes_namespace.namespace]
+  for_each   = var.k8s_rbac
+
+  metadata {
+    name      = "github-sp-access"
+    namespace = each.value.namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "github-sp-access"
+  }
+  subject {
+    kind      = "Group"
+    namespace = each.value.namespace
+    name      = each.value.sp_group
+  }
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/sealsedsecrets.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/sealsedsecrets.tf
@@ -1,0 +1,8 @@
+resource "helm_release" "sealed_secrets" {
+  name             = "sealedsecrets"
+  namespace        = "sealedsecrets-system"
+  create_namespace = true
+  repository       = "https://bitnami-labs.github.io/sealed-secrets"
+  chart            = "sealed-secrets"
+  version          = "2.17.1"
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/variables.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/variables.tf
@@ -1,0 +1,31 @@
+variable "suffix" {
+  type = string
+}
+
+variable "tenant_id" {
+  type = string
+}
+
+variable "k8s_rbac" {
+  type = map(
+    object(
+      {
+        namespace = string
+        dev_group = string
+        sp_group  = string
+      }
+    )
+  )
+}
+
+variable "k6tests_cluster_name" {
+  type = string
+}
+
+variable "oidc_issuer_url" {
+  type = string
+}
+
+variable "remote_write_endpoint" {
+  type = string
+}

--- a/infrastructure/adminservices-test/k6tests-rg/outputs.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/outputs.tf
@@ -1,0 +1,7 @@
+output "k6tests_cluster_name" {
+  value = local.k6tests_cluster_name
+}
+
+output "k6tests_resource_group_name" {
+  value = local.k6tests_resource_group_name
+}

--- a/infrastructure/adminservices-test/k6tests-rg/providers.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/providers.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.1"
+    }
+  }
+
+  backend "azurerm" {
+    use_azuread_auth = true
+  }
+
+}
+
+provider "azurerm" {
+  // subscription_id =
+  features {}
+}
+
+provider "helm" {
+  kubernetes {
+    config_path    = "~/.kube/config"
+    config_context = "k6tests-cluster"
+  }
+}
+
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "k6tests-cluster"
+}
+
+provider "random" {}


### PR DESCRIPTION
#1186 
The idea is to delete the old setup first and then re-create it with this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Deployed an automated workflow that streamlines continuous testing and deployment upon code changes.
	- Launched a dedicated performance testing environment featuring a highly scalable Kubernetes cluster with enhanced monitoring, flexible node configurations, and integrated operator deployments.
	- Introduced a ConfigMap resource for managing deployment environments dynamically within Kubernetes.
	- Added a Helm release for the K6 operator and integrated Prometheus monitoring within the Kubernetes environment.
	- Created a new Azure Resource Group and defined various resources for monitoring and managing Kubernetes clusters.
	- Established role-based access control (RBAC) for managing access in the Kubernetes environment.
	- Added new Terraform configurations for managing Azure resources, including data sources, outputs, and local variables.

- **Documentation**
	- Introduced an overview document outlining the purpose and setup of the new performance testing infrastructure.
	- Added a README file for the K6 tests cluster infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->