### PR TITLE
chore: add health probe annotations

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_ingress-nginx-controller.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_ingress-nginx-controller.tf
@@ -9,4 +9,7 @@ resource "helm_release" "ingress_nginx" {
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
   version          = "4.12.5"
+  values = [
+    "${templatefile("${path.module}/k6_tests_rg_ingress-nginx_values.tftpl", {})}"
+  ]
 }

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_ingress-nginx_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_ingress-nginx_values.tftpl
@@ -1,0 +1,4 @@
+controler:
+  service:
+    annotations:
+      "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthz"

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/ingress-nginx-controller.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/ingress-nginx-controller.tf
@@ -7,4 +7,7 @@ resource "helm_release" "ingress_nginx" {
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
   version          = "4.12.5"
+  values = [
+    "${templatefile("${path.module}/ingress-nginx_values.tftpl", {})}"
+  ]
 }

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/ingress-nginx_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/ingress-nginx_values.tftpl
@@ -1,0 +1,4 @@
+controler:
+  service:
+    annotations:
+      "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthz"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the ingress controller to expose a standardized health endpoint (/healthz) for Azure Load Balancer health probes.
  * Ensures accurate health checks during deployments, improving service availability and stability in test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->