### PR TITLE
fix: federation name with dash instead of dot

### DIFF
--- a/infrastructure/adminservices-prod/altinncr/managed-identities.tf
+++ b/infrastructure/adminservices-prod/altinncr/managed-identities.tf
@@ -5,7 +5,7 @@ resource "azurerm_user_assigned_identity" "github_pusher" {
 }
 
 resource "azurerm_federated_identity_credential" "altinn_platform_federation_main" {
-  name                = "github.altinn.altinn-platform.ref.main"
+  name                = "github-altinn-altinn-platform-ref-main"
   parent_id           = azurerm_user_assigned_identity.github_pusher.id
   resource_group_name = azurerm_resource_group.acr.name
   audience            = ["api://AzureADTokenExchange"]
@@ -14,7 +14,7 @@ resource "azurerm_federated_identity_credential" "altinn_platform_federation_mai
 }
 
 resource "azurerm_federated_identity_credential" "altinn_platform_federation_flux_release" {
-  name                = "github.altinn.altinn-platform.environment.flux-release"
+  name                = "github-altinn-altinn-platform-environment-flux-release"
   parent_id           = azurerm_user_assigned_identity.github_pusher.id
   resource_group_name = azurerm_resource_group.acr.name
   audience            = ["api://AzureADTokenExchange"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the naming convention for federated identity credentials to use hyphens instead of dots for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->