### PR TITLE
fix(tf-obs): add missing depends on

### DIFF
--- a/infrastructure/modules/observability/kv.tf
+++ b/infrastructure/modules/observability/kv.tf
@@ -33,6 +33,7 @@ resource "azurerm_role_assignment" "obs_kv_reader" {
 
 ## add connection string to key vault
 resource "azurerm_key_vault_secret" "conn_string" {
+  depends_on      = [azurerm_role_assignment.ci_kv_secrets_role]
   name            = "connectionString"
   value           = azurerm_application_insights.obs.connection_string
   key_vault_id    = azurerm_key_vault.obs_kv.id


### PR DESCRIPTION
When creating key vault the secret can't be added before the service principal is granted the neccessary permissions to create a secret

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enabled automated permissions for our CI to manage Key Vault secrets, improving reliability of secret updates.
  - Introduced a default 1-year expiration for the connection string secret to enhance security hygiene.
  - Ensured secret updates respect expiration management without unnecessary churn during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->