### PR TITLE
feat: configure letsencrypt issuer and add necessary config to Ingress so certmanager generates the certificate

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager_resources.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager_resources.tf
@@ -1,0 +1,24 @@
+# TODO: change to -production after testing and use prod server
+resource "kubernetes_manifest" "letsencrypt_issuer" {
+  manifest = yamldecode(<<EOT
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+  namespace: monitoring
+spec:
+  acme:
+    # server: https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    # email: user@example.com
+    profile: tlsserver
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+  EOT
+  )
+}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
@@ -95,6 +95,8 @@ ruler:
 # This exposes the Loki gateway so it can be written to and queried externaly
 gateway:
   ingress:
+    annotations:
+      cert-manager.io/issuer: "letsencrypt-staging" # TODO: change to prod after testing
     enabled: true
     ingressClassName: nginx
     hosts:
@@ -102,10 +104,10 @@ gateway:
         paths:
           - path: /
             pathType: Prefix
-    #tls: # TODO: update values based on certmanager config
-    #- hosts:
-    #    - k6.dis.altinn.cloud
-    #  secretName: testsecret-tls
+    tls:
+      - hosts:
+          - k6.dis.altinn.cloud
+        secretName: k6-dis-altinn-cloud-tls
   basicAuth:
     enabled: true
     existingSecret: loki-basic-auth

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager_resources.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager_resources.tf
@@ -1,0 +1,24 @@
+# TODO: change to -production after testing and use prod server
+resource "kubernetes_manifest" "letsencrypt_issuer" {
+  manifest = yamldecode(<<EOT
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+  namespace: monitoring
+spec:
+  acme:
+    # server: https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    # email: user@example.com
+    profile: tlsserver
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+  EOT
+  )
+}

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
@@ -95,6 +95,8 @@ ruler:
 # This exposes the Loki gateway so it can be written to and queried externaly
 gateway:
   ingress:
+    annotations:
+      cert-manager.io/issuer: "letsencrypt-staging" # TODO: change to prod after testing
     enabled: true
     ingressClassName: nginx
     hosts:
@@ -102,10 +104,10 @@ gateway:
         paths:
           - path: /
             pathType: Prefix
-    #tls: # TODO: update values based on certmanager config
-    #- hosts:
-    #    - k6.dis.altinn.cloud
-    #  secretName: testsecret-tls
+    tls:
+      - hosts:
+          - k6.dis.altinn.cloud
+        secretName: k6-dis-altinn-cloud-tls
   basicAuth:
     enabled: true
     existingSecret: loki-basic-auth


### PR DESCRIPTION
## Related Issue(s)
- #2056 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled HTTPS/TLS for the Loki gateway ingress.
  * Automatic certificate issuance and renewal via cert-manager (Let's Encrypt staging).
  * Secured access at k6.dis.altinn.cloud with a configured TLS secret.

* **Chores**
  * Added an Issuer configuration for cert-manager (staging) and related annotations.
  * Activated TLS settings on the ingress and updated TLS secret reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->