### PR TITLE
chore: use letsencrypt's prod server

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager_resources.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_certmanager_resources.tf
@@ -1,20 +1,16 @@
-# TODO: change to -production after testing and use prod server
 resource "kubernetes_manifest" "letsencrypt_issuer" {
   manifest = yamldecode(<<EOT
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: letsencrypt-staging
+  name: letsencrypt-prod
   namespace: monitoring
 spec:
   acme:
-    # server: https://acme-v02.api.letsencrypt.org/directory
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
-    # Email address used for ACME registration
-    # email: user@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
     profile: tlsserver
     privateKeySecretRef:
-      name: letsencrypt-staging
+      name: letsencrypt-prod
     solvers:
       - http01:
           ingress:

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_loki_values.tftpl
@@ -96,7 +96,7 @@ ruler:
 gateway:
   ingress:
     annotations:
-      cert-manager.io/issuer: "letsencrypt-staging" # TODO: change to prod after testing
+      cert-manager.io/issuer: "letsencrypt-prod"
     enabled: true
     ingressClassName: nginx
     hosts:

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager_resources.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/certmanager_resources.tf
@@ -1,20 +1,16 @@
-# TODO: change to -production after testing and use prod server
 resource "kubernetes_manifest" "letsencrypt_issuer" {
   manifest = yamldecode(<<EOT
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: letsencrypt-staging
+  name: letsencrypt-prod
   namespace: monitoring
 spec:
   acme:
-    # server: https://acme-v02.api.letsencrypt.org/directory
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
-    # Email address used for ACME registration
-    # email: user@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
     profile: tlsserver
     privateKeySecretRef:
-      name: letsencrypt-staging
+      name: letsencrypt-prod
     solvers:
       - http01:
           ingress:

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/loki_values.tftpl
@@ -96,7 +96,7 @@ ruler:
 gateway:
   ingress:
     annotations:
-      cert-manager.io/issuer: "letsencrypt-staging" # TODO: change to prod after testing
+      cert-manager.io/issuer: "letsencrypt-prod"
     enabled: true
     ingressClassName: nginx
     hosts:


### PR DESCRIPTION
## Related Issue(s)
- #2056 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Endpoints now use trusted TLS certificates issued by the production certificate authority, improving browser trust and compatibility.
- Chores
  - Updated certificate issuer configuration from staging to production across relevant ingress and gateway settings.
- Style
  - Removed obsolete comments and performed minor formatting cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->