### PR TITLE
Add Grafana Operator with external Grafana integration

### DIFF
--- a/flux/grafana-operator/external-grafana.yaml
+++ b/flux/grafana-operator/external-grafana.yaml
@@ -1,0 +1,13 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: external-grafana
+  namespace: grafana
+  labels:
+    dashboards: "external-grafana"
+spec:
+  external:
+    url: "${EXTERNAL_GRAFANA_URL}"
+    apiKey:
+      name: grafana-admin-apikey
+      key: GF_SECURITY_APIKEY

--- a/flux/grafana-operator/grafana-admin-apikey.yaml
+++ b/flux/grafana-operator/grafana-admin-apikey.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-apikey
+type: Opaque
+stringData:
+  GF_SECURITY_APIKEY: "${GRAFANA_ADMIN_APIKEY}"

--- a/flux/grafana-operator/grafana-admin-apikey.yaml
+++ b/flux/grafana-operator/grafana-admin-apikey.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: grafana-admin-apikey
+  namespace: grafana
 type: Opaque
 stringData:
   GF_SECURITY_APIKEY: "${GRAFANA_ADMIN_APIKEY}"

--- a/flux/grafana-operator/helmrelease.yaml
+++ b/flux/grafana-operator/helmrelease.yaml
@@ -15,10 +15,13 @@ spec:
       version: 5.18.0
   interval: 1h
   timeout: 5m
+
   install:
+    crds: CreateReplace
     remediation:
       retries: 5
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 5
   postRenderers:

--- a/flux/grafana-operator/helmrelease.yaml
+++ b/flux/grafana-operator/helmrelease.yaml
@@ -1,0 +1,48 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana-operator
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: grafana-operator
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: monitoring
+      version: 5.18.0
+  interval: 1h
+  timeout: 5m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+            patch: |
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+  values:
+    image:
+      repository: altinncr.azurecr.io/ghcr.io/grafana/grafana-operator
+    serviceMonitor:
+      enabled: true
+    dashboard:
+      enabled: true

--- a/flux/grafana-operator/helmrelease.yaml
+++ b/flux/grafana-operator/helmrelease.yaml
@@ -2,7 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: grafana-operator
-  namespace: monitoring
+  namespace: grafana
 spec:
   chart:
     spec:
@@ -11,7 +11,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-        namespace: monitoring
+        namespace: grafana
       version: 5.18.0
   interval: 1h
   timeout: 5m

--- a/flux/grafana-operator/helmrepository.yaml
+++ b/flux/grafana-operator/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts

--- a/flux/grafana-operator/helmrepository.yaml
+++ b/flux/grafana-operator/helmrepository.yaml
@@ -2,7 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana
-  namespace: monitoring
+  namespace: grafana
 spec:
   interval: 1h
   url: https://grafana.github.io/helm-charts

--- a/flux/grafana-operator/kustomization.yaml
+++ b/flux/grafana-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - grafana-admin-apikey.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - external-grafana.yaml

--- a/flux/grafana-operator/namespace.yaml
+++ b/flux/grafana-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  annotations:
+    linkerd.io/inject: enabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create flux-oci for grafana operator

## Related Issue(s)
- #1548 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated deployment and management of Grafana using Flux and Helm in a dedicated namespace.
  - Added secure storage for the Grafana admin API key.
  - Enabled integration with an external Grafana instance via configurable URL and API key.
  - Applied custom monitoring configurations for enhanced observability.
  - Established a separate namespace with Linkerd sidecar injection for improved service mesh capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->