### PR TITLE
fix: provide creds as flux acr impl seems unstable

### DIFF
--- a/.github/workflows/manage-flux-releases.yml
+++ b/.github/workflows/manage-flux-releases.yml
@@ -190,6 +190,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
+        id: setup_flux_acr
         uses: ./actions/flux/setup-flux-acr
         with:
           azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
@@ -198,10 +199,9 @@ jobs:
       - name: Promote release
         env:
           REGISTRY: altinncr.azurecr.io
+          CREDS: ${{ steps.setup_flux_acr.outputs.credentials }}
         run: |
           echo "Promoting release..."
-          # Login to ACR to establish authentication context
-          creds=$(az acr login --name $(echo ${REGISTRY} | cut -d'.' -f1) --expose-token)
           # Read the releases config file and loop through the releases
           releasesConfigFile="${{ env.RELEASE_FILE }}"
           releasesConfig=$(cat $releasesConfigFile)
@@ -212,7 +212,7 @@ jobs:
               echo "retagging oci://${REGISTRY}/manifests/infra/${releaseName}:${releaseVersion} to ${envName}"
               flux tag artifact oci://${REGISTRY}/manifests/infra/${releaseName}:${releaseVersion} \
               --tag ${envName} \
-              --creds="${creds}" \
-              --provider=azure
+              --provider=azure \
+              --creds="${CREDS}"
             done
           done

--- a/.github/workflows/manage-flux-releases.yml
+++ b/.github/workflows/manage-flux-releases.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           echo "Promoting release..."
           # Login to ACR to establish authentication context
-          az acr login --name $(echo ${REGISTRY} | cut -d'.' -f1)
+          creds=$(az acr login --name $(echo ${REGISTRY} | cut -d'.' -f1) --expose-token)
           # Read the releases config file and loop through the releases
           releasesConfigFile="${{ env.RELEASE_FILE }}"
           releasesConfig=$(cat $releasesConfigFile)
@@ -211,6 +211,8 @@ jobs:
               echo "Promoting release $releaseName to version $releaseVersion for environment $envName"
               echo "retagging oci://${REGISTRY}/manifests/infra/${releaseName}:${releaseVersion} to ${envName}"
               flux tag artifact oci://${REGISTRY}/manifests/infra/${releaseName}:${releaseVersion} \
-              --tag ${envName}
+              --tag ${envName} \
+              --creds="${creds}" \
+              --provider=azure
             done
           done

--- a/.github/workflows/release-flux-artifact.yml
+++ b/.github/workflows/release-flux-artifact.yml
@@ -48,6 +48,7 @@ jobs:
           fi
 
           # Extract unique folder names directly under ./manifests/infra/
+          creds=$(az acr login --name altinncr --expose-token)
           ARTIFACTS=$(echo "${FLUX_FILES}" | awk -F'/' '{print $2}' | sort -u)
           for artifact in $ARTIFACTS;do
             flux push artifact "oci://${REGISTRY}/manifests/infra/${artifact}:$(git rev-parse --short HEAD)" \
@@ -55,10 +56,12 @@ jobs:
               --reproducible \
               --path="./flux/${artifact}" \
               --source="$(git config --get remote.origin.url)" \
-              --revision="$(git branch --show-current)/$(git rev-parse HEAD)"
+              --revision="$(git branch --show-current)/$(git rev-parse HEAD)" \
+              --creds="${creds}"
             flux tag artifact "oci://${REGISTRY}/manifests/infra/${artifact}:$(git rev-parse --short HEAD)" \
               --provider=azure \
-              --tag latest
+              --tag latest \
+              --creds="${creds}"
           done
   tag-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-flux-artifact.yml
+++ b/.github/workflows/release-flux-artifact.yml
@@ -26,19 +26,17 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - name: Setup flux
-        uses: fluxcd/flux2/action@8d5f40dca5aa5d3c0fc3414457dda15a0ac92fa4 # v2.5.1
+      - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
+        id: setup_flux_acr
+        uses: ./actions/flux/setup-flux-acr
         with:
-          version: latest
-      - name: az login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          subscription-id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
-          client-id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ secrets.AZURE_ALTINNACR_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.AZURE_ALTINNACR_APP_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
       - name: Build and push artifacts with commit sha tag
         env:
           REGISTRY: altinncr.azurecr.io
+          CREDS: ${{ steps.setup_flux_acr.outputs.credentials }}
         run: |
           echo '### Check if there are any changes in ./flux/ folder'
           FLUX_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD | grep 'flux/' || true)
@@ -48,7 +46,6 @@ jobs:
           fi
 
           # Extract unique folder names directly under ./manifests/infra/
-          creds=$(az acr login --name altinncr --expose-token)
           ARTIFACTS=$(echo "${FLUX_FILES}" | awk -F'/' '{print $2}' | sort -u)
           for artifact in $ARTIFACTS;do
             flux push artifact "oci://${REGISTRY}/manifests/infra/${artifact}:$(git rev-parse --short HEAD)" \
@@ -57,11 +54,11 @@ jobs:
               --path="./flux/${artifact}" \
               --source="$(git config --get remote.origin.url)" \
               --revision="$(git branch --show-current)/$(git rev-parse HEAD)" \
-              --creds="${creds}"
+              --creds="${CREDS}"
             flux tag artifact "oci://${REGISTRY}/manifests/infra/${artifact}:$(git rev-parse --short HEAD)" \
               --provider=azure \
               --tag latest \
-              --creds="${creds}"
+              --creds="${CREDS}"
           done
   tag-release:
     runs-on: ubuntu-latest

--- a/actions/flux/build-push-image/action.yaml
+++ b/actions/flux/build-push-image/action.yaml
@@ -49,6 +49,7 @@ runs:
         ACR_NAME: ${{ inputs.acr_name }}
         WORKDIR: ${{ inputs.workdir }}
       shell: bash
+      needs: setup_flux_acr
       run: |
         container_registry=${ACR_NAME}.azurecr.io
         short_sha=$(git rev-parse --short HEAD)
@@ -60,9 +61,11 @@ runs:
           --reproducible \
           --path="${WORKDIR}" \
           --source="${repo_url}" \
-          --revision="${branch_sha}"
+          --revision="${branch_sha}" \
+          --creds="${{steps.setup_flux_acr.outputs.credentials}}"
     - name: Tag artifact with custom tag
       if: inputs.tag != ''
+      needs: setup_flux_acr
       env:
         ARTIFACT_NAME: ${{ inputs.image_name }}
         EXTRA_TAG: ${{ inputs.tag }}
@@ -71,6 +74,8 @@ runs:
       run: |
         container_registry=${ACR_NAME}.azurecr.io
         short_sha=$(git rev-parse --short HEAD)
+        creds=$(az acr login --name ${ACR_NAME} --expose-token)
         flux tag artifact "oci://${container_registry}/${ARTIFACT_NAME}:${short_sha}" \
           --provider=azure \
-          --tag "${EXTRA_TAG}"
+          --tag "${EXTRA_TAG}" \
+          --creds="${{steps.setup_flux_acr.outputs.credentials}}"

--- a/actions/flux/build-push-image/action.yaml
+++ b/actions/flux/build-push-image/action.yaml
@@ -48,6 +48,7 @@ runs:
         ARTIFACT_NAME: ${{ inputs.image_name }}
         ACR_NAME: ${{ inputs.acr_name }}
         WORKDIR: ${{ inputs.workdir }}
+        CREDS: ${{ steps.setup_flux_acr.outputs.credentials }}
       shell: bash
       needs: setup_flux_acr
       run: |
@@ -62,7 +63,7 @@ runs:
           --path="${WORKDIR}" \
           --source="${repo_url}" \
           --revision="${branch_sha}" \
-          --creds="${{steps.setup_flux_acr.outputs.credentials}}"
+          --creds="${CREDS}"
     - name: Tag artifact with custom tag
       if: inputs.tag != ''
       needs: setup_flux_acr
@@ -70,12 +71,12 @@ runs:
         ARTIFACT_NAME: ${{ inputs.image_name }}
         EXTRA_TAG: ${{ inputs.tag }}
         ACR_NAME: ${{ inputs.acr_name }}
+        CREDS: ${{ steps.setup_flux_acr.outputs.credentials }}
       shell: bash
       run: |
         container_registry=${ACR_NAME}.azurecr.io
         short_sha=$(git rev-parse --short HEAD)
-        creds=$(az acr login --name ${ACR_NAME} --expose-token)
         flux tag artifact "oci://${container_registry}/${ARTIFACT_NAME}:${short_sha}" \
           --provider=azure \
           --tag "${EXTRA_TAG}" \
-          --creds="${{steps.setup_flux_acr.outputs.credentials}}"
+          --creds="${CREDS}"

--- a/actions/flux/retag-image/action.yaml
+++ b/actions/flux/retag-image/action.yaml
@@ -51,10 +51,10 @@ runs:
         TO_TAG: ${{ inputs.tag }}
         ACR_NAME: ${{ inputs.acr_name }}
       shell: bash
+      needs: setup_flux_acr
       run: |
         container_registry=${ACR_NAME}.azurecr.io
-        credentials=$(az acr login --name ${ACR_NAME} --expose-token)
         flux tag artifact "oci://${container_registry}/${ARTIFACT_NAME}:${FROM_TAG}" \
             --provider=azure \
             --tag "${TO_TAG}" \
-            --creds="${credentials}"
+            --creds="${{ steps.setup_flux_acr.outputs.credentials }}"

--- a/actions/flux/retag-image/action.yaml
+++ b/actions/flux/retag-image/action.yaml
@@ -50,6 +50,7 @@ runs:
         FROM_TAG: ${{ inputs.from_tag }}
         TO_TAG: ${{ inputs.tag }}
         ACR_NAME: ${{ inputs.acr_name }}
+        CREDS: ${{ steps.setup_flux_acr.outputs.credentials }}
       shell: bash
       needs: setup_flux_acr
       run: |
@@ -57,4 +58,4 @@ runs:
         flux tag artifact "oci://${container_registry}/${ARTIFACT_NAME}:${FROM_TAG}" \
             --provider=azure \
             --tag "${TO_TAG}" \
-            --creds="${{ steps.setup_flux_acr.outputs.credentials }}"
+            --creds="${CREDS}"

--- a/actions/flux/setup-flux-acr/action.yaml
+++ b/actions/flux/setup-flux-acr/action.yaml
@@ -16,6 +16,10 @@ inputs:
   azure_tenant_id:
     description: "Azure tenant id used to authenticate to altinncr"
     required: true
+outputs:
+  credentials:
+    description: "Credentials for the Azure Container Registry (ACR) to use with flux"
+    value: ${{ steps.get_acr_creds.outputs.credentials }}
 
 runs:
   using: composite
@@ -30,3 +34,13 @@ runs:
         client-id: ${{ inputs.azure_app_id }}
         subscription-id: ${{ inputs.azure_subscription_id }}
         tenant-id: ${{ inputs.azure_tenant_id }}
+    - name: Get ACR credentials
+      id: get_acr_creds
+      run: |
+        credentials=$(az acr login --name altinncr --expose-token)
+        # Add log mask for accessToken and refreshToken to avoid leaking sensitive information using jq
+        accessToken=$(echo "${credentials}" | jq -r '.accessToken')
+        refreshToken=$(echo "${credentials}" | jq -r '.refreshToken')
+        echo "::add-mask::${accessToken}"
+        echo "::add-mask::${refreshToken}"
+        echo "credentials=${credentials}" >> $GITHUB_OUTPUT

--- a/actions/flux/setup-flux-acr/action.yaml
+++ b/actions/flux/setup-flux-acr/action.yaml
@@ -16,6 +16,12 @@ inputs:
   azure_tenant_id:
     description: "Azure tenant id used to authenticate to altinncr"
     required: true
+  acr_name:
+    description: "Name of the Azure Container Registry (ACR) to use"
+    required: false
+    default: "altinncr"
+    type: string
+    pattern: "^[a-zA-Z0-9-]{5,50}$"
 outputs:
   credentials:
     description: "Credentials for the Azure Container Registry (ACR) to use with flux"
@@ -36,8 +42,11 @@ runs:
         tenant-id: ${{ inputs.azure_tenant_id }}
     - name: Get ACR credentials
       id: get_acr_creds
+      shell: bash
+      env:
+        ACR_NAME: ${{ inputs.acr_name }}
       run: |
-        credentials=$(az acr login --name altinncr --expose-token)
+        credentials=$(az acr login --name ${ACR_NAME} --expose-token)
         # Add log mask for accessToken and refreshToken to avoid leaking sensitive information using jq
         accessToken=$(echo "${credentials}" | jq -r '.accessToken')
         refreshToken=$(echo "${credentials}" | jq -r '.refreshToken')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
reverting back to providing creds manually as azure auth impl in fluxcli seems unstable

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved authentication handling for Azure Container Registry (ACR) in GitHub Actions workflows by centralizing credential acquisition and securely passing credentials to Flux commands.
	- Enhanced workflow reliability by ensuring steps that require credentials explicitly depend on the credential setup step.
	- Added secure output of ACR credentials for use in subsequent workflow steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->