### PR TITLE
Feat: add grafana manifests aks-resources and auth at22

### DIFF
--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
@@ -59,3 +59,9 @@ module "infra-resources" {
   grafana_endpoint              = module.grafana.grafana_endpoint
   token_grafana_operator        = module.grafana.token_grafana_operator
 }
+
+
+moved {
+  from = module.infra-resources.azapi_resource.grafana-operator
+  to   = module.infra-resources.azapi_resource.grafana_operator
+}

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/grafana.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/grafana.tf
@@ -16,8 +16,3 @@ module "grafana" {
     var.subscription_id,
   ]
 }
-
-moved {
-  from = module.grafana.azapi_resource.grafana-operator
-  to   = module.grafana.azapi_resource.grafana_operator
-}

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/grafana.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/grafana.tf
@@ -16,3 +16,8 @@ module "grafana" {
     var.subscription_id,
   ]
 }
+
+moved {
+  from = module.grafana.azapi_resource.grafana-operator
+  to   = module.grafana.azapi_resource.grafana_operator
+}

--- a/infrastructure/modules/aks-resources/grafana-manifests.tf
+++ b/infrastructure/modules/aks-resources/grafana-manifests.tf
@@ -1,0 +1,35 @@
+resource "azapi_resource" "grafana_manifests" {
+  depends_on = [azapi_resource.linkerd]
+  type       = "Microsoft.KubernetesConfiguration/fluxConfigurations@2024-11-01"
+  name       = "grafana-manifests"
+  parent_id  = var.azurerm_kubernetes_cluster_id
+  body = {
+    properties = {
+      kustomizations = {
+        grafana-manifests = {
+          force                  = false
+          path                   = "./dashboards/"
+          prune                  = false
+          retryIntervalInSeconds = 300
+          syncIntervalInSeconds  = 300
+          timeoutInSeconds       = 300
+          wait                   = true
+        }
+      }
+      namespace = "flux-system"
+      ociRepository = {
+        insecure = false
+        repositoryRef = {
+          tag = var.flux_release_tag
+        }
+        syncIntervalInSeconds = 300
+        timeoutInSeconds      = 300
+        url                   = "oci://altinncr.azurecr.io/manifests/infra/grafana-manifests"
+        useWorkloadIdentity   = true
+      }
+      reconciliationWaitDuration = "PT5M"
+      waitForReconciliation      = true
+      sourceKind                 = "OCIRepository"
+    }
+  }
+}

--- a/infrastructure/modules/aks-resources/grafana-operator.tf
+++ b/infrastructure/modules/aks-resources/grafana-operator.tf
@@ -1,4 +1,4 @@
-resource "azapi_resource" "grafana-operator" {
+resource "azapi_resource" "grafana_operator" {
   depends_on = [azapi_resource.linkerd]
   type       = "Microsoft.KubernetesConfiguration/fluxConfigurations@2024-11-01"
   name       = "grafana-operator"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated deployment of Grafana dashboard manifests to the Azure Kubernetes cluster using Flux and OCI repository integration.

- **Chores**
  - Updated resource naming conventions for improved consistency in infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->