### PR TITLE
bugfix: add paths filter to action

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/govulncheck.yaml
+      - "services/dis-apim-operator"
+      - "tools/daisctl"
+      - "actions/generate-k6-manifests"
   pull_request:
     branches:
       - main
+    paths:
+      - .github/workflows/govulncheck.yaml
+      - "services/dis-apim-operator"
+      - "tools/daisctl"
+      - "actions/generate-k6-manifests"
   schedule:
     - cron: "0 6 * * *" #Every day at 6
 


### PR DESCRIPTION
Noticed that this was triggering in random PRs that were not touching any of these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow triggers to run vulnerability checks only when relevant files or directories are changed, reducing unnecessary workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->