### PR TITLE
feat: support browser tests and fix env duplication

### DIFF
--- a/actions/generate-k6-manifests/cmd/config_file_test.go
+++ b/actions/generate-k6-manifests/cmd/config_file_test.go
@@ -65,6 +65,7 @@ test_definitions:
 			"soak",
 			"spike",
 			"breakpoint",
+			"browser",
 			"custom",
 		},
 	}
@@ -137,6 +138,7 @@ test_definitions:
 			"soak",
 			"spike",
 			"breakpoint",
+			"browser",
 			"custom",
 		},
 	}

--- a/actions/generate-k6-manifests/cmd/example_configfiles/v11.yaml
+++ b/actions/generate-k6-manifests/cmd/example_configfiles/v11.yaml
@@ -1,0 +1,12 @@
+namespace: platform
+test_definitions:
+  - test_file: actions/generate-k6-manifests/test_service/k8s_wrapper/get_deployments.js
+    contexts:
+      - environment: at22
+        test_type:
+          type: browser
+          enabled: true
+        test_run:
+          env:
+            - name: K6_PROMETHEUS_RW_TREND_STATS
+              value: "avg,count,min,med,max,p(75),p(95)"

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": "octocat/Hello-World"
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": "14965885066"
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": "https://github.com"
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": "octocat/Hello-World"
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": "https://github.com"
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": "14965885066"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": "octocat/Hello-World"
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": "14965885066"
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": "https://github.com"
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": "octocat/Hello-World"
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": "https://github.com"
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": "14965885066"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": "octocat/Hello-World"
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": "14965885066"
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": "https://github.com"
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": "octocat/Hello-World"
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": "https://github.com"
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": "14965885066"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -16,15 +16,15 @@
          "env": [
             {
                "name": "GITHUB_REPOSITORY",
-               "value": "octocat/Hello-World"
+               "value": ""
             },
             {
                "name": "GITHUB_RUN_ID",
-               "value": "14965885066"
+               "value": ""
             },
             {
                "name": "GITHUB_SERVER_URL",
-               "value": "https://github.com"
+               "value": ""
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -36,7 +36,7 @@
             },
             {
                "name": "K6_PROMETHEUS_RW_TREND_STATS",
-               "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
+               "value": "avg,count,min,med,max,p(75),p(95)"
             },
             {
                "name": "MANIFEST_GENERATION_TIMESTAMP",
@@ -54,15 +54,16 @@
          "envFrom": [
             {
                "configMapRef": {
-                  "name": "deploy-environments-tt02"
+                  "name": "deploy-environments-at22"
                }
             },
             {
                "secretRef": {
-                  "name": "slack-prod"
+                  "name": "slack-test"
                }
             }
          ],
+         "image": "grafana/k6:master-with-browser",
          "metadata": {
             "labels": {
                "k6-test": "{{ .UniqueName }}"

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/tweaked-testconfig.json
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/tweaked-testconfig.json
@@ -1,0 +1,5 @@
+{
+  "browser": {
+    "type": "chromium"
+  }
+}

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
@@ -1,0 +1,23 @@
+namespace: platform
+test_definitions:
+    - test_file: actions/generate-k6-manifests/test_service/k8s_wrapper/get_deployments.js
+      config_file: ""
+      env_file: ""
+      contexts:
+        - environment: at22
+          node_type: spot
+          test_type:
+            type: browser
+            enabled: true
+            config_file: ""
+          test_run:
+            name: get-deployments
+            parallelism: 1
+            resources:
+                requests:
+                    memory: 200Mi
+                    cpu: 250m
+            env:
+                - name: K6_PROMETHEUS_RW_TREND_STATS
+                  value: avg,count,min,med,max,p(75),p(95)
+            secrets: []

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -15,30 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "K6_NO_USAGE_REPORT",
-               "value": "true"
-            },
-            {
-               "name": "K6_PROMETHEUS_RW_SERVER_URL",
-               "value": "http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/write"
-            },
-            {
-               "name": "K6_PROMETHEUS_RW_TREND_STATS",
-               "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
-            },
-            {
-               "name": "NAMESPACE",
-               "value": "platform"
-            },
-            {
-               "name": "TESTID",
-               "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
                "name": "API_VERSION",
                "value": "3"
             },
@@ -51,12 +27,36 @@
                "value": ""
             },
             {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
                "name": "GITHUB_SERVER_URL",
                "value": ""
             },
             {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
+               "name": "K6_NO_USAGE_REPORT",
+               "value": "true"
+            },
+            {
+               "name": "K6_PROMETHEUS_RW_SERVER_URL",
+               "value": "http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/write"
+            },
+            {
+               "name": "K6_PROMETHEUS_RW_TREND_STATS",
+               "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
+            },
+            {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
+               "name": "NAMESPACE",
+               "value": "platform"
+            },
+            {
+               "name": "TESTID",
+               "value": "{{ .UniqueName }}"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -15,6 +15,18 @@
       "runner": {
          "env": [
             {
+               "name": "GITHUB_REPOSITORY",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
+               "name": "GITHUB_SERVER_URL",
+               "value": ""
+            },
+            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -27,28 +39,16 @@
                "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
             },
             {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
                "name": "NAMESPACE",
                "value": "platform"
             },
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -15,30 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "K6_NO_USAGE_REPORT",
-               "value": "true"
-            },
-            {
-               "name": "K6_PROMETHEUS_RW_SERVER_URL",
-               "value": "http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/write"
-            },
-            {
-               "name": "K6_PROMETHEUS_RW_TREND_STATS",
-               "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
-            },
-            {
-               "name": "NAMESPACE",
-               "value": "platform"
-            },
-            {
-               "name": "TESTID",
-               "value": "{{ .UniqueName }}"
-            },
-            {
-               "name": "MANIFEST_GENERATION_TIMESTAMP",
-               "value": "{{ .ManifestGenerationTimestamp }}"
-            },
-            {
                "name": "ENVFROMFILE1",
                "value": "ENV1"
             },
@@ -55,12 +31,36 @@
                "value": ""
             },
             {
+               "name": "GITHUB_RUN_ID",
+               "value": ""
+            },
+            {
                "name": "GITHUB_SERVER_URL",
                "value": ""
             },
             {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
+               "name": "K6_NO_USAGE_REPORT",
+               "value": "true"
+            },
+            {
+               "name": "K6_PROMETHEUS_RW_SERVER_URL",
+               "value": "http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/write"
+            },
+            {
+               "name": "K6_PROMETHEUS_RW_TREND_STATS",
+               "value": "avg,min,med,max,count,p(95),p(99),p(99.5),p(99.9)"
+            },
+            {
+               "name": "MANIFEST_GENERATION_TIMESTAMP",
+               "value": "{{ .ManifestGenerationTimestamp }}"
+            },
+            {
+               "name": "NAMESPACE",
+               "value": "platform"
+            },
+            {
+               "name": "TESTID",
+               "value": "{{ .UniqueName }}"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/generator_test.go
+++ b/actions/generate-k6-manifests/cmd/generator_test.go
@@ -138,7 +138,7 @@ func postTest(version string) {
 	}
 }
 
-var generateExamplesVersion = []string{"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10"}
+var generateExamplesVersion = []string{"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11"}
 
 func TestGenerate(t *testing.T) {
 	for _, version := range generateExamplesVersion {

--- a/infrastructure/images/k6-action/default_scenarios/browser.json
+++ b/infrastructure/images/k6-action/default_scenarios/browser.json
@@ -1,0 +1,5 @@
+{
+    "browser": {
+        "type": "chromium"
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The image used to run browser tests is different than the default one.
Ended up hijacking the PR and fixing a TODO that has been there for a while.
## Related Issue(s)
- #1783 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for browser-based performance tests with new configuration options specifying browser type.
  - Introduced new example configuration files and templates for browser tests.
- **Refactor**
  - Improved environment variable handling in test run configurations for clarity and extensibility.
  - Enhanced manifest generation logic to conditionally use browser-enabled test images.
- **Tests**
  - Expanded test coverage to include browser test scenarios and new configuration versions.
- **Chores**
  - Reorganized and updated environment variable ordering in generated files for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->