### PR TITLE
feature: allow passing extra env vars needed in the init stage

### DIFF
--- a/actions/generate-k6-manifests/action.yml
+++ b/actions/generate-k6-manifests/action.yml
@@ -6,7 +6,12 @@ inputs:
     required: true
 
   command_line_args:
-    description: "Command line arguments to pass to the k6 command"
+    description: "Command line arguments to pass to the k6 run command"
+    required: false
+    default: ""
+
+  init_stage_env_vars:
+    description: "Extra environmental veriables that might be needed in the init stage. e.g.: BROWSER_VUS=3 DURATION=10s"
     required: false
     default: ""
 runs:


### PR DESCRIPTION
This is required for situations such as:
```
export const options = {
    vus: __ENV.BROWSER_VUS || 10,
    duration: '30s',
};
```
where the init stage will run when we call `k6 archive`
