### PR TITLE
fix(dis-cr-action): use default terraform version in our action instead of latest

### DIFF
--- a/.github/workflows/auth-at22-aks-rg.yml
+++ b/.github/workflows/auth-at22-aks-rg.yml
@@ -51,7 +51,6 @@ env:
   TF_PROJECT: ./infrastructure/altinn-auth-test/auth-at22-aks-rg
   ARM_CLIENT_ID: ${{ secrets.TF_AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: 37bac63a-b964-46b2-8de8-ba93c432ea1f
-  TF_VERSION: latest
 
 permissions:
   id-token: write

--- a/.github/workflows/corr-at22-aks-rg.yml
+++ b/.github/workflows/corr-at22-aks-rg.yml
@@ -51,7 +51,6 @@ env:
   TF_PROJECT: ./infrastructure/altinn-correspondence-test/corr-at22-aks-rg
   ARM_CLIENT_ID: ${{ secrets.TF_AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: 37bac63a-b964-46b2-8de8-ba93c432ea1f
-  TF_VERSION: latest
 
 permissions:
   id-token: write


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
default terraform version from our action instead of latest. This will atm. default to 1.12.2

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
