### PR TITLE
chore: use the more readable grafana domain

### DIFF
--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -279,7 +279,7 @@ func (r K8sManifestGenerator) Generate() {
 				fmt.Printf("\nTo run the test '%s' in '%s' run\n\tkubectl --context k6tests-cluster apply --server-side -f %s", *c.TestRun.Name, c.Environment, filepath.Join(r.DistDirectory, dirName))
 				fmt.Printf("\nTo check the logs run\n\tkubectl --context k6tests-cluster -n %s logs -f --tail=-1 -l \"k6-test=%s,runner=true\"", cf.Namespace, uniqName)
 				fmt.Printf("\nGrafana URL: \n\t%s/%s?orgId=1&var-DS_PROMETHEUS=%s&var-namespace=%s&var-testid=%s&from=%s&to=now&refresh=1m\n\n",
-					"https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com",
+					"https://grafana.altinn.cloud",
 					grafanaDashboard,
 					"k6tests-amw",
 					cf.Namespace,

--- a/libs/k6/src/config.js
+++ b/libs/k6/src/config.js
@@ -1,7 +1,7 @@
 export const config = {
   grafanaBaseUrl:
     __ENV.GRAFANA_BASE_URL ??
-    'https://altinn-grafana-test-b2b8dpdkcvfuhfd3.eno.grafana.azure.com',
+    'https://grafana.altinn.cloud',
   k6PrometheusDashboard:
     __ENV.K6_PROMETHEUS_DASHBOARD ??
     'd/ccbb2351-2ae2-462f-ae0e-f2c893ad1028/k6-prometheus',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Grafana base URL to https://grafana.altinn.cloud for k6 configs and generated manifests.
  * Generated dashboard links now target the cloud endpoint while preserving existing parameters (dashboard, environment, timestamp).
  * Environment variable override for the Grafana URL continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->