### PR TITLE
Remove Grafana Token setup from auth-at22-aks-rg workflow

### DIFF
--- a/.github/workflows/auth-at22-aks-rg.yml
+++ b/.github/workflows/auth-at22-aks-rg.yml
@@ -93,12 +93,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Grafana Token
-        uses: Altinn/altinn-platform/actions/terraform/azure-app-token@51c287c68ccb36575e383df649217fc2088106be # main
-        with:
-          arm_client_id: ${{ env.ARM_CLIENT_ID }}
-          app_resource_id: ce34e7e5-485f-4d76-964f-b3d2b16d1e4f
-
       - name: Terraform Apply
         uses: Altinn/altinn-platform/actions/terraform/apply@7b92cd191baa4569aa2e6d054455a70183962ab7 # main
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove not needed grafana token gen from apply. Can not be used when apply with stored plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow by removing the "Set up Grafana Token" step from the deployment process. This change does not affect the planning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->