### PR TITLE
bugfix: correct syntax for multiple labels in the filter

### DIFF
--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -262,7 +262,7 @@ func (r K8sManifestGenerator) Generate() {
 				r.CallJsonnet(dirName, uniqName, strconv.FormatInt(manifestGenerationTimestamp, 10), cf.Namespace, c.Environment, *c.TestRun.Parallelism, *c.NodeType, secretReferences, mergedEnvsMarshalled, resources)
 
 				fmt.Printf("\nTo run the test '%s' in '%s' run\n\tkubectl --context k6tests-cluster apply -f %s", *c.TestRun.Name, c.Environment, filepath.Join(r.DistDirectory, dirName))
-				fmt.Printf("\nTo check the logs run\n\tkubectl --context k6tests-cluster -n %s logs -f -l \"k6-test=%s\" -l \"runner=true\"\n\n", cf.Namespace, uniqName)
+				fmt.Printf("\nTo check the logs run\n\tkubectl --context k6tests-cluster -n %s logs -f --tail=-1 -l \"k6-test=%s,runner=true\"\n\n", cf.Namespace, uniqName)
 
 				if githubOutputFilePath, ok := os.LookupEnv("GITHUB_OUTPUT"); ok {
 					f, err := os.OpenFile(githubOutputFilePath, os.O_APPEND|os.O_WRONLY, 0644)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the log message to provide a more accurate `kubectl logs` command, now showing all logs from the beginning and using an improved label selector format for easier log retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->