### PR TITLE
bugfix: correct config for functional.json

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/tweaked-testconfig.json
@@ -1,13 +1,9 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ],
+  "iterations": 1,
   "thresholds": {
     "http_req_duration": [
       "avg\u003c123"
     ]
-  }
+  },
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/tweaked-testconfig.json
@@ -1,8 +1,4 @@
 {
-  "stages": [
-    {
-      "iterations": 1,
-      "vus": 1
-    }
-  ]
+  "iterations": 1,
+  "vus": 1
 }

--- a/infrastructure/images/k6-action/default_scenarios/functional.json
+++ b/infrastructure/images/k6-action/default_scenarios/functional.json
@@ -1,8 +1,4 @@
 {
-    "stages": [
-        {
-            "vus": 1,
-            "iterations": 1
-        }
-    ]
+    "vus": 1,
+    "iterations": 1
 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Previous config was wrong: https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#stages

I randomly noticed a warning message as I was checking through the logs today. In practice it ended up defaulting to exactly what was expected, i.e. 1 vu and 1 iteration, which is why I didn't notice it before.

```
time="2025-06-04T06:25:19Z" level=warning msg="`stages` was explicitly set to an empty value, running the script with 1 iteration in 1 VU"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated load test configuration for a simpler and more direct setup. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->