### PR TITLE
chore: cleanup terraform backend config

### DIFF
--- a/actions/terraform/init/action.yaml
+++ b/actions/terraform/init/action.yaml
@@ -90,13 +90,12 @@ runs:
       shell: bash
       if: always()
       working-directory: ${{ inputs.working_directory }}
-      env:
-        ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
-        ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
-        ARM_SUBSCRIPTION_ID: ${{ inputs.tf_arm_subscription_id }}
-        ARM_USE_OIDC: "true"
       run: |
         terraform init -input=false \
+          -backend-config="use_oidc=true" \
+          -backend-config="use_azuread_auth=true" \
+          -backend-config="tenant_id=${{ inputs.arm_tenant_id }}" \
+          -backend-config="client_id=${{ inputs.arm_client_id }}" \
           -backend-config="subscription_id=${{ inputs.tf_arm_subscription_id }}" \
           -backend-config="resource_group_name=${{ inputs.tf_arm_resource_group_name }}" \
           -backend-config="storage_account_name=${{ inputs.tf_arm_storage_account_name }}" \


### PR DESCRIPTION
Relevant docs:
- https://developer.hashicorp.com/terraform/language/backend/azurerm#azure-active-directory-with-openid-connect-workload-identity-federation
- https://developer.hashicorp.com/terraform/language/backend#partial-configuration

In a future PR where we bump the action hash, we can remove the backend config from the TF files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Terraform initialization with additional backend configuration options that enable OIDC and Azure AD authentication, improving the security and flexibility of the setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->