### PR TITLE
chore: fix code scanning warning in plan action

### DIFF
--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -80,18 +80,21 @@ runs:
       if: always()
       working-directory: ${{ inputs.working_directory }}
       run: |
-        terraform plan -detailed-exitcode -no-color -input=false -out tfplan.out ${{ inputs.tf_args }} 2>&1 > tfplan.log  && cat tfplan.log || export EC=$?; cat tfplan.log; exit $EC
+        terraform plan -detailed-exitcode -no-color -input=false -out tfplan.out $TERRAFORM_ARGS 2>&1 > tfplan.log  && cat tfplan.log || export EC=$?; cat tfplan.log; exit $EC
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}
         ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
         ARM_USE_OIDC: "true"
+        TERRAFORM_ARGS: ${{ inputs.tf_args }}
 
     - name: Artifact Key
       id: artifact_key
       shell: bash
+      env:
+        TERRAFORM_STATE_FILE: ${{ env.TF_STATE_FILE }}
       run: |
-        TF_STATE_FILE=${{ env.TF_STATE_FILE }}
+        TF_STATE_FILE=$TERRAFORM_STATE_FILE
         ARTIFACT_KEY="${TF_STATE_FILE////_}.tfplan"
         echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Related Issue(s)
- #2088


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Terraform plan arguments and state-file handling in CI to improve consistency, debuggability and runner compatibility.
  * CI workflow now references an updated Terraform action version/branch to alter which implementation runs during plans.
  * Increased log analytics daily quota from 5 GB to 6 GB for test workspace.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->