### PR TITLE
chore: update base image with first real version

### DIFF
--- a/actions/generate-k6-manifests/Dockerfile
+++ b/actions/generate-k6-manifests/Dockerfile
@@ -1,5 +1,6 @@
-FROM ghcr.io/altinn/altinn-platform/k6-action-image:v0.0.3
+FROM ghcr.io/altinn/altinn-platform/k6-action-image:v0.0.1
 
-ADD generate.sh /generate.sh
+COPY generate.sh /generate.sh
+RUN chmod +x /generate.sh
 
 CMD ["/generate.sh"]

--- a/actions/generate-k6-manifests/generate.sh
+++ b/actions/generate-k6-manifests/generate.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -euo
 
 rm -rf .build .dist .conf
 mkdir -p .build .dist .conf

--- a/actions/generate-k6-manifests/test_service/conf.yaml
+++ b/actions/generate-k6-manifests/test_service/conf.yaml
@@ -1,0 +1,8 @@
+namespace: platform
+test_definitions:
+  - test_file: actions/generate-k6-manifests/test_service/k8s_wrapper/get_deployments.js
+    contexts:
+      - environment: at22
+        node_type: "default"
+        test_run:
+          name: "k8s-wrapper-deployments"


### PR DESCRIPTION
I've deleted the previous versions since they were not actually usable and were only intended to test the general workflow.
I will do a release of the first working PoC once #1564 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the base Docker image version for manifest generation.
	- Changed the shell interpreter in the generation script for improved compatibility.
- **New Features**
	- Added a configuration file to define and organize test scenarios for a specific service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->