### PR TITLE
bugfix: add cluster name to output

### DIFF
--- a/infrastructure/adminservices-test/k6tests-rg/locals.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/locals.tf
@@ -34,7 +34,7 @@ locals {
     }
   }
   namespaces                  = toset([for v in local.k8s_rbac : v["namespace"]])
-  k6tests_cluster_name        = data.azurerm_kubernetes_cluster.k6tests.name
+  k6tests_cluster_name        = module.foundational.k6tests_cluster_name
   k6tests_resource_group_name = module.foundational.k6tests_resource_group_name
   oidc_issuer_url             = data.azurerm_kubernetes_cluster.k6tests.oidc_issuer_url
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined internal configuration by updating how the cluster identifier is sourced. The change now retrieves values from a centralized module output, ensuring a more consistent infrastructure setup while keeping other configurations intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->