### PR TITLE
feat: enable ingress for loki gateway

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
@@ -94,8 +94,18 @@ ruler:
 
 # This exposes the Loki gateway so it can be written to and queried externaly
 gateway:
-  service:
-    type: LoadBalancer
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - host: k6.dis.altinn.cloud
+        paths:
+          - path: /
+            pathType: Prefix
+    #tls: # TODO: update values based on certmanager config
+    #- hosts:
+    #    - k6.dis.altinn.cloud
+    #  secretName: testsecret-tls
   basicAuth:
     enabled: true
     existingSecret: loki-basic-auth

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
@@ -94,8 +94,18 @@ ruler:
 
 # This exposes the Loki gateway so it can be written to and queried externaly
 gateway:
-  service:
-    type: LoadBalancer
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - host: k6.dis.altinn.cloud
+        paths:
+          - path: /
+            pathType: Prefix
+    #tls: # TODO: update values based on certmanager config
+    #- hosts:
+    #    - k6.dis.altinn.cloud
+    #  secretName: testsecret-tls
   basicAuth:
     enabled: true
     existingSecret: loki-basic-auth


### PR DESCRIPTION
## Related Issue(s)
- #2056 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched Loki gateway exposure from LoadBalancer Service to Ingress (nginx).

* **Chores**
  * Configured host k6.dis.altinn.cloud with root (/) path; TLS entries kept as placeholders but disabled.
  * Users now access Loki via the hostname instead of a LoadBalancer IP; BasicAuth behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->