### PR TITLE
fix(obs-tf): default and check for null instead of empty string.

### DIFF
--- a/infrastructure/modules/observability/README.md
+++ b/infrastructure/modules/observability/README.md
@@ -56,7 +56,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_insights_app_type"></a> [app\_insights\_app\_type](#input\_app\_insights\_app\_type) | n/a | `string` | `"web"` | no |
 | <a name="input_app_insights_name"></a> [app\_insights\_name](#input\_app\_insights\_name) | Name for the Application Insights instance. | `string` | `""` | no |
-| <a name="input_azurerm_kubernetes_cluster_id"></a> [azurerm\_kubernetes\_cluster\_id](#input\_azurerm\_kubernetes\_cluster\_id) | AKS cluster resource id | `string` | `""` | no |
+| <a name="input_azurerm_kubernetes_cluster_id"></a> [azurerm\_kubernetes\_cluster\_id](#input\_azurerm\_kubernetes\_cluster\_id) | AKS cluster resource id | `string` | `null` | no |
 | <a name="input_azurerm_resource_group_obs_name"></a> [azurerm\_resource\_group\_obs\_name](#input\_azurerm\_resource\_group\_obs\_name) | Optional explicit name of the observability resource group | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment for resources | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Default region for resources | `string` | `"norwayeast"` | no |

--- a/infrastructure/modules/observability/amw-collection.tf
+++ b/infrastructure/modules/observability/amw-collection.tf
@@ -1,5 +1,5 @@
 resource "azurerm_monitor_data_collection_endpoint" "amw" {
-  count               = var.azurerm_kubernetes_cluster_id != "" ? 1 : 0
+  count               = var.azurerm_kubernetes_cluster_id != null ? 1 : 0
   name                = "${azurerm_monitor_workspace.obs.name}-mdce"
   resource_group_name = azurerm_resource_group.obs.name
   location            = azurerm_resource_group.obs.location
@@ -7,7 +7,7 @@ resource "azurerm_monitor_data_collection_endpoint" "amw" {
 }
 
 resource "azurerm_monitor_data_collection_rule" "amw" {
-  count                       = var.azurerm_kubernetes_cluster_id != "" ? 1 : 0
+  count                       = var.azurerm_kubernetes_cluster_id != null ? 1 : 0
   name                        = "${azurerm_monitor_workspace.obs.name}-mdcr"
   resource_group_name         = azurerm_resource_group.obs.name
   location                    = azurerm_resource_group.obs.location
@@ -41,7 +41,7 @@ resource "azurerm_monitor_data_collection_rule" "amw" {
 }
 
 resource "azurerm_monitor_data_collection_rule_association" "amw" {
-  count                   = var.azurerm_kubernetes_cluster_id != "" ? 1 : 0
+  count                   = var.azurerm_kubernetes_cluster_id != null ? 1 : 0
   name                    = "${azurerm_monitor_workspace.obs.name}-mdcra"
   target_resource_id      = var.azurerm_kubernetes_cluster_id
   data_collection_rule_id = azurerm_monitor_data_collection_rule.amw[0].id

--- a/infrastructure/modules/observability/variables.tf
+++ b/infrastructure/modules/observability/variables.tf
@@ -72,6 +72,6 @@ variable "oidc_issuer_url" {
 
 variable "azurerm_kubernetes_cluster_id" {
   type        = string
-  default     = ""
+  default     = null
   description = "AKS cluster resource id"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
to support setting up firsttime clusters we should check for null instead of empty string. 
The theory is that terraform knows if it is null or not, but not if the value is "" or "some-charachters"

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of the Kubernetes cluster ID: resources are now created when any value is provided and skipped only when the value is null. This clarifies opt-in behavior and keeps the default behavior unchanged (no resources by default).
  - Note: Supplying an empty string will now create resources.

- Documentation
  - Updated Observability module README to show the default for the cluster ID input is null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->