### PR TITLE
fix(tf-devops-agent): ignore CVE-2025-47907 for tf-devopsagent

### DIFF
--- a/infrastructure/images/terraform-azure-devops-agent/.trivyignore
+++ b/infrastructure/images/terraform-azure-devops-agent/.trivyignore
@@ -1,3 +1,4 @@
 # Checkd against kubectl with govulncheck and kubectl is not affected (false positiv)
 CVE-2024-45338
 CVE-2025-22869
+CVE-2025-47907


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignoring CVE-2025-47907 helm binary is affected, but as this would require parallel calls with context cancelation and the fact that this image is used as an agent for running azure devops pipelines it seems ok to ignore until a fix is released

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanner ignore list to suppress a newly flagged issue, reducing noise in security reports.
  * Improves reliability of CI/CD checks by preventing known false positives from blocking pipelines.
  * No user-facing changes; functionality and performance remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->