### PR TITLE
fix(tf-module-aks): replace deprecated argument metric with enabled_metric

### DIFF
--- a/infrastructure/modules/aks/aks.tf
+++ b/infrastructure/modules/aks/aks.tf
@@ -119,8 +119,7 @@ resource "azurerm_monitor_diagnostic_setting" "aks" {
     category = "kube-audit-admin"
   }
 
-  metric {
+  enabled_metric {
     category = "AllMetrics"
-    enabled  = false
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
azurerm_monitor_diagnostic_setting.metric attribute is deprecated. Replace it with azurerm_monitor_diagnostic_setting.enabled_metric attribute as stated in tf output

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled platform metrics collection for AKS, improving visibility in monitoring dashboards and alerts.

* **Chores**
  * Updated monitoring configuration to align with the latest provider schema for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->