### PR TITLE
chore: configure ingester maxUnavailable

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
@@ -24,7 +24,7 @@ loki:
      volume_enabled: true
      retention_period: 672h # 28 days retention
    compactor:
-     retention_enabled: true 
+     retention_enabled: true
      delete_request_store: azure
    ruler:
     enable_api: true
@@ -59,6 +59,7 @@ deploymentMode: Distributed
 
 ingester:
  replicas: 3
+ maxUnavailable: 1
  zoneAwareReplication:
   enabled: false
 
@@ -92,7 +93,7 @@ ruler:
 gateway:
  service:
    type: LoadBalancer
- basicAuth: 
+ basicAuth:
      enabled: true
      existingSecret: loki-basic-auth
 

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
@@ -24,7 +24,7 @@ loki:
      volume_enabled: true
      retention_period: 672h # 28 days retention
    compactor:
-     retention_enabled: true 
+     retention_enabled: true
      delete_request_store: azure
    ruler:
     enable_api: true
@@ -59,6 +59,7 @@ deploymentMode: Distributed
 
 ingester:
  replicas: 3
+ maxUnavailable: 1
  zoneAwareReplication:
   enabled: false
 
@@ -92,7 +93,7 @@ ruler:
 gateway:
  service:
    type: LoadBalancer
- basicAuth: 
+ basicAuth:
      enabled: true
      existingSecret: loki-basic-auth
 


### PR DESCRIPTION
Fixes: https://github.com/Altinn/altinn-platform/actions/runs/16588932445/job/46919924954

```
│ Error: installation failed
│ 
│   with helm_release.loki,
│   on k6_tests_rg_loki.tf line 45, in resource "helm_release" "loki":
│   45: resource "helm_release" "loki" {
│ 
│ execution error at
│ (loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml:3:4):
│ `.Values.ingester.maxUnavailable` must be set when
│ `.Values.ingester.replicas` is greater than 1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to control the maximum number of unavailable ingester pods during updates.

* **Style**
  * Improved formatting by removing unnecessary trailing spaces in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->