### PR TITLE
fix(azdev-tf-agent): upgrade helm and remove fixed CVEs from ignore file

### DIFF
--- a/infrastructure/images/terraform-azure-devops-agent/.trivyignore
+++ b/infrastructure/images/terraform-azure-devops-agent/.trivyignore
@@ -1,1 +1,2 @@
 # Checkd against kubectl with govulncheck and kubectl is not affected (false positiv)
+CVE-2025-47907

--- a/infrastructure/images/terraform-azure-devops-agent/.trivyignore
+++ b/infrastructure/images/terraform-azure-devops-agent/.trivyignore
@@ -1,4 +1,1 @@
 # Checkd against kubectl with govulncheck and kubectl is not affected (false positiv)
-CVE-2024-45338
-CVE-2025-22869
-CVE-2025-47907

--- a/infrastructure/images/terraform-azure-devops-agent/scripts/install.sh
+++ b/infrastructure/images/terraform-azure-devops-agent/scripts/install.sh
@@ -5,7 +5,7 @@ set -e
 # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
 KUBECTL_VERSION="v1.33.4" #Get the latest version with: curl -L -s https://dl.k8s.io/release/stable.txt
 # renovate: datasource=github-releases depName=helm packageName=helm/helm versioning=semver
-HELM_VERSION="v3.18.5" #Find the latest version at https://github.com/helm/helm/releases
+HELM_VERSION="v3.18.6" #Find the latest version at https://github.com/helm/helm/releases
 
 ###################################
 ### Install kubectl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled Helm to v3.18.6 for the Terraform-based Azure DevOps agent image, ensuring the latest patch improvements during image builds.
  * Cleaned up vulnerability ignore configuration by removing two outdated CVE exceptions, keeping only the relevant entry.

* **Bug Fixes**
  * Improved security posture by no longer ignoring resolved vulnerabilities, allowing scanners to flag any reintroduced issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->