### PR TITLE
fix: pattern_ingester and storage blocks are under the loki block

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
@@ -1,4 +1,14 @@
 loki:
+  pattern_ingester:
+    enabled: true
+  storage:
+    type: azure
+    bucketNames:
+      chunks: "${chunks_container_name}"
+      ruler: "${ruler_container_name}"
+    azure:
+      accountName: "${account_name}"
+      useFederatedToken: true
   structuredConfig:
     limits_config:
       allow_structured_metadata: true
@@ -6,8 +16,6 @@ loki:
       retention_period: 672h # 28 days retention
     ingester:
       chunk_encoding: snappy
-    pattern_ingester:
-      enabled: true
     compactor:
       retention_enabled: true
       delete_request_store: azure
@@ -21,34 +29,27 @@ loki:
           use_federated_token: true
     querier:
       max_concurrent: 4
-    storage:
-      type: azure
-      bucketNames:
-        chunks: "${chunks_container_name}"
-        ruler: "${ruler_container_name}"
+    schema_config:
+      configs:
+        - from: "2024-04-01"
+          store: tsdb
+          object_store: azure
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+    storage_config:
+      tsdb_shipper:
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
+        cache_ttl: 168h
       azure:
-        accountName: "${account_name}"
-        useFederatedToken: true
+        account_name: "${account_name}"
+        container_name: "${chunks_container_name}"
+        use_federated_token: true
+
   podLabels:
     "azure.workload.identity/use": "true"
-  schemaConfig:
-    configs:
-      - from: "2024-04-01"
-        store: tsdb
-        object_store: azure
-        schema: v13
-        index:
-          prefix: loki_index_
-          period: 24h
-  storageConfig:
-    tsdb_shipper:
-      active_index_directory: /var/loki/index
-      cache_location: /var/loki/cache
-      cache_ttl: 168h
-    azure:
-      account_name: "${account_name}"
-      container_name: "${chunks_container_name}"
-      use_federated_token: true
 
 # Define the Azure workload identity
 serviceAccount:

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
@@ -1,4 +1,14 @@
 loki:
+  pattern_ingester:
+    enabled: true
+  storage:
+    type: azure
+    bucketNames:
+      chunks: "${chunks_container_name}"
+      ruler: "${ruler_container_name}"
+    azure:
+      accountName: "${account_name}"
+      useFederatedToken: true
   structuredConfig:
     limits_config:
       allow_structured_metadata: true
@@ -6,8 +16,6 @@ loki:
       retention_period: 672h # 28 days retention
     ingester:
       chunk_encoding: snappy
-    pattern_ingester:
-      enabled: true
     compactor:
       retention_enabled: true
       delete_request_store: azure
@@ -21,34 +29,27 @@ loki:
           use_federated_token: true
     querier:
       max_concurrent: 4
-    storage:
-      type: azure
-      bucketNames:
-        chunks: "${chunks_container_name}"
-        ruler: "${ruler_container_name}"
+    schema_config:
+      configs:
+        - from: "2024-04-01"
+          store: tsdb
+          object_store: azure
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+    storage_config:
+      tsdb_shipper:
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
+        cache_ttl: 168h
       azure:
-        accountName: "${account_name}"
-        useFederatedToken: true
+        account_name: "${account_name}"
+        container_name: "${chunks_container_name}"
+        use_federated_token: true
+
   podLabels:
     "azure.workload.identity/use": "true"
-  schemaConfig:
-    configs:
-      - from: "2024-04-01"
-        store: tsdb
-        object_store: azure
-        schema: v13
-        index:
-          prefix: loki_index_
-          period: 24h
-  storageConfig:
-    tsdb_shipper:
-      active_index_directory: /var/loki/index
-      cache_location: /var/loki/cache
-      cache_ttl: 168h
-    azure:
-      account_name: "${account_name}"
-      container_name: "${chunks_container_name}"
-      use_federated_token: true
 
 # Define the Azure workload identity
 serviceAccount:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Loki configuration for improved clarity, moving pattern ingester and storage settings to more prominent locations.
  * Updated Azure storage settings with clearer structure and consistent naming conventions.
  * Consolidated and clarified schema and storage configuration within structured sections.
  * No impact on user-facing functionality; these are internal configuration improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->