### PR TITLE
chore: lock flux-action to the release of flux

### DIFF
--- a/.github/workflows/dis-apim-kustomize-release.yml
+++ b/.github/workflows/dis-apim-kustomize-release.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "reponame=${GITHUB_REPOSITORY,,}" >> ${GITHUB_OUTPUT}
       - name: Setup flux
-        uses: fluxcd/flux2/action@6150fe9942b822c926e76a43dce31c595313f324
+        uses: fluxcd/flux2/action@8d5f40dca5aa5d3c0fc3414457dda15a0ac92fa4 # v2.5.1
         with:
           version: latest
       - name: Build latest artifact

--- a/.github/workflows/reusable-oci-image-push.yml
+++ b/.github/workflows/reusable-oci-image-push.yml
@@ -64,7 +64,7 @@ jobs:
           done
           echo "Validation successful: kustomization.yaml exists in all specified environment folders."
       - name: Setup flux
-        uses: fluxcd/flux2/action@6150fe9942b822c926e76a43dce31c595313f324
+        uses: fluxcd/flux2/action@8d5f40dca5aa5d3c0fc3414457dda15a0ac92fa4 # v2.5.1
         with:
           version: latest
       - name: az login


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently we get a upgrade PR every time there is a commit to main on the flux repo. I suggest we lock the action with the flux releases. The action does not always (almost never) update with flux, but atleast we reduce the number of PRs/noise

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the Flux CLI used in the "latest" job of certain workflows to improve reliability and compatibility. No changes affect end-user features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->