### PR TITLE
chore: update k8s rbac in k6 cluster

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_providers.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_providers.tf
@@ -23,7 +23,7 @@ provider "azurerm" {
 }
 */
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"
   }
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_pyrra.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_pyrra.tf
@@ -6,8 +6,10 @@ resource "helm_release" "pyrra" {
   repository       = "https://rlex.github.io/helm-charts"
   chart            = "pyrra"
   version          = "0.14.2"
-  set {
-    name  = "genericRules.enabled"
-    value = "true"
-  }
+  set = [
+    {
+      name  = "genericRules.enabled"
+      value = "true"
+    }
+  ]
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -18,7 +18,7 @@ resource "kubernetes_cluster_role_v1" "dev_access" {
   rule {
     api_groups = [""]
     resources  = ["configmaps"]
-    verbs      = ["get", "list", "watch", "delete"]
+    verbs      = ["get", "list", "watch", "delete", "patch"]
   }
   rule {
     api_groups = [""]
@@ -30,11 +30,13 @@ resource "kubernetes_cluster_role_v1" "dev_access" {
     resources  = ["testruns"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
+  /*
   rule {
     api_groups = [""]
     resources  = ["secrets"]
     verbs      = ["list", "watch"]
   }
+  */
   rule {
     api_groups = ["bitnami.com"]
     resources  = ["sealedsecrets"]
@@ -50,7 +52,7 @@ resource "kubernetes_cluster_role_v1" "sp_access" {
   rule {
     api_groups = [""]
     resources  = ["configmaps"]
-    verbs      = ["create", "update", "delete", "get"]
+    verbs      = ["create", "update", "delete", "get", "patch"]
   }
   rule {
     api_groups = ["bitnami.com"]
@@ -60,7 +62,7 @@ resource "kubernetes_cluster_role_v1" "sp_access" {
   rule {
     api_groups = ["k6.io"]
     resources  = ["testruns"]
-    verbs      = ["create", "update", "get", "list", "watch", "delete"]
+    verbs      = ["create", "update", "get", "list", "watch", "delete", "patch"]
   }
   rule {
     api_groups = [""]

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/pyrra.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/pyrra.tf
@@ -5,8 +5,10 @@ resource "helm_release" "pyrra" {
   repository       = "https://rlex.github.io/helm-charts"
   chart            = "pyrra"
   version          = "0.14.2"
-  set {
-    name  = "genericRules.enabled"
-    value = "true"
-  }
+  set = [
+    {
+      name  = "genericRules.enabled"
+      value = "true"
+    }
+  ]
 }

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/rbac.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/rbac.tf
@@ -6,7 +6,7 @@ resource "kubernetes_cluster_role_v1" "dev_access" {
   rule {
     api_groups = [""]
     resources  = ["configmaps"]
-    verbs      = ["get", "list", "watch", "delete"]
+    verbs      = ["get", "list", "watch", "delete", "patch"]
   }
   rule {
     api_groups = [""]
@@ -18,11 +18,13 @@ resource "kubernetes_cluster_role_v1" "dev_access" {
     resources  = ["testruns"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
+  /*
   rule {
     api_groups = [""]
     resources  = ["secrets"]
     verbs      = ["list", "watch"]
   }
+  */
   rule {
     api_groups = ["bitnami.com"]
     resources  = ["sealedsecrets"]
@@ -38,7 +40,7 @@ resource "kubernetes_cluster_role_v1" "sp_access" {
   rule {
     api_groups = [""]
     resources  = ["configmaps"]
-    verbs      = ["create", "update", "delete", "get"]
+    verbs      = ["create", "update", "delete", "get", "patch"]
   }
   rule {
     api_groups = ["bitnami.com"]
@@ -48,7 +50,7 @@ resource "kubernetes_cluster_role_v1" "sp_access" {
   rule {
     api_groups = ["k6.io"]
     resources  = ["testruns"]
-    verbs      = ["create", "update", "get", "list", "watch", "delete"]
+    verbs      = ["create", "update", "get", "list", "watch", "delete", "patch"]
   }
   rule {
     api_groups = [""]

--- a/infrastructure/adminservices-test/k6tests-rg/providers.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/providers.tf
@@ -19,7 +19,7 @@ provider "azurerm" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = "~/.kube/config"
     config_context = "k6tests-cluster"
   }


### PR DESCRIPTION
Before this wasn't needed since a new configmap and testrun were always being generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated permissions to allow partial updates ("patch") on configmaps and testruns resources for certain user roles.
	- Disabled list and watch permissions on secrets for specific user roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->