### PR TITLE
fix(obs-tf): introduce variable and validation to ensure plan works on firsttime setups

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/obs.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/obs.tf
@@ -3,6 +3,7 @@ module "observability" {
   depends_on                    = [module.aks]
   prefix                        = local.team_name
   environment                   = local.environment
+  enable_aks_monitoring         = true
   azurerm_kubernetes_cluster_id = module.aks.azurerm_kubernetes_cluster_id
   oidc_issuer_url               = module.aks.aks_oidc_issuer_url
 }

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/obs.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/obs.tf
@@ -3,6 +3,7 @@ module "observability" {
   depends_on                    = [module.aks]
   prefix                        = "auth"
   environment                   = "at22"
+  enable_aks_monitoring         = true
   azurerm_kubernetes_cluster_id = module.aks.azurerm_kubernetes_cluster_id
   oidc_issuer_url               = module.aks.aks_oidc_issuer_url
 }

--- a/infrastructure/modules/observability/README.md
+++ b/infrastructure/modules/observability/README.md
@@ -56,8 +56,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_insights_app_type"></a> [app\_insights\_app\_type](#input\_app\_insights\_app\_type) | n/a | `string` | `"web"` | no |
 | <a name="input_app_insights_name"></a> [app\_insights\_name](#input\_app\_insights\_name) | Name for the Application Insights instance. | `string` | `""` | no |
-| <a name="input_azurerm_kubernetes_cluster_id"></a> [azurerm\_kubernetes\_cluster\_id](#input\_azurerm\_kubernetes\_cluster\_id) | AKS cluster resource id | `string` | `null` | no |
+| <a name="input_azurerm_kubernetes_cluster_id"></a> [azurerm\_kubernetes\_cluster\_id](#input\_azurerm\_kubernetes\_cluster\_id) | AKS cluster resource id | `string` | `""` | no |
 | <a name="input_azurerm_resource_group_obs_name"></a> [azurerm\_resource\_group\_obs\_name](#input\_azurerm\_resource\_group\_obs\_name) | Optional explicit name of the observability resource group | `string` | `""` | no |
+| <a name="input_enable_aks_monitoring"></a> [enable\_aks\_monitoring](#input\_enable\_aks\_monitoring) | Should monitoring of a AKS cluster be enabled. If true azurerm\_kubernetes\_cluster\_id is required. | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment for resources | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Default region for resources | `string` | `"norwayeast"` | no |
 | <a name="input_log_analytics_retention_days"></a> [log\_analytics\_retention\_days](#input\_log\_analytics\_retention\_days) | n/a | `number` | `30` | no |

--- a/infrastructure/modules/observability/amw-collection.tf
+++ b/infrastructure/modules/observability/amw-collection.tf
@@ -1,5 +1,5 @@
 resource "azurerm_monitor_data_collection_endpoint" "amw" {
-  count               = var.azurerm_kubernetes_cluster_id != null ? 1 : 0
+  count               = var.enable_aks_monitoring ? 1 : 0
   name                = "${azurerm_monitor_workspace.obs.name}-mdce"
   resource_group_name = azurerm_resource_group.obs.name
   location            = azurerm_resource_group.obs.location
@@ -7,7 +7,7 @@ resource "azurerm_monitor_data_collection_endpoint" "amw" {
 }
 
 resource "azurerm_monitor_data_collection_rule" "amw" {
-  count                       = var.azurerm_kubernetes_cluster_id != null ? 1 : 0
+  count                       = var.enable_aks_monitoring ? 1 : 0
   name                        = "${azurerm_monitor_workspace.obs.name}-mdcr"
   resource_group_name         = azurerm_resource_group.obs.name
   location                    = azurerm_resource_group.obs.location
@@ -41,7 +41,7 @@ resource "azurerm_monitor_data_collection_rule" "amw" {
 }
 
 resource "azurerm_monitor_data_collection_rule_association" "amw" {
-  count                   = var.azurerm_kubernetes_cluster_id != null ? 1 : 0
+  count                   = var.enable_aks_monitoring ? 1 : 0
   name                    = "${azurerm_monitor_workspace.obs.name}-mdcra"
   target_resource_id      = var.azurerm_kubernetes_cluster_id
   data_collection_rule_id = azurerm_monitor_data_collection_rule.amw[0].id

--- a/infrastructure/modules/observability/variables.tf
+++ b/infrastructure/modules/observability/variables.tf
@@ -70,8 +70,17 @@ variable "oidc_issuer_url" {
   }
 }
 
+variable "enable_aks_monitoring" {
+  type        = bool
+  description = "Should monitoring of a AKS cluster be enabled. If true azurerm_kubernetes_cluster_id is required."
+}
+
 variable "azurerm_kubernetes_cluster_id" {
   type        = string
-  default     = null
+  default     = ""
   description = "AKS cluster resource id"
+  validation {
+    condition     = var.enable_aks_monitoring == false || (var.enable_aks_monitoring == true && length(var.azurerm_kubernetes_cluster_id) > 0)
+    error_message = "You must provide a value for azurerm_kubernetes_cluster_id when enable_aks_monitoring is true."
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Plan on first time setups fail. Introduce a more static variable to support spinning up new environments without plan failure or hacks

## Related Issue(s)
- #1900 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a toggle to enable AKS cluster monitoring via the observability module.
  * Enabled AKS monitoring for select test environments.
  * Conditional creation of monitoring resources based on the toggle, reducing unnecessary provisioning.
  * Added validation to require a cluster ID when monitoring is enabled.

* Documentation
  * Updated module documentation to include the new monitoring toggle and revised default values for related inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->