### PR TITLE
fix: Remove ACR credential handling from flux workflows

### DIFF
--- a/.github/workflows/release-flux-artifact.yml
+++ b/.github/workflows/release-flux-artifact.yml
@@ -7,11 +7,11 @@ on:
     paths:
       - flux/*/**
   release:
-    types: 
+    types:
       - created
 
 env:
-  RELEASE_TAG_PREFIX: 'flux-oci-'
+  RELEASE_TAG_PREFIX: "flux-oci-"
 
 permissions:
   id-token: write
@@ -49,18 +49,15 @@ jobs:
           # Extract unique folder names directly under ./manifests/infra/
           ARTIFACTS=$(echo "${FLUX_FILES}" | awk -F'/' '{print $2}' | sort -u)
           for artifact in $ARTIFACTS;do
-            creds=$(az acr login --name altinncr --expose-token)
             flux push artifact oci://${REGISTRY}/manifests/infra/${artifact}:$(git rev-parse --short HEAD) \
               --provider=azure \
               --reproducible \
               --path="./flux/${artifact}" \
               --source="$(git config --get remote.origin.url)" \
               --revision="$(git branch --show-current)/$(git rev-parse HEAD)" \
-              --creds="${creds}" || { echo "Failed to push $artifact" >&2; exit 1; }
             flux tag artifact oci://${REGISTRY}/manifests/infra/${artifact}:$(git rev-parse --short HEAD) \
               --provider=azure \
               --tag latest \
-              --creds="${creds}" || { echo "Failed to tag $artifact with latest" >&2; exit 1; }
           done
   tag-release:
     runs-on: ubuntu-latest
@@ -97,7 +94,7 @@ jobs:
         with:
           image_name: "manifests/infra/${{ steps.extract-release.outputs.releaseName }}"
           tag: ${{ steps.extract-release.outputs.releaseVersion }}
-          workdir: './flux/${{ steps.extract-release.outputs.releaseName }}'
+          workdir: "./flux/${{ steps.extract-release.outputs.releaseName }}"
           azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
           azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}

--- a/actions/flux/build-push-image/action.yaml
+++ b/actions/flux/build-push-image/action.yaml
@@ -1,53 +1,57 @@
 name: Build kustomize oci artifact and push to azure container registry
-description: 'Build and push a kustomize OCI artifact to Azure Container Registry (ACR) using the FluxCLI'
+description: "Build and push a kustomize OCI artifact to Azure Container Registry (ACR) using the FluxCLI"
 
 inputs:
   image_name:
-    description: 'Name of the OCI image to push'
+    description: "Name of the OCI image to push"
     required: true
     type: string
   workdir:
-    description: 'Folder containing the OCI context'
+    description: "Folder containing the OCI context"
     required: true
     type: string
   tag:
-    description: 'Tag to push in addition to the short commit sha tag'
+    description: "Tag to push in addition to the short commit sha tag"
     required: false
-    default: ''
+    default: ""
     type: string
   acr_name:
-    description: 'Name of the Azure Container Registry (ACR) to use'
+    description: "Name of the Azure Container Registry (ACR) to use"
     required: false
-    default: 'altinncr'
+    default: "altinncr"
     type: string
-    pattern: '^[a-zA-Z0-9-]{5,50}$'
   azure_app_id:
-    description: 'Azure application id used to authenticate to altinncr'
+    description: "Azure application id used to authenticate to altinncr"
     required: true
+    type: string
   azure_subscription_id:
-    description: 'Azure subscription id used to authenticate to altinncr'
+    description: "Azure subscription id used to authenticate to altinncr"
     required: true
+    type: string
   azure_tenant_id:
-    description: 'Azure tenant id used to authenticate to altinncr'
+    description: "Azure tenant id used to authenticate to altinncr"
     required: true
+    type: string
 
 runs:
   using: composite
   defaults:
     run:
       working-directory: ${{ inputs.workdir }}
-  runs-on: ubuntu-latest
   steps:
     - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
       uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@main
       id: setup_flux_acr
       with:
         acr_name: ${{ inputs.acr_name }}
+        azure_app_id: ${{ inputs.azure_app_id }}
+        azure_subscription_id: ${{ inputs.azure_subscription_id }}
+        azure_tenant_id: ${{ inputs.azure_tenant_id }}
     - name: Build and push artifact with commit sha tag
       env:
         ARTIFACT_NAME: ${{ inputs.image_name }}
         ACR_NAME: ${{ inputs.acr_name }}
-        ACR_CREDS: ${{ steps.setup_flux_acr.outputs.acr_token }}
+      shell: bash
       run: |
         container_registry=${ACR_NAME}.azurecr.io
         short_sha=$(git rev-parse --short HEAD)
@@ -59,19 +63,17 @@ runs:
           --reproducible \
           --path="." \
           --source="${repo_url}" \
-          --revision="${branch_sha}" \
-          --creds="${ACR_CREDS}"
+          --revision="${branch_sha}"
     - name: Tag artifact with custom tag
       if: inputs.tag != ''
       env:
         ARTIFACT_NAME: ${{ inputs.image_name }}
         EXTRA_TAG: ${{ inputs.tag }}
         ACR_NAME: ${{ inputs.acr_name }}
-        ACR_CREDS: ${{ steps.setup_flux_acr.outputs.acr_token }}
+      shell: bash
       run: |
         container_registry=${ACR_NAME}.azurecr.io
         short_sha=$(git rev-parse --short HEAD)
         flux tag artifact "oci://${container_registry}/${ARTIFACT_NAME}:${short_sha}" \
           --provider=azure \
-          --tag "${EXTRA_TAG}" \
-          --creds="${ACR_CREDS}"
+          --tag "${EXTRA_TAG}"

--- a/actions/flux/retag-image/action.yaml
+++ b/actions/flux/retag-image/action.yaml
@@ -1,40 +1,38 @@
 name: Add tag to existing flux OCI image
-description: 'Re-tag an existing OCI image in Azure Container Registry (ACR) using the FluxCLI'
+description: "Re-tag an existing OCI image in Azure Container Registry (ACR) using the FluxCLI"
 
 inputs:
   image_name:
-    description: 'Name of the OCI image to tag'
+    description: "Name of the OCI image to tag"
     required: true
     type: string
   from_tag:
-    description: 'The tag of the existing image to re-tag'
+    description: "The tag of the existing image to re-tag"
     required: true
     type: string
   tag:
-    description: 'The new tag to apply to the existing image'
+    description: "The new tag to apply to the existing image"
     required: true
     type: string
   workdir:
-    description: 'Folder containing the OCI resources'
+    description: "Folder containing the OCI resources"
     required: true
     type: string
   acr_name:
-    description: 'Name of the Azure Container Registry (ACR) to use'
+    description: "Name of the Azure Container Registry (ACR) to use"
     required: false
-    default: 'altinncr'
+    default: "altinncr"
     type: string
-    pattern: '^[a-zA-Z0-9-]{5,50}$
+    pattern: "^[a-zA-Z0-9-]{5,50}$"
   azure_app_id:
-    description: 'Azure application id used to authenticate to altinncr'
+    description: "Azure application id used to authenticate to altinncr"
     required: true
   azure_subscription_id:
-    description: 'Azure subscription id used to authenticate to altinncr'
+    description: "Azure subscription id used to authenticate to altinncr"
     required: true
   azure_tenant_id:
-    description: 'Azure tenant id used to authenticate to altinncr'
+    description: "Azure tenant id used to authenticate to altinncr"
     required: true
-
-
 
 runs:
   using: composite
@@ -47,16 +45,18 @@ runs:
       id: setup_flux_acr
       with:
         acr_name: ${{ inputs.acr_name }}
+        azure_app_id: ${{ inputs.azure_app_id }}
+        azure_subscription_id: ${{ inputs.azure_subscription_id }}
+        azure_tenant_id: ${{ inputs.azure_tenant_id }}
     - name: Tag release artifact
       env:
         ARTIFACT_NAME: ${{ inputs.image_name }}
         FROM_TAG: ${{ inputs.from_tag }}
         TO_TAG: ${{ inputs.tag }}
         ACR_NAME: ${{ inputs.acr_name }}
-        ACR_CREDS: ${{ steps.setup_flux_acr.outputs.acr_token }}
+      shell: bash
       run: |
         container_registry=${ACR_NAME}.azurecr.io
         flux tag artifact "oci://${container_registry}/${ARTIFACT_NAME}:${FROM_TAG}" \
             --provider=azure \
-            --tag "${TO_TAG}" \
-            --creds="${ACR_CREDS}"
+            --tag "${TO_TAG}"

--- a/actions/flux/setup-flux-acr/action.yaml
+++ b/actions/flux/setup-flux-acr/action.yaml
@@ -3,35 +3,28 @@ description: Downloads flux cli and fetches credentials for the Azure Container 
 
 inputs:
   flux_version:
-    description: 'Version of flux to use'
+    description: "Version of flux to use"
     required: false
-    default: 'latest'
+    default: "latest"
     type: string
   acr_name:
-    description: 'Name of the Azure Container Registry (ACR) to use'
+    description: "Name of the Azure Container Registry (ACR) to use"
     required: false
-    default: 'altinncr'
+    default: "altinncr"
     type: string
-    pattern: '^[a-zA-Z0-9-]{5,50}$
+    pattern: "^[a-zA-Z0-9-]{5,50}$"
   azure_app_id:
-    description: 'Azure application id used to authenticate to altinncr'
+    description: "Azure application id used to authenticate to altinncr"
     required: true
   azure_subscription_id:
-    description: 'Azure subscription id used to authenticate to altinncr'
+    description: "Azure subscription id used to authenticate to altinncr"
     required: true
   azure_tenant_id:
-    description: 'Azure tenant id used to authenticate to altinncr'
+    description: "Azure tenant id used to authenticate to altinncr"
     required: true
-outputs:
-  acr_token:
-    description: 'Credentials for the Azure Container Registry to use with flux'
-    value: ${{ steps.artifact_key.outputs.key }}
-    secret: true
-
 
 runs:
   using: composite
-  runs-on: ubuntu-latest
   steps:
     - name: Setup flux
       uses: fluxcd/flux2/action@8d5f40dca5aa5d3c0fc3414457dda15a0ac92fa4 # v2.5.1
@@ -40,13 +33,6 @@ runs:
     - name: az login
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
-        client-id: ${{ secrets.azure_app_id }}
-        subscription-id: ${{ secrets.azure_subscription_id }}
-        tenant-id: ${{ secrets.azure_tenant_id }}
-    - name: Fetch ACR credentials
-      id: artifact_key
-      env:
-        ACR_NAME: ${{ inputs.acr_name }}
-      run: |
-        creds=$(az acr login --name ${ACR_NAME} --expose-token)
-        echo "key=${creds}" >> $GITHUB_OUTPUT
+        client-id: ${{ inputs.azure_app_id }}
+        subscription-id: ${{ inputs.azure_subscription_id }}
+        tenant-id: ${{ inputs.azure_tenant_id }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Simplify authentication by removing manual credential fetching and passing. The flux CLI now uses Azure login context directly instead of requiring explicit --creds parameters.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved workflow configuration by correcting syntax and standardizing string formatting.
	- Streamlined authentication in GitHub Actions by updating credential handling and removing unnecessary credential outputs.
	- Updated input parameters for Azure authentication, enhancing clarity and consistency.
- **Refactor**
	- Removed explicit credential passing in artifact push and tag commands to simplify workflows and reduce complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->