### PR TITLE
chore: remove prometheus.enabled from values.yaml

### DIFF
--- a/.github/workflows/k6tests-rg-deploy.yml
+++ b/.github/workflows/k6tests-rg-deploy.yml
@@ -222,12 +222,8 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'partial-plan-apply')
         with:
           working_directory: ${{ env.TF_PROJECT }}
-          oidc_type: environment
-          oidc_value: ${{ env.ENVIRONMENT }}
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
-          tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: ${{ env.TF_VERSION }}
           tf_args: -target=${{ env.TF_FOUNDATIONAL_MODULE }}
 
       - name: Terraform Apply
@@ -235,9 +231,5 @@ jobs:
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
         with:
           working_directory: ${{ env.TF_PROJECT }}
-          oidc_type: environment
-          oidc_value: ${{ env.ENVIRONMENT }}
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
-          tf_state_name: ${{ env.TF_STATE_NAME }}
-          tf_version: ${{ env.TF_VERSION }}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k6_operator_values.yaml
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k6_operator_values.yaml
@@ -2,6 +2,3 @@ installCRDs: true
 
 namespace:
   create: false
-
-prometheus:
-  enabled: true

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/k6_operator_values.yaml
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/k6_operator_values.yaml
@@ -2,6 +2,3 @@ installCRDs: true
 
 namespace:
   create: false
-
-prometheus:
-  enabled: true


### PR DESCRIPTION
It was removed in this commit: https://github.com/grafana/k6-operator/commit/15878fc356057b07f936c0b35a5e1f1dbc028079#diff-92aae00e6ad9817d7277debbf58b13989f08f96eda65a95efc68fc4ef9e6ee07L41

I'm not really doing anything with those metrics so I won't update to the new config right now.

Also cleaning up some unused inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow by removing unused parameters from Terraform apply steps.
  - Simplified configuration files by removing Prometheus monitoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->