### PR TITLE
feat: Add Grafana dashboard folders for external instance

### DIFF
--- a/flux/grafana-manifests/dashboards/folders.yaml
+++ b/flux/grafana-manifests/dashboards/folders.yaml
@@ -1,0 +1,32 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: external-grafana-altinn
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "external-grafana"
+  title: Altinn
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: external-grafana-fluxcd
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "external-grafana"
+  title: Fluxcd
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: external-grafana-linkerd
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "external-grafana"
+  title: linkerd

--- a/flux/grafana-manifests/dashboards/kustomization.yaml
+++ b/flux/grafana-manifests/dashboards/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - altinn-folder.yaml
+  - folders.yaml

--- a/flux/grafana-manifests/dashboards/kustomization.yaml
+++ b/flux/grafana-manifests/dashboards/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - altinn-folder.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Creates GrafanaFolder resources for Altinn, Fluxcd, and Linkerd dashboards targeting the external-grafana instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new organizational folders in Grafana for Altinn, Fluxcd, and linkerd dashboards, enhancing dashboard management and navigation.
- **Chores**
  - Added configuration files to streamline deployment and organization of Grafana dashboard resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->