### PR TITLE
feat: Add flux oci for AKS configuration

### DIFF
--- a/flux/container-runtime-aks-config/ama/ama-metrics-settings-configmap.yaml
+++ b/flux/container-runtime-aks-config/ama/ama-metrics-settings-configmap.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  schema-version:
+    #string.used by agent to parse config. supported versions are {v1}. Configs with other schema versions will be rejected by the agent.
+    v1
+  config-version:
+    #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
+    ver1
+  prometheus-collector-settings: |-
+    cluster_alias = ""
+  default-scrape-settings-enabled: |-
+    kubelet = true
+    coredns = false
+    cadvisor = true
+    kubeproxy = false
+    apiserver = false
+    kubestate = true
+    nodeexporter = true
+    windowsexporter = false
+    windowskubeproxy = false
+    kappiebasic = true
+    networkobservabilityRetina = true
+    networkobservabilityHubble = true
+    networkobservabilityCilium = true
+    prometheuscollectorhealth = false
+    controlplane-apiserver = true
+    controlplane-cluster-autoscaler = false
+    controlplane-kube-scheduler = false
+    controlplane-kube-controller-manager = false
+    controlplane-etcd = true
+    acstor-capacity-provisioner = true
+    acstor-metrics-exporter = true
+  # Regex for which namespaces to scrape through pod annotation based scraping.
+  # This is none by default.
+  # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
+  pod-annotation-based-scraping: |-
+    podannotationnamespaceregex = "flux-system"
+  default-targets-metrics-keep-list: |-
+    kubelet = ""
+    coredns = ""
+    cadvisor = ""
+    kubeproxy = ""
+    apiserver = ""
+    kubestate = ""
+    nodeexporter = ""
+    windowsexporter = ""
+    windowskubeproxy = ""
+    podannotations = ""
+    kappiebasic = ""
+    networkobservabilityRetina = ""
+    networkobservabilityHubble = ""
+    networkobservabilityCilium = ""
+    controlplane-apiserver = ""
+    controlplane-cluster-autoscaler = ""
+    controlplane-kube-scheduler = ""
+    controlplane-kube-controller-manager = ""
+    controlplane-etcd = ""
+    acstor-capacity-provisioner = ""
+    acstor-metrics-exporter = ""
+    minimalingestionprofile = true
+  default-targets-scrape-interval-settings: |-
+    kubelet = "30s"
+    coredns = "30s"
+    cadvisor = "30s"
+    kubeproxy = "30s"
+    apiserver = "30s"
+    kubestate = "30s"
+    nodeexporter = "30s"
+    windowsexporter = "30s"
+    windowskubeproxy = "30s"
+    kappiebasic = "30s"
+    networkobservabilityRetina = "30s"
+    networkobservabilityHubble = "30s"
+    networkobservabilityCilium = "30s"
+    prometheuscollectorhealth = "30s"
+    acstor-capacity-provisioner = "30s"
+    acstor-metrics-exporter = "30s"
+    podannotations = "30s"
+  debug-mode: |-
+    enabled = false
+metadata:
+  name: ama-metrics-settings-configmap
+  namespace: kube-system

--- a/flux/container-runtime-aks-config/ama/kustomization.yaml
+++ b/flux/container-runtime-aks-config/ama/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ama-metrics-settings-configmap.yaml

--- a/flux/container-runtime-aks-config/metrics-server/kustomization.yaml
+++ b/flux/container-runtime-aks-config/metrics-server/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- metrics-server-config.yaml

--- a/flux/container-runtime-aks-config/metrics-server/metrics-server-config.yaml
+++ b/flux/container-runtime-aks-config/metrics-server/metrics-server-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-server-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: 100m
+    cpuPerNode: 1m
+    baseMemory: 100Mi
+    memoryPerNode: 8Mi

--- a/flux/container-runtime-aks-config/rbac/kustomization.yaml
+++ b/flux/container-runtime-aks-config/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- read-everything-and-restart.yaml

--- a/flux/container-runtime-aks-config/rbac/read-everything-and-restart.yaml
+++ b/flux/container-runtime-aks-config/rbac/read-everything-and-restart.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-everything-and-restart
+rules:
+  - apiGroups: [""] # core resources
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"] # apps group (deployments, etc.)
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"] # for jobs, cronjobs
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"] # legacy deployments (if any)
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "update"] # update needed for rollout restart
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "delete"] # delete pods
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-everything-and-restart-binding
+subjects:
+  - kind: Group
+    name: 12345678-1234-5678-90ab-1234567890ab # The objectId of the Entra ID group
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: read-everything-and-restart
+  apiGroup: rbac.authorization.k8s.io

--- a/flux/container-runtime-aks-config/rbac/read-everything-and-restart.yaml
+++ b/flux/container-runtime-aks-config/rbac/read-everything-and-restart.yaml
@@ -29,7 +29,7 @@ metadata:
   name: read-everything-and-restart-binding
 subjects:
   - kind: Group
-    name: 12345678-1234-5678-90ab-1234567890ab # The objectId of the Entra ID group
+    name: "${AKS_READ_EVERYTHING_AND_RESTART_GROUP_ID}" # The objectId of the Entra ID group
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/infrastructure/modules/aks/law-collection.tf
+++ b/infrastructure/modules/aks/law-collection.tf
@@ -77,6 +77,26 @@ resource "azurerm_monitor_data_collection_rule" "law" {
             "azure-arc"
           ],
           "enableContainerLogV2" : true
+
+          log_collection_settings = {
+            stdout = {
+              enabled            = false
+              exclude_namespaces = ["kube-system"]
+            },
+            stderr = {
+              enabled            = true
+              exclude_namespaces = ["kube-system", "monitoring", "linkerd-viz"]
+            },
+            env_var = {
+              enabled = false
+            },
+            enrich_container_logs = {
+              enabled = false
+            },
+            collect_all_kube_events = {
+              enabled = false
+            }
+          }
         }
       })
       name = "ContainerInsightsExtension"

--- a/infrastructure/modules/aks/law-collection.tf
+++ b/infrastructure/modules/aks/law-collection.tf
@@ -76,25 +76,24 @@ resource "azurerm_monitor_data_collection_rule" "law" {
             "gatekeeper-system",
             "azure-arc"
           ],
-          "enableContainerLogV2" : true
-
-          log_collection_settings = {
-            stdout = {
-              enabled            = false
-              exclude_namespaces = ["kube-system"]
+          "enableContainerLogV2" : true,
+          "log_collection_settings" : {
+            "stdout" : {
+              "enabled" : false,
+              "exclude_namespaces" : ["kube-system"]
             },
-            stderr = {
-              enabled            = true
-              exclude_namespaces = ["kube-system", "monitoring"]
+            "stderr" : {
+              "enabled" : true,
+              "exclude_namespaces" : ["kube-system", "monitoring"]
             },
-            env_var = {
-              enabled = false
+            "env_var" : {
+              "enabled" : false
             },
-            enrich_container_logs = {
-              enabled = false
+            "enrich_container_logs" : {
+              "enabled" : false
             },
-            collect_all_kube_events = {
-              enabled = false
+            "collect_all_kube_events" : {
+              "enabled" : false
             }
           }
         }

--- a/infrastructure/modules/aks/law-collection.tf
+++ b/infrastructure/modules/aks/law-collection.tf
@@ -85,7 +85,7 @@ resource "azurerm_monitor_data_collection_rule" "law" {
             },
             stderr = {
               enabled            = true
-              exclude_namespaces = ["kube-system", "monitoring", "linkerd-viz"]
+              exclude_namespaces = ["kube-system", "monitoring"]
             },
             env_var = {
               enabled = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Add AMA metrics settings ConfigMap with selective scraping enabled
- Add metrics-server nanny configuration
- Configure RBAC for cluster read/restart permissions
- Update log collection to exclude noisy namespaces and disable stdout




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced centralized configuration for metrics collection settings and scrape intervals for Kubernetes components via new ConfigMaps.
	- Added resource allocation configuration for the metrics server nanny component.
	- Implemented a new RBAC role and binding, granting broad read access and limited update/delete permissions to a designated Entra ID group.
- **Chores**
	- Added Kustomization files for easier management and deployment of configuration resources.
	- Enhanced log collection settings for container logs, including namespace-based exclusions and control over log types collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->