### PR TITLE
chore: implement workaround from release notes

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager.tf
@@ -10,10 +10,7 @@ resource "helm_release" "certmanager" {
   chart            = "cert-manager" // jetstack/cert-manager
   version          = "1.18.2"
 
-  set = [
-    {
-      name  = "crds.enabled"
-      value = "true"
-    }
+  values = [
+    "${templatefile("${path.module}/k6_tests_rg_certmanager_values.tftpl", {})}"
   ]
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager_values.tftpl
@@ -1,0 +1,8 @@
+# values.yaml
+crds:
+  enabled: true
+config:
+  featureGates:
+    # Disable the use of Exact PathType in Ingress resources, to work around a bug in ingress-nginx
+    # https://github.com/kubernetes/ingress-nginx/issues/11176
+    ACMEHTTP01IngressPathTypeExact: false

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager.tf
@@ -8,10 +8,7 @@ resource "helm_release" "certmanager" {
   chart            = "cert-manager" // jetstack/cert-manager
   version          = "1.18.2"
 
-  set = [
-    {
-      name  = "crds.enabled"
-      value = "true"
-    }
+  values = [
+    "${templatefile("${path.module}/certmanager_values.tftpl", {})}"
   ]
 }

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager_values.tftpl
@@ -1,0 +1,8 @@
+# values.yaml
+crds:
+  enabled: true
+config:
+  featureGates:
+    # Disable the use of Exact PathType in Ingress resources, to work around a bug in ingress-nginx
+    # https://github.com/kubernetes/ingress-nginx/issues/11176
+    ACMEHTTP01IngressPathTypeExact: false


### PR DESCRIPTION
Release notes:
https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated cert-manager Helm configuration from inline settings to templated values files for consistency across test environments.
- Chores
  - Added values templates that enable CRD installation by default.
  - Adjusted feature gate configuration to set ACMEHTTP01IngressPathTypeExact to false.
  - Standardized Helm release configuration to load settings from values files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->