### PR TITLE
feat: allow k6 users access to log analytics workspace

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -4,6 +4,12 @@ resource "azurerm_role_assignment" "azure_kubernetes_service_cluster_user_role" 
   principal_id         = "b95b1fc9-7f21-49c3-8932-07161cd9ac5a"
 }
 
+resource "azurerm_role_assignment" "reader_user_role" {
+  scope                = azurerm_log_analytics_workspace.k6tests.id
+  role_definition_name = "Reader"
+  principal_id         = "b95b1fc9-7f21-49c3-8932-07161cd9ac5a"
+}
+
 resource "kubernetes_cluster_role_v1" "dev_access" {
   metadata {
     name = "dev-access"

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/rbac.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/rbac.tf
@@ -3,3 +3,9 @@ resource "azurerm_role_assignment" "azure_kubernetes_service_cluster_user_role" 
   role_definition_name = "Azure Kubernetes Service Cluster User Role"
   principal_id         = var.k8s_users_group_object_id
 }
+
+resource "azurerm_role_assignment" "reader_user_role" {
+  scope                = azurerm_log_analytics_workspace.k6tests.id
+  role_definition_name = "Reader"
+  principal_id         = var.k8s_users_group_object_id
+}


### PR DESCRIPTION
Noticed this was missing while Onboarding Vegard into K6
## Related Issue(s)
- #1573 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new role assignments to provide "Reader" access to the Log Analytics workspace for specified user groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->