### PR TITLE
feat/add custom renovate manager

### DIFF
--- a/actions/terraform/init/action.yaml
+++ b/actions/terraform/init/action.yaml
@@ -42,7 +42,8 @@ inputs:
   tf_version:
     required: false
     description: Terraform Version
-    default: ~1.11.0
+    # renovate: datasource=github-releases depName=terraform packageName=hashicorp/terraform versioning=semver
+    default: 1.11.4
   tf_log_level:
     required: false
     description: Terraform Log level

--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -1,9 +1,13 @@
 FROM golang:1.24-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS builder
-
+# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
 ARG KUBECTL_VERSION=1.32.3
+# renovate: datasource=github-releases depName=kubeseal packageName=bitnami-labs/sealed-secrets versioning=semver extractVersion=^sealed-secrets-(?<version>.*)$
 ARG KUBESEAL_VERSION=0.29.0
+# renovate: datasource=github-releases depName=jsonnet packageName=google/jsonnet versioning=semver
 ARG JSONNET_VERSION=0.20.0
+# renovate: datasource=github-releases depName=k6 packageName=grafana/k6 versioning=semver
 ARG K6_VERSION=0.57.0
+# renovate: datasource=github-releases depName=jsonnet-bundler packageName=jsonnet-bundler/jsonnet-bundler versioning=semver extractVersion=^v(?<version>.*)$
 ARG JB_VERSION=0.6.0
 ARG K8S_LIBSONNET_VERSION=1.32
 

--- a/infrastructure/images/terraform-azure-devops-agent/scripts/install.sh
+++ b/infrastructure/images/terraform-azure-devops-agent/scripts/install.sh
@@ -2,7 +2,9 @@
 set -e
 
 # Versions
+# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
 KUBECTL_VERSION="v1.32.1" #Get the latest version with: curl -L -s https://dl.k8s.io/release/stable.txt
+# renovate: datasource=github-releases depName=helm packageName=helm/helm versioning=semver
 HELM_VERSION="v3.17.1" #Find the latest version at https://github.com/helm/helm/releases
 
 ###################################

--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,20 @@
         "*"
       ]
     }
-  ]
+  ],
+  "customManagers": [
+      {
+        "customType": "regex",
+        "managerFilePatterns": [
+          "/(^|/)(.*?/)*.*?\\.ya?ml$/",
+          "/(^|/)(.*?/)*.*?\\.sh$/",
+          "/(^|/)(.*?/)*Dockerfile$/"
+        ],
+        "matchStrings": [
+          "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s+?default: (?<currentValue>.+?)\\s",
+          "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s+?.+?_VERSION\\s?=\\s?\"?v?(?<currentValue>.+?)\"?(\\s|$)"
+        ],
+        "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      }
+    ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To update custom fields that renovate normally can't handle we could use a customManager that help us keep these tools updated
Renovate docs:
https://docs.renovatebot.com/modules/manager/regex/

I have tested this on one of my private repos:
Folder with examples: https://github.com/tjololo/hello-actions/tree/main/actions/composite
Example PRs from renovate: https://github.com/tjololo/hello-actions/pulls

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added Renovate metadata comments to various configuration and script files to enable automated dependency version management.
  - Updated the default Terraform version to 1.11.4 for improved version control.
  - Enhanced Renovate configuration to support custom regex-based dependency extraction in YAML, shell scripts, and Dockerfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->