### PR TITLE
fix(dis-cr): rename aso resource group to match other resource group names

### DIFF
--- a/infrastructure/modules/azure-service-operator/identity.tf
+++ b/infrastructure/modules/azure-service-operator/identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "aso_rg" {
-  name     = var.azurerm_resource_group_aso_name != "" ? var.azurerm_resource_group_aso_name : "aso-${var.prefix}-${var.environment}-rg"
+  name     = var.azurerm_resource_group_aso_name != "" ? var.azurerm_resource_group_aso_name : "${var.prefix}-${var.environment}-aso-rg"
   location = var.location
   tags     = var.tags
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This will recreate the user managed identity. But the scripts will handle this

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the default naming convention for the Azure Service Operator resource group, moving the "aso" segment to the end (from aso-<prefix>-<env>-rg to <prefix>-<env>-aso-rg).
  - Deployments relying on the default will adopt the new name; configurations with a custom name are unaffected. Location and tags remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->