### PR TITLE
feat(flux-artifacts): move flux artifacts from devops to github

### DIFF
--- a/flux/cert-manager/helmrelease.yaml
+++ b/flux/cert-manager/helmrelease.yaml
@@ -1,0 +1,43 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  chart:
+    spec:
+      chart: cert-manager
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: cert-manager
+      version: 1.17.1
+  interval: 1h
+  timeout: 5m
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  values:
+    crds:
+      enabled: true
+    dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53"
+    dns01RecursiveNameserversOnly: true
+    image:
+      registry: altinncr.azurecr.io
+    webhook:
+      image:
+        registry: altinncr.azurecr.io
+    cainjector:
+      image:
+        registry: altinncr.azurecr.io
+    acmesolver:
+      image:
+        registry: altinncr.azurecr.io
+    startupapicheck:
+      image:
+        registry: altinncr.azurecr.io

--- a/flux/cert-manager/helmrepository.yaml
+++ b/flux/cert-manager/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: cert-manager
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io

--- a/flux/cert-manager/kustomization.yaml
+++ b/flux/cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/flux/cert-manager/namespace.yaml
+++ b/flux/cert-manager/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/flux/external-secrets-operator/helmrelease.yaml
+++ b/flux/external-secrets-operator/helmrelease.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+spec:
+  chart:
+    spec:
+      chart: external-secrets
+      version: 0.16.2
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: external-secrets
+  interval: 1h
+  timeout: 5m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    installCRDs: true
+    # we run the controller **without** Azure identity;
+    # actual auth is delegated via SecretStore.serviceAccountRef
+    serviceAccount:
+      create: false

--- a/flux/external-secrets-operator/helmrepository.yaml
+++ b/flux/external-secrets-operator/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+spec:
+  type: oci
+  interval: 1h
+  url: oci://ghcr.io/external-secrets/charts

--- a/flux/external-secrets-operator/kustomization.yaml
+++ b/flux/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/flux/external-secrets-operator/namespace.yaml
+++ b/flux/external-secrets-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  annotations:
+    linkerd.io/inject: enabled

--- a/flux/linkerd/helmrelease.yaml
+++ b/flux/linkerd/helmrelease.yaml
@@ -1,0 +1,101 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: linkerd-crds
+  namespace: linkerd
+spec:
+  chart:
+    spec:
+      chart: linkerd-crds
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: linkerd
+        namespace: linkerd
+      version: 2025.1.2
+  interval: 1h
+  timeout: 5m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: linkerd
+  namespace: linkerd
+spec:
+  chart:
+    spec:
+      chart: linkerd-control-plane
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: linkerd
+        namespace: linkerd
+      version: 2025.1.2
+  interval: 1h
+  timeout: 10m
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+    - name: linkerd-crds
+      namespace: linkerd
+  install:
+    crds: Skip
+    remediation:
+      retries: 5
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 5
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: PodMonitor
+            patch: |
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+  valuesFrom:
+    - kind: Secret
+      name: linkerd-trust-anchor
+      valuesKey: ca.crt
+      targetPath: identityTrustAnchorsPEM
+    - kind: ConfigMap
+      name: linkerd-ha-values
+      valuesKey: values-ha.yaml
+  values:
+    identity:
+      issuer:
+        scheme: kubernetes.io/tls
+    disableHeartBeat: true
+    controllerImage: altinncr.azurecr.io/linkerd/controller
+    debugContainer:
+      image:
+        name: altinncr.azurecr.io/linkerd/debug
+    policyController:
+      image:
+        name: altinncr.azurecr.io/linkerd/policy-controller
+    proxy:
+      image:
+        name: altinncr.azurecr.io/linkerd/proxy
+    proxyInit:
+      image:
+        name: altinncr.azurecr.io/linkerd/proxy-init
+    podMonitor:
+      enabled: true
+    disableIPv6: "${DISABLE_IPV6}"

--- a/flux/linkerd/helmrepository.yaml
+++ b/flux/linkerd/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: linkerd
+  namespace: linkerd
+spec:
+  interval: 1h
+  url: https://helm.linkerd.io/edge

--- a/flux/linkerd/kustomization.yaml
+++ b/flux/linkerd/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - linkerd-root-ca-clusterissuer.yaml
+  - namespace.yaml
+  - values-ha.yaml
+  - linkerd-root-ca-cert.yaml
+  - linkerd-trust-anchor-issuer.yaml
+  - linkerd-identity-issuer-cert.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/flux/linkerd/linkerd-identity-issuer-cert.yaml
+++ b/flux/linkerd/linkerd-identity-issuer-cert.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: linkerd-identity-issuer
+  namespace: linkerd
+spec:
+  secretName: linkerd-identity-issuer
+  duration: 48h
+  renewBefore: 25h
+  issuerRef:
+    name: linkerd-trust-anchor
+    kind: Issuer
+  commonName: identity.linkerd.cluster.local
+  dnsNames:
+    - identity.linkerd.cluster.local
+  isCA: true
+  privateKey:
+    algorithm: ECDSA
+  usages:
+    - cert sign
+    - crl sign
+    - server auth
+    - client auth

--- a/flux/linkerd/linkerd-root-ca-cert.yaml
+++ b/flux/linkerd/linkerd-root-ca-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: linkerd-root-ca
+  namespace: linkerd
+spec:
+  isCA: true
+  literalSubject: CN=root.linkerd.cluster.local
+  secretName: linkerd-trust-anchor
+  duration: 87600h
+  renewBefore: 1460h
+  usages: ["cert sign", "crl sign"]
+  privateKey:
+    rotationPolicy: Always
+    algorithm: ECDSA
+    size: 256
+  revisionHistoryLimit: 3
+  issuerRef:
+    name: linkerd-root-ca
+    kind: ClusterIssuer

--- a/flux/linkerd/linkerd-root-ca-clusterissuer.yaml
+++ b/flux/linkerd/linkerd-root-ca-clusterissuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: linkerd-root-ca
+spec:
+  selfSigned: {}

--- a/flux/linkerd/linkerd-trust-anchor-issuer.yaml
+++ b/flux/linkerd/linkerd-trust-anchor-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: linkerd-trust-anchor
+  namespace: linkerd
+spec:
+  ca:
+    secretName: linkerd-trust-anchor

--- a/flux/linkerd/namespace.yaml
+++ b/flux/linkerd/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: linkerd

--- a/flux/linkerd/post-deploy/kustomization.yaml
+++ b/flux/linkerd/post-deploy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rollout-restart-job.yaml

--- a/flux/linkerd/post-deploy/rollout-restart-job.yaml
+++ b/flux/linkerd/post-deploy/rollout-restart-job.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rollout-restart-sa
+  namespace: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rollout-restart-role
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rollout-restart-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rollout-restart-role
+subjects:
+  - kind: ServiceAccount
+    name: rollout-restart-sa
+    namespace: linkerd
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rollout-restart-job
+  namespace: linkerd
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    spec:
+      serviceAccountName: rollout-restart-sa
+      containers:
+        - name: kubectl
+          image: altinncr.azurecr.io/docker.io/bitnami/kubectl:latest
+          command: ["sh", "-c"]
+          args:
+            - |
+              # Check if linkerd label is set in kube-system ns, if not set
+              if ! kubectl label ns kube-system --list=true | grep -q config.linkerd.io/admission-webhooks=disabled; then
+                kubectl label ns kube-system config.linkerd.io/admission-webhooks=disabled
+              fi
+              # Restart all pods that use linkerd in the namespaces
+              kubectl -n traefik rollout restart deployments,statefulsets,daemonsets ;
+              kubectl -n default rollout restart deployments,statefulsets,daemonsets ;
+              kubectl -n pdf rollout restart deployments,statefulsets,daemonsets ;
+              kubectl -n monitoring rollout restart deployments,statefulsets,daemonsets ;
+      restartPolicy: Never

--- a/flux/linkerd/values-ha.yaml
+++ b/flux/linkerd/values-ha.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: linkerd-ha-values
+  namespace: linkerd
+data:
+  values-ha.yaml: |
+    # High-Availability configuration for Linkerd
+    # This values.yaml file contains the values needed to enable HA mode.
+    # Usage:
+    #   helm install -f values-ha.yaml
+
+    # -- Create PodDisruptionBudget resources for each control plane workload
+    enablePodDisruptionBudget: true
+
+    controller:
+      # -- sets pod disruption budget parameter for all deployments
+      podDisruptionBudget:
+        # -- Maximum number of pods that can be unavailable during disruption
+        maxUnavailable: 1
+
+    # -- Specify a deployment strategy for each control plane workload
+    deploymentStrategy:
+      rollingUpdate:
+        maxUnavailable: 1
+        maxSurge: 25%
+
+    # -- add PodAntiAffinity to each control plane workload
+    enablePodAntiAffinity: true
+
+    # nodeAffinity:
+
+    # proxy configuration
+    proxy:
+      resources:
+        cpu:
+          request: 20m
+        memory:
+          limit: 250Mi
+          request: 20Mi
+
+    # controller configuration
+    controllerReplicas: 3
+    controllerResources: &controller_resources
+      cpu: &controller_resources_cpu
+        limit: ""
+        request: 25m
+      memory:
+        limit: 250Mi
+        request: 50Mi
+    destinationResources: *controller_resources
+
+    # identity configuration
+    identityResources:
+      cpu: *controller_resources_cpu
+      memory:
+        limit: 250Mi
+        request: 10Mi
+
+    # heartbeat configuration
+    heartbeatResources: *controller_resources
+
+    # proxy injector configuration
+    proxyInjectorResources: *controller_resources
+    webhookFailurePolicy: Fail
+
+    # service profile validator configuration
+    spValidatorResources: *controller_resources
+
+    # flag for linkerd check
+    highAvailability: true

--- a/flux/otel-collector/collector.yaml
+++ b/flux/otel-collector/collector.yaml
@@ -1,0 +1,66 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: monitoring
+spec:
+  env:
+    - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+      valueFrom:
+        secretKeyRef:
+          name: app-insights-connstring
+          key: connectionString
+  image: altinncr.azurecr.io/docker.io/otel/opentelemetry-collector-contrib:0.122.0
+  podAnnotations:
+    linkerd.io/inject: "enabled"
+    config.linkerd.io/skip-outbound-ports: "443"
+  resources:
+    limits:
+      memory: 1000Mi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+  mode: deployment
+  upgradeStrategy: automatic
+  serviceAccount: otel-collector
+  observability:
+    metrics:
+      disablePrometheusAnnotations: true
+      enableMetrics: true
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch: {}
+      probabilistic_sampler:
+        # We should decrease this later as more apps use
+        # the collector
+        sampling_percentage: 50
+    exporters:
+      azuremonitor: {}
+      debug: {}
+
+    service:
+      telemetry:
+        metrics:
+          level: basic
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: 0.0.0.0
+                  port: 8888
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [azuremonitor, debug]
+        traces:
+          receivers: [otlp]
+          processors: [probabilistic_sampler, batch]
+          exporters: [azuremonitor, debug]

--- a/flux/otel-collector/external-secrets.yaml
+++ b/flux/otel-collector/external-secrets.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: otel-azure-kv-store
+  namespace: monitoring
+spec:
+  provider:
+    azurekv:
+      authType: WorkloadIdentity
+      vaultUrl: ${KV_URI}
+      serviceAccountRef:
+        name: otel-collector
+        namespace: monitoring
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-insights-connstring-external-secret
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: otel-azure-kv-store
+  target:
+    name: app-insights-connstring
+    creationPolicy: Owner
+  data:
+    - secretKey: connectionString           # key inside the k8s Secret
+      remoteRef:
+        key: connectionString

--- a/flux/otel-collector/kustomization.yaml
+++ b/flux/otel-collector/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - external-secrets.yaml
+  - collector.yaml
+  - sa.yaml

--- a/flux/otel-collector/namespace.yaml
+++ b/flux/otel-collector/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  annotations:
+    linkerd.io/inject: enabled

--- a/flux/otel-collector/sa.yaml
+++ b/flux/otel-collector/sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: monitoring
+  labels:
+    app: otel-collector
+  annotations:
+    azure.workload.identity/client-id: ${CLIENT_ID}
+    azure.workload.identity/tenant-id: ${TENANT_ID}

--- a/flux/otel-operator/helmrelease.yaml
+++ b/flux/otel-operator/helmrelease.yaml
@@ -1,0 +1,35 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dis-otel-operator
+  namespace: monitoring
+spec:
+  interval: 1h
+  timeout: 5m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  chart:
+    spec:
+      chart: opentelemetry-operator
+      sourceRef:
+        kind: HelmRepository
+        name: otel-oci
+        namespace: monitoring
+      version: 0.84.2
+  values:
+    manager:
+      collectorImage:
+        repository: otel/opentelemetry-collector-k8s
+      serviceMonitor:
+        enabled: false
+      env:
+        ENABLE_WEBHOOKS: "false"
+      podAnnotations:
+        linkerd.io/inject: "enabled"
+        config.linkerd.io/skip-outbound-ports: "443"
+    admissionWebhooks:
+      create: false

--- a/flux/otel-operator/helmrepository.yaml
+++ b/flux/otel-operator/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: otel-oci
+  namespace: monitoring
+spec:
+  type: oci
+  interval: 1m0s
+  url: oci://ghcr.io/open-telemetry/opentelemetry-helm-charts

--- a/flux/otel-operator/kustomization.yaml
+++ b/flux/otel-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/flux/otel-operator/namespace.yaml
+++ b/flux/otel-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  annotations:
+    linkerd.io/inject: enabled

--- a/flux/traefik/helmrelease.yaml
+++ b/flux/traefik/helmrelease.yaml
@@ -1,0 +1,235 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik-crds
+  namespace: traefik
+spec:
+  chart:
+    spec:
+      chart: traefik-crds
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: traefik
+      version: 1.5.0
+  interval: 1h
+  timeout: 5m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinn-traefik
+  namespace: traefik
+spec:
+  chart:
+    spec:
+      chart: traefik
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: traefik
+      version: 34.4.1
+  interval: 1h
+  timeout: 5m
+  dependsOn:
+    - name: traefik-crds
+      namespace: traefik
+  install:
+    crds: Skip
+    remediation:
+      retries: 5
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 5
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+            patch: |
+              - op: replace
+                path: /apiVersion
+                value: azmonitoring.coreos.com/v1
+              - op: add
+                path: /spec/labelLimit
+                value: 63
+              - op: add
+                path: /spec/labelNameLengthLimit
+                value: 511
+              - op: add
+                path: /spec/labelValueLengthLimit
+                value: 1023
+  values:
+    image:
+      registry: altinncr.azurecr.io
+    deployment:
+      replicas: 3
+      labels:
+        release: traefik
+      podAnnotations:
+        linkerd.io/inject: enabled
+        config.linkerd.io/skip-inbound-ports: 8000,8443
+        config.linkerd.io/proxy-cpu-request: 50m
+        config.linkerd.io/proxy-memory-limit: 250Mi
+        config.linkerd.io/proxy-memory-request: 20Mi
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    ingressClass:
+      enabled: false
+    providers:
+      kubernetesIngress:
+        enabled: false
+    globalArguments:
+      - "--global.checknewversion=false"
+      - "--global.sendanonymoususage=false"
+    ports:
+      web: null
+      websecure: null
+      http:
+        port: 8000
+        expose:
+          default: true
+        exposedPort: 80
+        protocol: TCP
+        redirections:
+          entryPoint:
+            to: https
+            scheme: https
+            permanent: true
+        forwardedHeaders:
+          insecure: false
+          trustedIPs:
+            - "${AKS_SYSP00L_IP_PREFIX_0}"
+            - "${AKS_SYSP00L_IP_PREFIX_1}"
+            - "${AKS_WORKPOOL_IP_PREFIX_0}"
+            - "${AKS_WORKPOOL_IP_PREFIX_1}"
+      https:
+        port: 8443
+        expose:
+          default: true
+        exposedPort: 443
+        protocol: TCP
+        forwardedHeaders:
+          insecure: false
+          trustedIPs:
+            - "${AKS_SYSP00L_IP_PREFIX_0}"
+            - "${AKS_SYSP00L_IP_PREFIX_1}"
+            - "${AKS_WORKPOOL_IP_PREFIX_0}"
+            - "${AKS_WORKPOOL_IP_PREFIX_1}"
+        tls:
+          enabled: true
+          options: ""
+          certResolver: ""
+          domains: []
+    tlsOptions:
+      default:
+        minVersion: VersionTLS12
+        cipherSuites:
+          - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+    tlsStore:
+      default:
+        defaultCertificate:
+          secretName: ssl-cert
+    service:
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-resource-group: "${AKS_NODE_RG}"
+        service.beta.kubernetes.io/azure-load-balancer-ipv4: "${PUBLIC_IP_V4}"
+        service.beta.kubernetes.io/azure-load-balancer-ipv6: "${PUBLIC_IP_V6}"
+      spec:
+        externalTrafficPolicy: "${EXTERNAL_TRAFFIC_POLICY:=Local}"
+      ipFamilyPolicy: PreferDualStack
+      ipFamilies:
+        - IPv4
+        - IPv6
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "50Mi"
+    metrics:
+      prometheus:
+        service:
+          enabled: true
+        disableAPICheck: true
+        serviceMonitor:
+          enabled: true
+          metricRelabelings:
+            - sourceLabels: [__name__]
+              separator: ;
+              regex: ^fluentd_output_status_buffer_(oldest|newest)_.+
+              replacement: $1
+              action: drop
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_pod_node_name]
+              separator: ;
+              regex: ^(.*)$
+              targetLabel: nodename
+              replacement: $1
+              action: replace
+          jobLabel: traefik
+          interval: 30s
+          honorLabels: true
+          namespaceSelector:
+            any: true
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - traefik
+              topologyKey: kubernetes.io/hostname
+    extraObjects:
+      - apiVersion: traefik.io/v1alpha1
+        kind: Middleware
+        metadata:
+          name: hsts-header
+          namespace: traefik
+        spec:
+          headers:
+            stsIncludeSubdomains: true
+            stsSeconds: 63072000
+            stsPreload: true
+      - apiVersion: traefik.io/v1alpha1
+        kind: Middleware
+        metadata:
+          name: hsts-header
+          namespace: default
+        spec:
+          headers:
+            stsIncludeSubdomains: true
+            stsSeconds: 63072000
+            stsPreload: true
+      - apiVersion: traefik.io/v1alpha1
+        kind: IngressRoute
+        metadata:
+          name: root-ingress-route
+          namespace: traefik
+        spec:
+          entryPoints:
+            - http
+            - https
+          routes:
+            - kind: Rule
+              match: PathPrefix(`/`)
+              middlewares:
+                - name: hsts-header
+                  namespace: traefik
+              services:
+                - kind: TraefikService
+                  name: noop@internal

--- a/flux/traefik/helmrepository.yaml
+++ b/flux/traefik/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  interval: 1h
+  url: https://traefik.github.io/charts

--- a/flux/traefik/kustomization.yaml
+++ b/flux/traefik/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/flux/traefik/namespace.yaml
+++ b/flux/traefik/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik

--- a/flux/whoami/kustomization.yaml
+++ b/flux/whoami/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - whoami.yaml

--- a/flux/whoami/namespace.yaml
+++ b/flux/whoami/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami

--- a/flux/whoami/whoami.yaml
+++ b/flux/whoami/whoami.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+        - image: altinncr.azurecr.io/traefik/whoami
+          imagePullPolicy: IfNotPresent
+          name: whoami
+          ports:
+            - containerPort: 80
+          env:
+            - name: PORT
+              value: "80"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv6
+    - IPv4
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: ClusterIP
+  selector:
+    app: whoami
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  entryPoints:
+    - http
+    - https
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/whoami/`) || Path(`/whoami`)
+      services:
+        - name: whoami
+          namespace: whoami
+          port: 80


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1656 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated deployment configurations for core infrastructure components including cert-manager, external-secrets-operator, Linkerd service mesh, Traefik ingress controller, OpenTelemetry operator and collector, and a sample "whoami" application.
  - Enabled secure secret management with Azure Key Vault integration and automated secret synchronization.
  - Added high-availability and observability settings for service mesh and monitoring components.
  - Implemented namespace isolation and service mesh injection for improved security and traffic management.
  - Automated rollout restarts and custom middleware for enhanced reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->