### PR TITLE
feat(renovate): schedule weekdays execution, except friday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": [
     "local>Altinn/renovate-config"
   ],
+  "schedule": [
+    "0 5-7 * * 1-4"
+  ],
+  "timezone": "Europe/Oslo",
   "postUpdateOptions": [
     "gomodTidy"
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request introduces a new schedule for Renovate to control when it checks for dependency updates.

Previously, Renovate may have been running every Thursday before 7. I see no reason for not generating renovate PRs every day. 

  The new schedule is set as follows:
   - Days: Monday through Thursday
   - Time: Between 5:00 AM and 7:00 AM
   - Timezone: Europe/Oslo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency update schedule to run during specific hours on Monday through Thursday, based on the Europe/Oslo timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->