### PR TITLE
chore: restrict namespaces where logs are collected

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring.tf
@@ -15,6 +15,7 @@ resource "helm_release" "grafana_k8s_monitoring" {
       "${path.module}/k6_tests_rg_grafana_k8s_monitoring_values.tftpl",
       {
         cluster_name = "${azurerm_kubernetes_cluster.k6tests.name}",
+        namespaces   = toset([for v in var.k8s_rbac : v["namespace"]])
       }
     )}"
   ]

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring_values.tftpl
@@ -19,7 +19,7 @@ destinations:
 clusterEvents:
   enabled: true
   collector: alloy-logs
-  # namespaces:
+  namespaces: ${jsonencode(namespaces)}
 
 nodeLogs:
   enabled: false
@@ -28,7 +28,7 @@ podLogs:
   enabled: true
   gatherMethod: kubernetesApi
   collector: alloy-logs
-  # namespaces:
+  namespaces: ${jsonencode(namespaces)}
 
 # Collectors
 alloy-singleton:

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring.tf
@@ -15,6 +15,7 @@ resource "helm_release" "grafana_k8s_monitoring" {
       "${path.module}/grafana_k8s_monitoring_values.tftpl",
       {
         cluster_name = "${azurerm_kubernetes_cluster.k6tests.name}",
+        namespaces   = toset([for v in var.k8s_rbac : v["namespace"]])
       }
     )}"
   ]

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring_values.tftpl
@@ -19,7 +19,7 @@ destinations:
 clusterEvents:
   enabled: true
   collector: alloy-logs
-  # namespaces:
+  namespaces: ${jsonencode(namespaces)}
 
 nodeLogs:
   enabled: false
@@ -28,7 +28,7 @@ podLogs:
   enabled: true
   gatherMethod: kubernetesApi
   collector: alloy-logs
-  # namespaces:
+  namespaces: ${jsonencode(namespaces)}
 
 # Collectors
 alloy-singleton:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Namespace-scoped monitoring enabled for Grafana: cluster events and pod logs now filter by a defined set of namespaces, reducing noise and making dashboards, logs, and alerts more relevant to monitored workloads.

- **Chores**
  - Template values updated and minor formatting cleanup with no change to behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->