### PR TITLE
feat: install certmanager

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager.tf
@@ -1,0 +1,19 @@
+resource "helm_release" "certmanager" {
+  depends_on = [
+    azurerm_kubernetes_cluster.k6tests
+  ]
+  lint             = true
+  name             = "certmanager"
+  namespace        = "certmanager"
+  create_namespace = true
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager" // jetstack/cert-manager
+  version          = "1.18.2"
+
+  set = [
+    {
+      name  = "crds.enabled"
+      value = "true"
+    }
+  ]
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager.tf
@@ -1,0 +1,17 @@
+resource "helm_release" "certmanager" {
+  // depends_on = [  ]
+  lint             = true
+  name             = "certmanager"
+  namespace        = "certmanager"
+  create_namespace = true
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager" // jetstack/cert-manager
+  version          = "1.18.2"
+
+  set = [
+    {
+      name  = "crds.enabled"
+      value = "true"
+    }
+  ]
+}


### PR DESCRIPTION
## Related Issue(s)
- #2047


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployed cert-manager to test Kubernetes clusters via Helm to automate TLS certificate issuance and renewal, including required CRDs and namespace setup.
  * Standardizes certificate handling across test environments, improving secure ingress and service communication while reducing manual maintenance and potential downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->