### PR TITLE
fix(obs-module): use sp object id as tf var

### DIFF
--- a/infrastructure/modules/observability/README.md
+++ b/infrastructure/modules/observability/README.md
@@ -9,7 +9,7 @@ A lightweight Terraform module that bootstraps a **Log Analytics Workspace, Ap
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.1.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.4.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.7.2 |
 
@@ -17,7 +17,7 @@ A lightweight Terraform module that bootstraps a **Log Analytics Workspace, Ap
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 3.1.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 3.4.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.7.2 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
@@ -39,6 +39,9 @@ No modules.
 | [azurerm_key_vault.obs_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_secret.conn_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_workspace.obs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_data_collection_endpoint.amw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_endpoint) | resource |
+| [azurerm_monitor_data_collection_rule.amw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_rule) | resource |
+| [azurerm_monitor_data_collection_rule_association.amw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_rule_association) | resource |
 | [azurerm_monitor_workspace.obs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_workspace) | resource |
 | [azurerm_resource_group.obs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.ci_kv_secrets_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -53,6 +56,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_insights_app_type"></a> [app\_insights\_app\_type](#input\_app\_insights\_app\_type) | n/a | `string` | `"web"` | no |
 | <a name="input_app_insights_name"></a> [app\_insights\_name](#input\_app\_insights\_name) | Name for the Application Insights instance. | `string` | `""` | no |
+| <a name="input_azurerm_kubernetes_cluster_id"></a> [azurerm\_kubernetes\_cluster\_id](#input\_azurerm\_kubernetes\_cluster\_id) | AKS cluster resource id | `string` | `""` | no |
 | <a name="input_azurerm_resource_group_obs_name"></a> [azurerm\_resource\_group\_obs\_name](#input\_azurerm\_resource\_group\_obs\_name) | Optional explicit name of the observability resource group | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment for resources | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Default region for resources | `string` | `"norwayeast"` | no |
@@ -60,6 +64,7 @@ No modules.
 | <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | Name for the Log Analytics workspace. | `string` | `""` | no |
 | <a name="input_monitor_workspace_name"></a> [monitor\_workspace\_name](#input\_monitor\_workspace\_name) | Name for the Azure Monitor workspace. | `string` | `""` | no |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Oidc issuer url needed for federation | `string` | n/a | yes |
+| <a name="input_pipeline_sp_object_id"></a> [pipeline\_sp\_object\_id](#input\_pipeline\_sp\_object\_id) | Object ID of the service-principal that should read / write secrets in this env | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for resource names | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
 

--- a/infrastructure/modules/observability/README.md
+++ b/infrastructure/modules/observability/README.md
@@ -92,6 +92,10 @@ module "observability" {
 
   oidc_issuer_url = "https://westeurope.oic.prod-aks.azure.com/00000000/11111111"
 
+  # Object ID of the service principal that needs read/write access to secrets
+  # NOTE: This is the AAD objectId, not the appId/clientId.
+  pipeline_sp_object_id = "00000000-0000-0000-0000-000000000000"
+
   tags = {
     project    = "billing-api"
     costcenter = "42"

--- a/infrastructure/modules/observability/kv.tf
+++ b/infrastructure/modules/observability/kv.tf
@@ -27,7 +27,7 @@ resource "azurerm_key_vault" "obs_kv" {
 resource "azurerm_role_assignment" "obs_kv_reader" {
   scope                            = azurerm_key_vault.obs_kv.id
   role_definition_name             = "Key Vault Secrets User"
-  principal_id                     = azuread_service_principal.sp.object_id 
+  principal_id                     = azuread_service_principal.sp.object_id
   skip_service_principal_aad_check = true
 }
 

--- a/infrastructure/modules/observability/kv.tf
+++ b/infrastructure/modules/observability/kv.tf
@@ -27,7 +27,7 @@ resource "azurerm_key_vault" "obs_kv" {
 resource "azurerm_role_assignment" "obs_kv_reader" {
   scope                            = azurerm_key_vault.obs_kv.id
   role_definition_name             = "Key Vault Secrets User"
-  principal_id                     = azuread_service_principal.sp.object_id
+  principal_id                     = var.pipeline_sp_object_id
   skip_service_principal_aad_check = true
 }
 

--- a/infrastructure/modules/observability/kv.tf
+++ b/infrastructure/modules/observability/kv.tf
@@ -27,7 +27,7 @@ resource "azurerm_key_vault" "obs_kv" {
 resource "azurerm_role_assignment" "obs_kv_reader" {
   scope                            = azurerm_key_vault.obs_kv.id
   role_definition_name             = "Key Vault Secrets User"
-  principal_id                     = var.pipeline_sp_object_id
+  principal_id                     = azuread_service_principal.sp.object_id 
   skip_service_principal_aad_check = true
 }
 
@@ -46,6 +46,6 @@ resource "azurerm_key_vault_secret" "conn_string" {
 resource "azurerm_role_assignment" "ci_kv_secrets_role" {
   scope                            = azurerm_key_vault.obs_kv.id
   role_definition_name             = "Key Vault Secrets Officer" # read + write secrets only
-  principal_id                     = data.azurerm_client_config.current.object_id
+  principal_id                     = var.pipeline_sp_object_id
   skip_service_principal_aad_check = true
 }

--- a/infrastructure/modules/observability/variables.tf
+++ b/infrastructure/modules/observability/variables.tf
@@ -75,3 +75,8 @@ variable "azurerm_kubernetes_cluster_id" {
   default     = ""
   description = "AKS cluster resource id"
 }
+
+variable "pipeline_sp_object_id" {
+  description = "Object ID of the service-principal that should read / write secrets in this env"
+  type        = string
+}

--- a/infrastructure/modules/observability/variables.tf
+++ b/infrastructure/modules/observability/variables.tf
@@ -75,8 +75,12 @@ variable "azurerm_kubernetes_cluster_id" {
   default     = ""
   description = "AKS cluster resource id"
 }
-
 variable "pipeline_sp_object_id" {
   description = "Object ID of the service-principal that should read / write secrets in this env"
   type        = string
+
+  validation {
+    condition     = length(var.pipeline_sp_object_id) > 0
+    error_message = "You must provide a non-empty value for pipeline_sp_object_id."
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Delegates setting the object id to the entity consuming the tf module

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow specifying a service principal for Key Vault secret access.
  * Added support for Azure Monitor data collection (endpoints, rules, associations).
  * Optional input to link an AKS cluster for observability.

* **Chores**
  * Role assignment updated to grant Key Vault access to the configured service principal.
  * Bumped Azure AD/provider dependency versions in documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->