### PR TITLE
fix(renovate): cron minutes needs to be *

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "local>Altinn/renovate-config"
   ],
   "schedule": [
-    "0 5-7 * * 1-4"
+    "* 5-7 * * 1-4"
   ],
   "timezone": "Europe/Oslo",
   "postUpdateOptions": [


### PR DESCRIPTION
Renovate only supports start for minutes in the cron statement as pr doucmentation: https://docs.renovatebot.com/key-concepts/scheduling/

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
