### PR TITLE
chore: pin terraform action versions

### DIFF
--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: Altinn/altinn-platform/actions/terraform/plan@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: altinn/altinn-platform/actions/terraform/apply@main
+        uses: Altinn/altinn-platform/actions/terraform/apply@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: Altinn/altinn-platform/actions/terraform/plan@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: altinn/altinn-platform/actions/terraform/apply@main
+        uses: Altinn/altinn-platform/actions/terraform/apply@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Terraform Plan
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: Altinn/altinn-platform/actions/terraform/plan@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -134,7 +134,7 @@ jobs:
           fi
 
       - name: Terraform Apply
-        uses: altinn/altinn-platform/actions/terraform/apply@main
+        uses: Altinn/altinn-platform/actions/terraform/apply@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: Altinn/altinn-platform/actions/terraform/plan@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: altinn/altinn-platform/actions/terraform/apply@main
+        uses: Altinn/altinn-platform/actions/terraform/apply@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/auth-at22-aks-rg.yml
+++ b/.github/workflows/auth-at22-aks-rg.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: Altinn/altinn-platform/actions/terraform/plan@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: altinn/altinn-platform/actions/terraform/apply@main
+        uses: Altinn/altinn-platform/actions/terraform/apply@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/products-deploy.yml
+++ b/.github/workflows/products-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Initialize
-        uses: altinn/altinn-platform/actions/terraform/plan@main
+        uses: Altinn/altinn-platform/actions/terraform/plan@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: altinn/altinn-platform/actions/terraform/apply@main
+        uses: Altinn/altinn-platform/actions/terraform/apply@fcd122fb2c05b528c6c834a4ddf77247cb3d2c7f # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment


### PR DESCRIPTION
Pinned to the latest version of main.
This will make it easier to test new versions of the action and control the rollout of changes to the different pipelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized several deployment workflows by pinning Terraform action versions to fixed releases, which enhances consistency and reliability during automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->