### PR TITLE
chore: fix code scanning warning in apply-only action

### DIFF
--- a/actions/terraform/apply-only/action.yaml
+++ b/actions/terraform/apply-only/action.yaml
@@ -29,8 +29,10 @@ runs:
     - name: Artifact Key
       id: artifact_key
       shell: bash
+      env:
+        TERRAFORM_STATE_FILE: ${{ env.TF_STATE_FILE }}
       run: |
-        TF_STATE_FILE=${{ env.TF_STATE_FILE }}
+        TF_STATE_FILE=$TERRAFORM_STATE_FILE
         ARTIFACT_KEY="${TF_STATE_FILE////_}.tfplan"
         echo "ARTIFACT_KEY=$ARTIFACT_KEY" >> $GITHUB_ENV
 
@@ -46,10 +48,12 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
-        terraform apply -input=false -auto-approve ${{ inputs.tf_args }} tfplan.out
-        terraform output -json >> ${{ inputs.tf_output_file }}
+        terraform apply -input=false -auto-approve $TERRAFORM_ARGS tfplan.out
+        terraform output -json >> $TERRAFORM_OUTPUT_FILE
       env:
         ARM_CLIENT_ID: ${{ inputs.arm_client_id }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.arm_subscription_id }}
         ARM_TENANT_ID: ${{ inputs.arm_tenant_id }}
         ARM_USE_OIDC: "true"
+        TERRAFORM_OUTPUT_FILE: ${{ inputs.tf_output_file }}
+        TERRAFORM_ARGS: ${{ inputs.tf_args }}


### PR DESCRIPTION
## Related Issue(s)
- #2088


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now configure Terraform arguments and output file via environment variables: TERRAFORM_ARGS and TERRAFORM_OUTPUT_FILE.
  * Introduced TERRAFORM_STATE_FILE as an alias feeding TF_STATE_FILE for state/artifact handling, improving flexibility.
* **Refactor**
  * Shifted from direct input usage to environment-variable–driven configuration for Terraform steps, providing more consistent and portable setups without changing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->