### PR TITLE
chore: Upgrade Linkerd to 2025.5.5 and improve security

### DIFF
--- a/flux/linkerd/helmrelease.yaml
+++ b/flux/linkerd/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: linkerd
         namespace: linkerd
-      version: 2025.1.2
+      version: 2025.5.5
   interval: 1h
   timeout: 5m
   install:
@@ -36,7 +36,7 @@ spec:
         kind: HelmRepository
         name: linkerd
         namespace: linkerd
-      version: 2025.1.2
+      version: 2025.5.5
   interval: 1h
   timeout: 10m
   dependsOn:
@@ -98,4 +98,4 @@ spec:
         name: altinncr.azurecr.io/linkerd/proxy-init
     podMonitor:
       enabled: true
-    disableIPv6: "${DISABLE_IPV6}"
+    disableIPv6: "${DISABLE_IPV6:=false}"

--- a/flux/linkerd/post-deploy/rollout-restart-job.yaml
+++ b/flux/linkerd/post-deploy/rollout-restart-job.yaml
@@ -43,9 +43,23 @@ spec:
   template:
     spec:
       serviceAccountName: rollout-restart-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       containers:
         - name: kubectl
           image: altinncr.azurecr.io/docker.io/bitnami/kubectl:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            capabilities:
+              drop:
+                - ALL
           command: ["sh", "-c"]
           args:
             - |
@@ -58,4 +72,5 @@ spec:
               kubectl -n default rollout restart deployments,statefulsets,daemonsets ;
               kubectl -n pdf rollout restart deployments,statefulsets,daemonsets ;
               kubectl -n monitoring rollout restart deployments,statefulsets,daemonsets ;
+              kubectl -n grafana rollout restart deployments,statefulsets,daemonsets ;
       restartPolicy: Never

--- a/flux/linkerd/post-deploy/rollout-restart-job.yaml
+++ b/flux/linkerd/post-deploy/rollout-restart-job.yaml
@@ -60,6 +60,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
           command: ["sh", "-c"]
           args:
             - |
@@ -67,10 +69,23 @@ spec:
               if ! kubectl label ns kube-system --list=true | grep -q config.linkerd.io/admission-webhooks=disabled; then
                 kubectl label ns kube-system config.linkerd.io/admission-webhooks=disabled
               fi
-              # Restart all pods that use linkerd in the namespaces
-              kubectl -n traefik rollout restart deployments,statefulsets,daemonsets ;
-              kubectl -n default rollout restart deployments,statefulsets,daemonsets ;
-              kubectl -n pdf rollout restart deployments,statefulsets,daemonsets ;
-              kubectl -n monitoring rollout restart deployments,statefulsets,daemonsets ;
-              kubectl -n grafana rollout restart deployments,statefulsets,daemonsets ;
+              # Define excluded namespaces
+              EXCLUDED_NAMESPACES="cert-manager flux-system kube-node-lease kube-public kube-system linkerd"
+              # Get all namespaces and filter out excluded ones
+              ALL_NAMESPACES=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
+              # Restart workloads in all namespaces except excluded ones
+              for ns in $ALL_NAMESPACES; do
+                skip=false
+                for excluded in $EXCLUDED_NAMESPACES; do
+                  if [ "$ns" = "$excluded" ]; then
+                    echo "Skipping excluded namespace: $ns"
+                    skip=true
+                    break
+                  fi
+                done
+                if [ "$skip" = false ]; then
+                  echo "Restarting workloads in namespace: $ns"
+                  kubectl -n "$ns" rollout restart deployments,statefulsets,daemonsets 2>/dev/null || echo "No workloads to restart in namespace: $ns"
+                fi
+              done
       restartPolicy: Never


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Sets runAsNonRoot, adds security contexts, and updates restart job to include grafana namespace

## Related Issue(s)
- #1593 
- #1704 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Linkerd Helm chart versions to the latest release.
  - Improved environment variable handling for IPv6 settings, ensuring a default value is applied if unset.
  - Enhanced security settings for the rollout restart job by enforcing non-root execution and restricting container privileges.
  - Expanded rollout restart operations to dynamically target all namespaces except a defined exclusion list, improving deployment coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->