### PR TITLE
chore: do not mount dockercontainers

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring_values.tftpl
@@ -43,6 +43,8 @@ alloy-logs:
   alloy:
     mounts:
       varlog: false
+      dockercontainers: false
+
     clustering:
       enabled: true
 

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring_values.tftpl
@@ -43,6 +43,8 @@ alloy-logs:
   alloy:
     mounts:
       varlog: false
+      dockercontainers: false
+
     clustering:
       enabled: true
   controller:


### PR DESCRIPTION
```
│ Pod Logs feature should not mount /var/lib/docker/containers when using the
│ "kubernetesApi" gather method.
│ Please set:
│ alloy-logs:
│   alloy:
│     mounts:
│       dockercontainers: false
```