### PR TITLE
fix: Set default Grafana dashboard branch to "release"

### DIFF
--- a/infrastructure/modules/aks-resources/grafana-manifests.tf
+++ b/infrastructure/modules/aks-resources/grafana-manifests.tf
@@ -16,9 +16,9 @@ resource "azapi_resource" "grafana_manifests" {
           timeoutInSeconds       = 300
           wait                   = true
           postBuild = {
-            substitute = var.grafana_dashboard_release_branch != "" ? {
+            substitute = {
               RELEASE_BRANCH = var.grafana_dashboard_release_branch
-            } : {}
+            }
           }
         }
       }

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -25,11 +25,11 @@ variable "flux_release_tag" {
 
 variable "grafana_dashboard_release_branch" {
   type        = string
-  default     = ""
+  default     = "release"
   description = "Grafana dashboard release branch"
   validation {
-    condition     = var.grafana_dashboard_release_branch == "" || can(regex("^[-A-Za-z0-9_/\\.]+$", var.grafana_dashboard_release_branch))
-    error_message = "grafana_dashboard_release_branch must be empty or a valid Git branch (alphanumeric, '-', '_', '/', or '.')."
+    condition     = can(regex("^[-A-Za-z0-9_/\\.]+$", var.grafana_dashboard_release_branch))
+    error_message = "grafana_dashboard_release_branch must be a valid Git branch (alphanumeric, '-', '_', '/', or '.')."
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

azure api removed `substitute: {}` because it was empty.
```yaml
spec:
  postBuild:
    substitute: {}
```
as result flux did not expand the variable to default value.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
