### PR TITLE
fix(grafana-tf): fixed issues with initial deploy of grafana resources

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
@@ -49,4 +49,5 @@ module "aks_resources" {
   grafana_endpoint                 = var.grafana_endpoint
   token_grafana_operator           = var.token_grafana_operator
   grafana_dashboard_release_branch = "main"
+  enable_grafana_operator          = true
 }

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
@@ -60,6 +60,7 @@ module "infra-resources" {
   grafana_endpoint                           = module.grafana.grafana_endpoint
   token_grafana_operator                     = module.grafana.token_grafana_operator
   enable_dis_identity_operator               = true
+  enable_grafana_operator                    = true
   azurerm_dis_identity_resource_group_id     = module.aks.dis_resource_group_id
   azurerm_kubernetes_cluster_oidc_issuer_url = module.aks.aks_oidc_issuer_url
 }

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/grafana.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/grafana.tf
@@ -3,9 +3,9 @@ module "grafana" {
   prefix                          = local.team_name
   environment                     = local.environment
   client_config_current_object_id = data.azurerm_client_config.current.object_id
-  monitor_workspace_id = [
-    module.observability.monitor_workspace_id
-  ]
+  monitor_workspace_ids = {
+    "default-obs-workspace" : module.observability.monitor_workspace_id
+  }
   grafana_admin_access = [
     "143ed28a-6e6d-4ca0-8273-eecb9c1665ba", # Altinn-30-Test-Operations
   ]

--- a/infrastructure/modules/aks-resources/grafana-manifests.tf
+++ b/infrastructure/modules/aks-resources/grafana-manifests.tf
@@ -1,5 +1,5 @@
 resource "azapi_resource" "grafana_manifests" {
-  count      = var.grafana_endpoint != null && var.grafana_endpoint != "" ? 1 : 0
+  count      = var.enable_grafana_operator ? 1 : 0
   depends_on = [azapi_resource.linkerd]
   type       = "Microsoft.KubernetesConfiguration/fluxConfigurations@2024-11-01"
   name       = "grafana-manifests"

--- a/infrastructure/modules/aks-resources/grafana-operator.tf
+++ b/infrastructure/modules/aks-resources/grafana-operator.tf
@@ -1,5 +1,5 @@
 resource "azapi_resource" "grafana_operator" {
-  count      = var.grafana_endpoint != null && var.grafana_endpoint != "" ? 1 : 0
+  count      = var.enable_grafana_operator ? 1 : 0
   depends_on = [azapi_resource.linkerd]
   type       = "Microsoft.KubernetesConfiguration/fluxConfigurations@2024-11-01"
   name       = "grafana-operator"

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -33,10 +33,20 @@ variable "grafana_dashboard_release_branch" {
   }
 }
 
+variable "enable_grafana_operator" {
+  type = bool
+  description = "Toggle deployment of grafana operator in cluster. If deployed grafana_endpoint must be defined"
+  default = true
+}
+
 variable "grafana_endpoint" {
   type        = string
   description = "URL endpoint for Grafana dashboard access"
   default     = ""
+  validation {
+    condition     = var.enable_grafana_operator == false || (var.enable_grafana_operator == true && length(var.grafana_endpoint) > 0)
+    error_message = "You must provide a value for grafana_endpoint when enable_grafana_operator is true."
+  }
 }
 
 variable "obs_client_id" {

--- a/infrastructure/modules/grafana/grafana-access.tf
+++ b/infrastructure/modules/grafana/grafana-access.tf
@@ -11,9 +11,7 @@ resource "azurerm_role_assignment" "grafana_permission" {
 
 # Give Grafana read access to Azure Monitor workspaces
 resource "azurerm_role_assignment" "amw_datareaderrole" {
-  for_each = {
-    for value in var.monitor_workspace_id : value => value if value != null
-  }
+  for_each = var.monitor_workspace_ids
   scope              = each.value
   role_definition_id = "/subscriptions/${split("/", each.value)[2]}/providers/Microsoft.Authorization/roleDefinitions/b0d8363b-8ddd-447d-831f-62ca05bff136"
   principal_id       = azurerm_dashboard_grafana.grafana.identity[0].principal_id

--- a/infrastructure/modules/grafana/grafana.tf
+++ b/infrastructure/modules/grafana/grafana.tf
@@ -12,7 +12,7 @@ resource "azurerm_dashboard_grafana" "grafana" {
   grafana_major_version             = var.grafana_major_version
 
   dynamic "azure_monitor_workspace_integrations" {
-    for_each = var.monitor_workspace_id
+    for_each = var.monitor_workspace_ids
     content {
       resource_id = azure_monitor_workspace_integrations.value
     }

--- a/infrastructure/modules/grafana/variables.tf
+++ b/infrastructure/modules/grafana/variables.tf
@@ -52,9 +52,9 @@ variable "location" {
   description = "Default region for resources"
 }
 
-variable "monitor_workspace_id" {
-  type        = list(string)
-  default     = []
+variable "monitor_workspace_ids" {
+  type        = map(string)
+  default     = {}
   description = "List of azure monitor workspaces to connect grafana."
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Grafana resources has count and for_each blocks that rely on values not known at deploy time. Introduced new variables and replaced some with new ones to support successful terraform plan the first time an environment is setup

## Related Issue(s)
- #2109 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional deployment of the Grafana Operator is now supported via an explicit toggle.
  * When enabled, a Grafana endpoint must be provided to complete setup.

* **Refactor**
  * Grafana integration now accepts a named map of Azure Monitor workspaces, enabling multi-workspace configuration. Update existing configs that used a list to the new map format.
  * Operator deployment is gated by the new toggle instead of inferring from an endpoint value.
  * Access role assignments align with the new multi-workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->