### PR TITLE
chore: fix code scanning warning in plan-only action

### DIFF
--- a/.github/workflows/k6tests-rg-deploy.yml
+++ b/.github/workflows/k6tests-rg-deploy.yml
@@ -115,6 +115,7 @@ jobs:
           fi
 
       - name: Terraform Plan Foundational Module
+        id: terraform_partial_plan
         uses: Altinn/altinn-platform/actions/terraform/plan-only@ee2c9590639e882a4b87f9da9c71c9ab9bf25053 # main
         if: contains(github.event.pull_request.labels.*.name, 'partial-plan-apply')
         with:
@@ -146,8 +147,8 @@ jobs:
           FMT_STEP_OUTCOME: ${{steps.terraform_init.outputs.fmt_step_outcome}}
           INIT_STEP_OUTPUT: ${{steps.terraform_init.outputs.init_step_stdout}}
           INIT_STEP_OUTCOME: ${{steps.terraform_init.outputs.init_step_outcome}}
-          PLAN_STEP_EXITCODE: ${{steps.terraform_plan.outputs.plan_step_exitcode}}
-          PLAN_STEP_OUTCOME: ${{steps.terraform_plan.outputs.plan_step_outcome}}
+          PLAN_STEP_EXITCODE: "${{ steps.terraform_plan.outputs.plan_step_exitcode != '' && steps.terraform_plan.outputs.plan_step_exitcode || steps.terraform_partial_plan.outputs.plan_step_exitcode }}"
+          PLAN_STEP_OUTCOME: "${{ steps.terraform_plan.outputs.plan_step_outcome != '' && steps.terraform_plan.outputs.plan_step_outcome || steps.terraform_partial_plan.outputs.plan_step_outcome }}"
 
   deploy:
     name: Deploy

--- a/actions/terraform/plan-only/action.yaml
+++ b/actions/terraform/plan-only/action.yaml
@@ -37,18 +37,21 @@ runs:
       if: always()
       working-directory: ${{ inputs.working_directory }}
       run: |
-        terraform plan -detailed-exitcode -no-color -input=false -out tfplan.out ${{ inputs.tf_args }} 2>&1 > tfplan.log  && cat tfplan.log || export EC=$?; cat tfplan.log; exit $EC
+        terraform plan -detailed-exitcode -no-color -input=false -out tfplan.out $TERRAFORM_ARGS 2>&1 > tfplan.log  && cat tfplan.log || export EC=$?; cat tfplan.log; exit $EC
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}
         ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
         ARM_USE_OIDC: "true"
+        TERRAFORM_ARGS: ${{ inputs.tf_args }}
 
     - name: Artifact Key
       id: artifact_key
       shell: bash
+      env:
+        TERRAFORM_STATE_FILE: ${{ env.TF_STATE_FILE }}
       run: |
-        TF_STATE_FILE=${{ env.TF_STATE_FILE }}
+        TF_STATE_FILE=$TERRAFORM_STATE_FILE
         ARTIFACT_KEY="${TF_STATE_FILE////_}.tfplan"
         echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Related Issue(s)
- #2088


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI pipeline now supports using a partial Terraform plan when a full plan is unavailable, improving resilience of deployment checks.
  * Deployment summaries now reliably display the correct plan outcome and exit code by selecting from full or partial results as needed.
  * Simplified and standardized environment handling for Terraform arguments and state file within the pipeline, enhancing consistency and reducing configuration errors.
  * Overall Terraform planning steps are more robust, with clearer outputs and fewer edge-case failures during automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->