### PR TITLE
Add aks-resources to auth-at22

### DIFF
--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
@@ -8,10 +8,7 @@ module "aks" {
     "10.202.72.0/21",
     "fd0a:7204:c37f:900::/56"
   ]
-  subnet_address_prefixes = {
-    aks_syspool  = ["fd0a:7204:c37f:901::/64", "10.202.72.0/24"]
-    aks_workpool = ["fd0a:7204:c37f:902::/64", "10.202.73.0/24"]
-  }
+  subnet_address_prefixes = var.subnet_address_prefixes
   pool_configs = {
     syspool = {
       vm_size              = "standard_b2s_v2"
@@ -34,4 +31,15 @@ module "aks" {
   admin_group_object_ids = [
     "09599a84-645b-4217-853f-01700a17cd4a"
   ]
+}
+
+module "infra-resources" {
+  depends_on                    = [module.aks]
+  source                        = "../../modules/aks-resources"
+  aks_node_resource_group       = module.aks.aks_node_resource_group
+  azurerm_kubernetes_cluster_id = module.aks.azurerm_kubernetes_cluster_id
+  flux_release_tag              = "at_ring2"
+  pip4_ip_address               = module.aks.pip4_ip_address
+  pip6_ip_address               = module.aks.pip6_ip_address
+  subnet_address_prefixes       = var.subnet_address_prefixes
 }

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/terraform.tfvars
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/terraform.tfvars
@@ -1,1 +1,5 @@
 subscription_id = "37bac63a-b964-46b2-8de8-ba93c432ea1f"
+subnet_address_prefixes = {
+  aks_syspool  = ["fd0a:7204:c37f:901::/64", "10.202.72.0/24"]
+  aks_workpool = ["fd0a:7204:c37f:902::/64", "10.202.73.0/24"]
+}

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/variables.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/variables.tf
@@ -2,3 +2,11 @@ variable "subscription_id" {
   type        = string
   description = "Subscription id to deploy services"
 }
+
+variable "subnet_address_prefixes" {
+  type = object({
+    aks_syspool  = list(string)
+    aks_workpool = list(string)
+  })
+  description = "list of subnets"
+}

--- a/infrastructure/modules/aks/README.md
+++ b/infrastructure/modules/aks/README.md
@@ -65,7 +65,7 @@
 | <a name="input_location"></a> [location](#input\_location) | Default region for resources | `string` | `"norwayeast"` | no |
 | <a name="input_pool_configs"></a> [pool\_configs](#input\_pool\_configs) | Variables for node pools | <pre>map(object({<br/>    vm_size              = string<br/>    auto_scaling_enabled = bool<br/>    node_count           = number<br/>    min_count            = number<br/>    max_count            = number<br/>  }))</pre> | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for resource names | `string` | `""` | no |
-| <a name="input_subnet_address_prefixes"></a> [subnet\_address\_prefixes](#input\_subnet\_address\_prefixes) | List of subnets | `map(list(string))` | n/a | yes |
+| <a name="input_subnet_address_prefixes"></a> [subnet\_address\_prefixes](#input\_subnet\_address\_prefixes) | List of subnets | <pre>object({<br/>    aks_syspool  = list(string)<br/>    aks_workpool = list(string)<br/>  })</pre> | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Subscription ID to deploy services | `string` | n/a | yes |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | VNet address space | `list(string)` | n/a | yes |
 
@@ -78,6 +78,7 @@
 | <a name="output_aks_name"></a> [aks\_name](#output\_aks\_name) | The name of the managed Kubernetes Cluster |
 | <a name="output_aks_node_resource_group"></a> [aks\_node\_resource\_group](#output\_aks\_node\_resource\_group) | The name of the Resource Group in which the managed Kubernetes Cluster exists |
 | <a name="output_aks_oidc_issuer_url"></a> [aks\_oidc\_issuer\_url](#output\_aks\_oidc\_issuer\_url) | The OIDC issuer URL that is associated with the cluster |
+| <a name="output_azurerm_kubernetes_cluster_id"></a> [azurerm\_kubernetes\_cluster\_id](#output\_azurerm\_kubernetes\_cluster\_id) | Resource id of aks cluster |
 | <a name="output_kube_admin_config"></a> [kube\_admin\_config](#output\_kube\_admin\_config) | Base64 encoded cert/key/user/pass used by clients to authenticate to the Kubernetes cluster |
 | <a name="output_pip4_ip_address"></a> [pip4\_ip\_address](#output\_pip4\_ip\_address) | The IPv4 address value that was allocated |
 | <a name="output_pip6_ip_address"></a> [pip6\_ip\_address](#output\_pip6\_ip\_address) | The IPv6 address value that was allocated |

--- a/infrastructure/modules/aks/network.tf
+++ b/infrastructure/modules/aks/network.tf
@@ -6,14 +6,11 @@ resource "azurerm_virtual_network" "aks" {
 }
 
 resource "azurerm_subnet" "aks" {
-  for_each = merge(
-    { for idx, prefix in var.subnet_address_prefixes.aks_syspool : "aks_syspool-${idx}" => prefix },
-    { for idx, prefix in var.subnet_address_prefixes.aks_workpool : "aks_workpool-${idx}" => prefix }
-  )
+  for_each             = var.subnet_address_prefixes
   name                 = each.key
   resource_group_name  = azurerm_resource_group.aks.name
   virtual_network_name = azurerm_virtual_network.aks.name
-  address_prefixes     = [each.value]
+  address_prefixes     = each.value
 }
 
 resource "azurerm_public_ip" "pip4" {

--- a/infrastructure/modules/aks/network.tf
+++ b/infrastructure/modules/aks/network.tf
@@ -6,11 +6,14 @@ resource "azurerm_virtual_network" "aks" {
 }
 
 resource "azurerm_subnet" "aks" {
-  for_each             = var.subnet_address_prefixes
+  for_each = merge(
+    { for idx, prefix in var.subnet_address_prefixes.aks_syspool : "aks_syspool-${idx}" => prefix },
+    { for idx, prefix in var.subnet_address_prefixes.aks_workpool : "aks_workpool-${idx}" => prefix }
+  )
   name                 = each.key
   resource_group_name  = azurerm_resource_group.aks.name
   virtual_network_name = azurerm_virtual_network.aks.name
-  address_prefixes     = each.value
+  address_prefixes     = [each.value]
 }
 
 resource "azurerm_public_ip" "pip4" {

--- a/infrastructure/modules/aks/output.tf
+++ b/infrastructure/modules/aks/output.tf
@@ -23,6 +23,11 @@ output "aks_oidc_issuer_url" {
   description = "The OIDC issuer URL that is associated with the cluster"
 }
 
+output "azurerm_kubernetes_cluster_id" {
+  value       = azurerm_kubernetes_cluster.aks.id
+  description = "Resource id of aks cluster"
+}
+
 output "kube_admin_config" {
   value       = azurerm_kubernetes_cluster.aks.kube_admin_config
   sensitive   = true

--- a/infrastructure/modules/aks/variables.tf
+++ b/infrastructure/modules/aks/variables.tf
@@ -78,7 +78,10 @@ variable "subscription_id" {
 }
 
 variable "subnet_address_prefixes" {
-  type        = map(list(string))
+  type = object({
+    aks_syspool  = list(string)
+    aks_workpool = list(string)
+  })
   description = "List of subnets"
   validation {
     condition     = length(var.subnet_address_prefixes) > 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add module aks-resources to cluster auth-at22-aks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an additional resource module to extend infrastructure integration.
  - Added a new output providing easy access to the deployed Kubernetes cluster’s identifier.

- **Refactor**
  - Transitioned subnet configuration from fixed values to a flexible, variable-driven format with a more structured schema.

- **Documentation**
  - Updated guidance to reflect the enhanced configuration and output details for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->