### PR TITLE
chore: configure concurrency in terraform workflows

### DIFF
--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -1,5 +1,9 @@
 name: admin-test-aks-rg
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   push:
     branches:

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -1,5 +1,9 @@
 name: altinn-apim-test-rg
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   push:
     branches:

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -1,5 +1,9 @@
 name: Altinn Monitor Test rg
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   push:
     branches:

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -1,5 +1,9 @@
 name: altinncr.azurecr.io deploy
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   push:
     branches:

--- a/.github/workflows/auth-at22-aks-rg.yml
+++ b/.github/workflows/auth-at22-aks-rg.yml
@@ -1,4 +1,9 @@
 name: auth-at22-aks-rg
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   push:
     branches:

--- a/.github/workflows/k6tests-rg-deploy.yml
+++ b/.github/workflows/k6tests-rg-deploy.yml
@@ -1,5 +1,9 @@
 name: k6tests-rg
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   pull_request:
     types:

--- a/.github/workflows/products-deploy.yml
+++ b/.github/workflows/products-deploy.yml
@@ -1,5 +1,9 @@
 name: Altinn Products
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+
 on:
   push:
     branches:


### PR DESCRIPTION
This should reduce the noise we have currently.
Relevant docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automation workflows with enhanced concurrency management. Now, when multiple jobs are triggered for the same branch or pull request, new runs cancel any in-progress jobs. This ensures only the latest execution is active, improving resource utilization and operational efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->