### PR TITLE
chore: remove duplication in terraform actions

### DIFF
--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -53,46 +53,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Terraform Install
-      id: install
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      with:
-        terraform_version: ${{ inputs.tf_version }}
-        terraform_wrapper: true
-
-    - name: Terraform Set Logger
-      id: logger
-      shell: bash
-      run: export TF_LOG="${{ inputs.tf_log_level == '' && 'INFO' || inputs.tf_log_level }}"
-
-    - name: Terraform Set State File Path
-      id: state_file_path_tmp
-      shell: bash
-      run: |
-        echo "TF_STATE_FILE_TMP=github.com/${GITHUB_REPOSITORY}/${{ inputs.oidc_type == 'environment' && 'environments' || 'branches' }}/${{ inputs.oidc_value }}/${{ inputs.tf_state_name }}" >> $GITHUB_ENV
-
-    - name: Terraform Set State File Path Lower
-      id: state_file_path
-      shell: bash
-      run: |
-        echo "TF_STATE_FILE=$(echo ${{ env.TF_STATE_FILE_TMP }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
     - name: Terraform Init
-      id: init
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-      env:
-        ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
-        ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
-        ARM_SUBSCRIPTION_ID: ${{ inputs.tf_arm_subscription_id }}
-        ARM_USE_OIDC: "true"
-      run: |
-        terraform init -input=false \
-          -backend-config="subscription_id=${{ inputs.tf_arm_subscription_id }}" \
-          -backend-config="resource_group_name=${{ inputs.tf_arm_resource_group_name }}" \
-          -backend-config="storage_account_name=${{ inputs.tf_arm_storage_account_name }}" \
-          -backend-config="container_name=tfstates" \
-          -backend-config="key=${{ env.TF_STATE_FILE }}"
+      uses: Altinn/altinn-platform/actions/terraform/init@main
+      with:
+        working_directory: ${{ inputs.working_directory }}
+
+        oidc_type: ${{ inputs.oidc_type }}
+        oidc_value: ${{ inputs.oidc_value }}
+
+        arm_client_id: ${{ inputs.arm_client_id }}
+        arm_subscription_id: ${{ inputs.arm_subscription_id }}
+        arm_tenant_id: ${{ inputs.arm_tenant_id }}
+
+        tf_arm_subscription_id: ${{ inputs.tf_arm_subscription_id }}
+        tf_arm_resource_group_name: ${{ inputs.tf_arm_resource_group_name }}
+        tf_arm_storage_account_name: ${{ inputs.tf_arm_storage_account_name }}
+        tf_state_name: ${{ inputs.tf_state_name }}
+
+        tf_version: ${{ inputs.tf_version }}
+        tf_log_level: ${{ inputs.tf_log_level }}
 
     - name: Artifact Key
       id: artifact_key

--- a/actions/terraform/init/action.yaml
+++ b/actions/terraform/init/action.yaml
@@ -1,0 +1,113 @@
+name: Terraform Init
+description: Setup Terraform
+inputs:
+  working_directory:
+    description: The directory where the Terraform project is located.
+    default: ./infrastructure
+    required: true
+
+  oidc_type:
+    description: Specifies a part of subject for OpenID Connect (OIDC), can be values 'branch' or 'environment'
+    required: true
+  oidc_value:
+    description: Name of branch or environment
+    required: true
+
+  arm_client_id:
+    required: true
+    description: Federated Azure Client ID.
+  arm_subscription_id:
+    required: true
+    description: Azure Subscription ID
+  arm_tenant_id:
+    description: Azure Tenant ID
+    default: cd0026d8-283b-4a55-9bfa-d0ef4a8ba21c
+
+  tf_arm_subscription_id:
+    required: true
+    default: d43d5057-8389-40d5-88c4-04db9275cbf2
+    description: Azure Subscription ID for the storage account that persists the terraform state
+  tf_arm_resource_group_name:
+    description: Azure resource group for the storage account that persists the terraform state
+    default: terraform-rg
+  tf_arm_storage_account_name:
+    description: Name of the azure storage account that persists the terraform state
+    default: altinnterraformstorage02
+  tf_state_name:
+    description: Name of Terraform state file
+    required: true
+    default: tfstate
+  tf_version:
+    description: Terraform Version
+    default: ~1.10.5
+  tf_log_level:
+    description: Terraform Log level
+    default: INFO
+  tf_args:
+    description: Terraform arguments
+    required: false
+
+  gh_token:
+    description: GitHub Token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Terraform Install
+      id: install
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      with:
+        terraform_version: ${{ inputs.tf_version }}
+        terraform_wrapper: true
+
+    - name: Terraform Set Logger
+      id: logger
+      shell: bash
+      run: export TF_LOG="${{ inputs.tf_log_level == '' && 'INFO' || inputs.tf_log_level }}"
+
+    - name: Terraform Set State File Path
+      id: state_file_path_tmp
+      shell: bash
+      run: |
+        echo "TF_STATE_FILE_TMP=github.com/${GITHUB_REPOSITORY}/${{ inputs.oidc_type == 'environment' && 'environments' || 'branches' }}/${{ inputs.oidc_value }}/${{ inputs.tf_state_name }}" >> $GITHUB_ENV
+
+    - name: Terraform Set State File Path Lower
+      id: state_file_path
+      shell: bash
+      run: |
+        echo "TF_STATE_FILE=$(echo ${{ env.TF_STATE_FILE_TMP }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Terraform Format
+      id: fmt
+      shell: bash
+      if: always()
+      working-directory: ${{ inputs.working_directory }}
+      run: terraform fmt -check
+
+    - name: Terraform Init
+      id: init
+      shell: bash
+      if: always()
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
+        ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
+        ARM_SUBSCRIPTION_ID: ${{ inputs.tf_arm_subscription_id }}
+        ARM_USE_OIDC: "true"
+      run: |
+        terraform init -input=false \
+          -backend-config="subscription_id=${{ inputs.tf_arm_subscription_id }}" \
+          -backend-config="resource_group_name=${{ inputs.tf_arm_resource_group_name }}" \
+          -backend-config="storage_account_name=${{ inputs.tf_arm_storage_account_name }}" \
+          -backend-config="container_name=tfstates" \
+          -backend-config="key=${{ env.TF_STATE_FILE }}"
+
+    - name: Terraform Validate
+      id: validate
+      shell: bash
+      if: always()
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        terraform version
+        terraform validate -no-color

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -54,63 +54,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Terraform Install
-      id: install
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      with:
-        terraform_version: ${{ inputs.tf_version }}
-        terraform_wrapper: true
-
-    - name: Terraform Set Logger
-      id: logger
-      shell: bash
-      run: export TF_LOG="${{ inputs.tf_log_level == '' && 'INFO' || inputs.tf_log_level }}"
-
-    - name: Terraform Set State File Path
-      id: state_file_path_tmp
-      shell: bash
-      run: |
-        echo "TF_STATE_FILE_TMP=github.com/${GITHUB_REPOSITORY}/${{ inputs.oidc_type == 'environment' && 'environments' || 'branches' }}/${{ inputs.oidc_value }}/${{ inputs.tf_state_name }}" >> $GITHUB_ENV
-
-    - name: Terraform Set State File Path Lower
-      id: state_file_path
-      shell: bash
-      run: |
-        echo "TF_STATE_FILE=$(echo ${{ env.TF_STATE_FILE_TMP }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-    - name: Terraform Format
-      id: fmt
-      shell: bash
-      if: always()
-      working-directory: ${{ inputs.working_directory }}
-      run: terraform fmt -check
-
     - name: Terraform Init
-      id: init
-      shell: bash
-      if: always()
-      working-directory: ${{ inputs.working_directory }}
-      env:
-        ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
-        ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
-        ARM_SUBSCRIPTION_ID: ${{ inputs.tf_arm_subscription_id }}
-        ARM_USE_OIDC: "true"
-      run: |
-        terraform init -input=false \
-          -backend-config="subscription_id=${{ inputs.tf_arm_subscription_id }}" \
-          -backend-config="resource_group_name=${{ inputs.tf_arm_resource_group_name }}" \
-          -backend-config="storage_account_name=${{ inputs.tf_arm_storage_account_name }}" \
-          -backend-config="container_name=tfstates" \
-          -backend-config="key=${{ env.TF_STATE_FILE }}"
+      uses: Altinn/altinn-platform/actions/terraform/init@main
+      with:
+        working_directory: ${{ inputs.working_directory }}
 
-    - name: Terraform Validate
-      id: validate
-      shell: bash
-      if: always()
-      working-directory: ${{ inputs.working_directory }}
-      run: |
-        terraform version
-        terraform validate -no-color
+        oidc_type: ${{ inputs.oidc_type }}
+        oidc_value: ${{ inputs.oidc_value }}
+
+        arm_client_id: ${{ inputs.arm_client_id }}
+        arm_subscription_id: ${{ inputs.arm_subscription_id }}
+        arm_tenant_id: ${{ inputs.arm_tenant_id }}
+
+        tf_arm_subscription_id: ${{ inputs.tf_arm_subscription_id }}
+        tf_arm_resource_group_name: ${{ inputs.tf_arm_resource_group_name }}
+        tf_arm_storage_account_name: ${{ inputs.tf_arm_storage_account_name }}
+        tf_state_name: ${{ inputs.tf_state_name }}
+
+        tf_version: ${{ inputs.tf_version }}
+        tf_log_level: ${{ inputs.tf_log_level }}
 
     - name: Terraform Plan
       id: plan


### PR DESCRIPTION
Removing the duplication from the plan and apply actions by creating a reusable action that can be called by both actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced Terraform initialization process with expanded configuration options for improved workflow execution.
- **Refactor**
  - Consolidated multiple setup steps into a unified initialization step, streamlining both apply and plan operations while removing redundant configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->