### PR TITLE
fix(dis-apim): dont check description and apiType in equality

### DIFF
--- a/services/dis-apim-operator/api/v1alpha1/apiversion_types.go
+++ b/services/dis-apim-operator/api/v1alpha1/apiversion_types.go
@@ -294,10 +294,8 @@ func (a *ApiVersion) MatchesAzureResource(current apim.APIClientGetResponse) boo
 		}
 	}
 	if a.Spec.Path != ptr.Deref(current.Properties.Path, "") ||
-		!ptr.Equal(a.Spec.ApiType.AzureApiType(), current.Properties.APIType) ||
 		!ptr.Equal(a.Spec.Name, current.Properties.APIVersion) ||
 		a.Spec.DisplayName != ptr.Deref(current.Properties.DisplayName, "") ||
-		a.Spec.Description != ptr.Deref(current.Properties.Description, "") ||
 		!ptr.Equal(a.Spec.ServiceUrl, current.Properties.ServiceURL) ||
 		!ptr.Equal(a.Spec.SubscriptionRequired, current.Properties.SubscriptionRequired) ||
 		!protocolsEqual(ToApimProtocolSlice(a.Spec.Protocols), current.Properties.Protocols) ||

--- a/services/dis-apim-operator/internal/controller/api_controller.go
+++ b/services/dis-apim-operator/internal/controller/api_controller.go
@@ -63,7 +63,6 @@ type ApiReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile
 func (r *ApiReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Reconciling Api")
 	var api apimv1alpha1.Api
 	if err := r.Get(ctx, req.NamespacedName, &api); err != nil {
 		if client.IgnoreNotFound(err) != nil {

--- a/services/dis-apim-operator/internal/controller/backend_controller.go
+++ b/services/dis-apim-operator/internal/controller/backend_controller.go
@@ -112,7 +112,6 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Info("Backend updated")
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
-	logger.Info("Backend matches actual state")
 	orig := backend.DeepCopy()
 	patch := client.MergeFrom(orig)
 	if backend.Status.ProvisioningState != apimv1alpha1.BackendProvisioningStateSucceeded || backend.Status.BackendID != *azBackend.ID {

--- a/services/dis-apim-operator/internal/utils/policytemplate_test.go
+++ b/services/dis-apim-operator/internal/utils/policytemplate_test.go
@@ -32,6 +32,17 @@ var _ = Describe("GeneratePolicyFromTemplate", func() {
 		})
 	})
 
+	Context("handles quotes and spaces", func() {
+		It("should generate the correct policy", func() {
+			expected := `Hello, "World"!`
+			templateContent := `Hello, "{{ .Name }}"!`
+			data := map[string]string{"Name": "World"}
+			result, err := GeneratePolicyFromTemplate(templateContent, data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expected))
+		})
+	})
+
 	Context("with template missing data", func() {
 		It("should return an error", func() {
 			expected := ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
description for api versions is fetched from swagger/openapi spec. Removing it for now from equality check

apiType seems to be black when http atleast, not something that should be changed over an update eitherway

removed some noisy logging statements

## Related Issue(s)
- #1799

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Relaxed API-version matching to ignore API type and description; matches now depend on path, name, display name, service URL, subscription requirement, protocols, and current flag.
  * API-version updates now follow a dedicated update flow with clearer decision checks and safer post-update handling for spec hashes and policies.
* **Chores**
  * Reduced noisy startup/reconcile logs and added more contextual, structured logging for version updates.
* **Tests**
  * Added a test to ensure policy templates handle whitespace and quotes around variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->