### PR TITLE
bugfix: sets should be ordered before calling set functions; don't append unset github env vars to env

### DIFF
--- a/actions/generate-k6-manifests/cmd/example_configfiles/v11.yaml
+++ b/actions/generate-k6-manifests/cmd/example_configfiles/v11.yaml
@@ -8,5 +8,7 @@ test_definitions:
           enabled: true
         test_run:
           env:
+            - name: ZZZ
+              value: "Something"
             - name: K6_PROMETHEUS_RW_TREND_STATS
               value: "avg,count,min,med,max,p(75),p(95)"

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },
@@ -49,6 +37,10 @@
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
+            },
+            {
+               "name": "ZZZ",
+               "value": "Something"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
@@ -18,6 +18,8 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env:
+                - name: ZZZ
+                  value: Something
                 - name: K6_PROMETHEUS_RW_TREND_STATS
                   value: avg,count,min,med,max,p(75),p(95)
             secrets: []

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -23,18 +23,6 @@
                "value": "enabled"
             },
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -15,18 +15,6 @@
       "runner": {
          "env": [
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -27,18 +27,6 @@
                "value": "BAR"
             },
             {
-               "name": "GITHUB_REPOSITORY",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_RUN_ID",
-               "value": ""
-            },
-            {
-               "name": "GITHUB_SERVER_URL",
-               "value": ""
-            },
-            {
                "name": "K6_NO_USAGE_REPORT",
                "value": "true"
             },

--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -224,23 +224,28 @@ func (r K8sManifestGenerator) Generate() {
 				githubServerUrlEnvName := "GITHUB_SERVER_URL"
 				githubRunIdEnvName := "GITHUB_RUN_ID"
 
-				githubRepositoryEnvValue := os.Getenv(githubRepositoryEnvName)
-				githubServerUrlEnvValue := os.Getenv(githubServerUrlEnvName)
-				githubRunIdEnvValue := os.Getenv(githubRunIdEnvName)
+				var githubRelatedEnvVars []*Env
 
-				githubRelatedEnvVars := []*Env{
-					&Env{
+				githubRepositoryEnvValue, ok := os.LookupEnv(githubRepositoryEnvName)
+				if ok {
+					githubRelatedEnvVars = append(githubRelatedEnvVars, &Env{
 						Name:  &githubRepositoryEnvName,
 						Value: &githubRepositoryEnvValue,
-					},
-					&Env{
+					})
+				}
+				githubServerUrlEnvValue, ok := os.LookupEnv(githubServerUrlEnvName)
+				if ok {
+					githubRelatedEnvVars = append(githubRelatedEnvVars, &Env{
 						Name:  &githubServerUrlEnvName,
 						Value: &githubServerUrlEnvValue,
-					},
-					&Env{
+					})
+				}
+				githubRunIdEnvValue, ok := os.LookupEnv(githubRunIdEnvName)
+				if ok {
+					githubRelatedEnvVars = append(githubRelatedEnvVars, &Env{
 						Name:  &githubRunIdEnvName,
 						Value: &githubRunIdEnvValue,
-					},
+					})
 				}
 
 				testRunEnvWithGithubContext := handleExtraEnvVars(c.TestRun.Env, githubRelatedEnvVars)

--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -74,4 +74,4 @@ COPY infrastructure/images/k6-action/jsonnet /actions/generate-k6-manifests/json
 RUN apk add --no-cache libstdc++
 WORKDIR /workspace
 
-CMD ["/bin/sh"]
+CMD ["generate-k6-manifests"]

--- a/infrastructure/images/k6-action/jsonnet/main.jsonnet
+++ b/infrastructure/images/k6-action/jsonnet/main.jsonnet
@@ -140,7 +140,12 @@ local testrun = {
     },
   },
   withExtraEnv(): {
-    local newEnv = std.sort(std.setUnion([{ name: v.name, value: std.toString(v.value) } for v in extra_env_vars], default_env, keyF=function(x) x.name), keyF=function(x) x.name),
+    local extraEnvVarsSet = std.set([{ name: v.name, value: std.toString(v.value) } for v in extra_env_vars], keyF=function(x) x.name),
+    local defaultEnvSet = std.set(default_env, keyF=function(x) x.name),
+    local newEnv =
+      std.setUnion(
+        extraEnvVarsSet, defaultEnvSet, keyF=function(x) x.name
+      ),
     spec+: {
       runner+: {
         env: newEnv,
@@ -150,7 +155,7 @@ local testrun = {
   withBrowserImage(): {
     spec+: {
       runner+: {
-        image+: 'grafana/k6:master-with-browser',
+        image: 'grafana/k6:master-with-browser',
       },
     },
   },


### PR DESCRIPTION
## Description
https://github.com/Altinn/altinn-platform/pull/1784 didn't quite work as expected.
I forgot the sets are supposed to be ordered: https://jsonnet.org/ref/stdlib.html#sets

Hijacking the same PR to also not append GITHUB related env vars when they are not set (i.e. when not running as a Github action)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new environment variable "ZZZ" with the value "Something" to test run configurations.

- **Bug Fixes**
  - Environment variables with empty values ("GITHUB_REPOSITORY", "GITHUB_RUN_ID", "GITHUB_SERVER_URL") are no longer included in test run manifests.

- **Refactor**
  - Improved logic for merging and handling environment variables in test run configurations to ensure more accurate deduplication and assignment.
  - Updated container default behavior to run manifest generation tool directly instead of opening a shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->