### PR TITLE
chore(actions): Update Terraform composite action references

### DIFF
--- a/.github/workflows/admin-test-aks-rg-deploy.yml
+++ b/.github/workflows/admin-test-aks-rg-deploy.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: Altinn/altinn-platform/actions/terraform/plan@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/apply@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/altinn-apim-test-rg-deploy.yml
+++ b/.github/workflows/altinn-apim-test-rg-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: Altinn/altinn-platform/actions/terraform/plan@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/apply@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Terraform Plan
-        uses: Altinn/altinn-platform/actions/terraform/plan@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -134,7 +134,7 @@ jobs:
           fi
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/apply@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/altinncr-deploy.yml
+++ b/.github/workflows/altinncr-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Plan
-        uses: Altinn/altinn-platform/actions/terraform/plan@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/apply@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/auth-at22-aks-rg.yml
+++ b/.github/workflows/auth-at22-aks-rg.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/apply@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment

--- a/.github/workflows/k6tests-rg-deploy.yml
+++ b/.github/workflows/k6tests-rg-deploy.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Terraform Init
         id: terraform_init
-        uses: Altinn/altinn-platform/actions/terraform/init@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/init@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -115,7 +115,7 @@ jobs:
           fi
 
       - name: Terraform Plan Foundational Module
-        uses: Altinn/altinn-platform/actions/terraform/plan-only@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan-only@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         if: contains(github.event.pull_request.labels.*.name, 'partial-plan-apply')
         with:
           working_directory: ${{ env.TF_PROJECT }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Terraform Plan
         id: terraform_plan
-        uses: Altinn/altinn-platform/actions/terraform/plan-only@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan-only@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
         with:
           working_directory: ${{ env.TF_PROJECT }}
@@ -133,7 +133,7 @@ jobs:
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: Write Terraform Summary
-        uses: Altinn/altinn-platform/actions/terraform/write-terraform-summary@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/write-terraform-summary@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -167,7 +167,7 @@ jobs:
           subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: Terraform Init
-        uses: Altinn/altinn-platform/actions/terraform/init@main
+        uses: Altinn/altinn-platform/actions/terraform/init@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -218,7 +218,7 @@ jobs:
           fi
 
       - name: Terraform Apply Foundational Module
-        uses: Altinn/altinn-platform/actions/terraform/apply-only@main
+        uses: Altinn/altinn-platform/actions/terraform/apply-only@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         if: contains(github.event.pull_request.labels.*.name, 'partial-plan-apply')
         with:
           working_directory: ${{ env.TF_PROJECT }}
@@ -227,7 +227,7 @@ jobs:
           tf_args: -target=${{ env.TF_FOUNDATIONAL_MODULE }}
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply-only@main
+        uses: Altinn/altinn-platform/actions/terraform/apply-only@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'partial-plan-apply') }}
         with:
           working_directory: ${{ env.TF_PROJECT }}

--- a/.github/workflows/products-deploy.yml
+++ b/.github/workflows/products-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Initialize
-        uses: Altinn/altinn-platform/actions/terraform/plan@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/plan@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@d9c2f3cd948fa894e0300f614cdb71cfba9502d3 # main
+        uses: Altinn/altinn-platform/actions/terraform/apply@276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03 # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates all references to the reusable Terraform composite actions (actions/terraform/*) within our GitHub Actions workflows.


  The actions have been pinned to the commit hash 276a9384f3adf9f0c2ca3c70e1cec7dad58e7f03. This update incorporates a critical bug fix that ensures special characters are properly escaped within the
  Terraform actions, improving the stability and predictability of our CI/CD pipelines.

The fix was merged in PR https://github.com/Altinn/altinn-platform/pull/1951

  Affected Workflows:
   - .github/workflows/admin-test-aks-rg-deploy.yml
   - .github/workflows/altinn-apim-test-rg-deploy.yml
   - .github/workflows/altinn-monitor-test-rg-deploy.yml
   - .github/workflows/altinncr-deploy.yml
   - .github/workflows/auth-at22-aks-rg.yml
   - .github/workflows/k6tests-rg-deploy.yml
   - .github/workflows/products-deploy.yml

## Related Issue(s)
- #{issue number}

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configurations to use the latest versions of Terraform-related GitHub Actions across multiple deployment pipelines. No changes were made to workflow logic or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->