### PR TITLE
fix: Add id-token write permission to default-syncroot workflow

### DIFF
--- a/.github/workflows/default-syncroot.yml
+++ b/.github/workflows/default-syncroot.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   latest:


### PR DESCRIPTION
The Azure login action was failing because it couldn't get the `ACTIONS_ID_TOKEN_REQUEST_URL` environment variable, which is only available when the workflow has `id-token: write` permissions.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to allow the use of OpenID Connect (OIDC) tokens during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->