### PR TITLE
feat(dis-cr): deploy dns child zone and cert-manager tls issuer

### DIFF
--- a/.github/workflows/corr-at22-aks-rg.yml
+++ b/.github/workflows/corr-at22-aks-rg.yml
@@ -51,6 +51,7 @@ env:
   TF_PROJECT: ./infrastructure/altinn-correspondence-test/corr-at22-aks-rg
   ARM_CLIENT_ID: ${{ secrets.TF_AZURE_CLIENT_ID }}
   ARM_SUBSCRIPTION_ID: 37bac63a-b964-46b2-8de8-ba93c432ea1f
+  TF_VAR_parent_zone_subscription_id: ${{ secrets.AZURE_ALTINN_CLOUD_DNS_SUBSCRIPTION_ID }}
 
 permissions:
   id-token: write

--- a/flux/cert-manager/helmrelease.yaml
+++ b/flux/cert-manager/helmrelease.yaml
@@ -27,6 +27,11 @@ spec:
       enabled: true
     dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53"
     dns01RecursiveNameserversOnly: true
+    podLabels:
+      azure.workload.identity/use: "true"
+    serviceAccount:
+      labels:
+        azure.workload.identity/use: "true"
     image:
       registry: altinncr.azurecr.io
     webhook:

--- a/flux/certm-lets-encrypt-dns-issuer/kustomization.yaml
+++ b/flux/certm-lets-encrypt-dns-issuer/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - staging.yaml
+  - production.yaml

--- a/flux/certm-lets-encrypt-dns-issuer/production.yaml
+++ b/flux/certm-lets-encrypt-dns-issuer/production.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    server: "https://acme-v02.api.letsencrypt.org/directory"
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+    - dns01:
+        azureDNS:
+          hostedZoneName: ${AZURE_DNS_ZONE_NAME}
+          resourceGroupName: ${AZURE_RESOURCE_GROUP}
+          subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: ${IDENTITY_CLIENT_ID}

--- a/flux/certm-lets-encrypt-dns-issuer/staging.yaml
+++ b/flux/certm-lets-encrypt-dns-issuer/staging.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: "https://acme-staging-v02.api.letsencrypt.org/directory"
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - dns01:
+        azureDNS:
+          hostedZoneName: ${AZURE_DNS_ZONE_NAME}
+          resourceGroupName: ${AZURE_RESOURCE_GROUP}
+          subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: ${IDENTITY_CLIENT_ID}

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
@@ -46,6 +46,7 @@ module "aks" {
 module "infra-resources" {
   depends_on                                 = [module.aks, module.observability]
   source                                     = "../../modules/aks-resources"
+  subscription_id                            = var.subscription_id
   aks_node_resource_group                    = module.aks.aks_node_resource_group
   azurerm_kubernetes_cluster_id              = module.aks.azurerm_kubernetes_cluster_id
   flux_release_tag                           = local.flux_release_tag
@@ -61,6 +62,7 @@ module "infra-resources" {
   token_grafana_operator                     = module.grafana.token_grafana_operator
   enable_dis_identity_operator               = true
   enable_grafana_operator                    = true
+  enable_cert_manager_tls_issuer             = false
   azurerm_dis_identity_resource_group_id     = module.aks.dis_resource_group_id
   azurerm_kubernetes_cluster_oidc_issuer_url = module.aks.aks_oidc_issuer_url
 }

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/aks.tf
@@ -38,23 +38,28 @@ module "aks" {
 }
 
 module "infra-resources" {
-  depends_on                                 = [module.aks, module.observability]
-  source                                     = "../../modules/aks-resources"
-  aks_node_resource_group                    = module.aks.aks_node_resource_group
-  azurerm_kubernetes_cluster_id              = module.aks.azurerm_kubernetes_cluster_id
-  flux_release_tag                           = var.flux_release_tag
-  pip4_ip_address                            = module.aks.pip4_ip_address
-  pip6_ip_address                            = module.aks.pip6_ip_address
-  subnet_address_prefixes                    = var.subnet_address_prefixes
-  obs_kv_uri                                 = module.observability.key_vault_uri
-  obs_client_id                              = module.observability.obs_client_id
-  obs_tenant_id                              = local.tenant_id
-  environment                                = var.environment
-  syncroot_namespace                         = var.team_name
-  grafana_endpoint                           = module.grafana.grafana_endpoint
-  token_grafana_operator                     = module.grafana.token_grafana_operator
-  enable_dis_identity_operator               = true
-  enable_grafana_operator                    = true
-  azurerm_dis_identity_resource_group_id     = module.aks.dis_resource_group_id
-  azurerm_kubernetes_cluster_oidc_issuer_url = module.aks.aks_oidc_issuer_url
+  depends_on                                   = [module.aks, module.observability, module.dns-child-zone]
+  source                                       = "../../modules/aks-resources"
+  subscription_id                              = var.subscription_id
+  aks_node_resource_group                      = module.aks.aks_node_resource_group
+  azurerm_kubernetes_cluster_id                = module.aks.azurerm_kubernetes_cluster_id
+  flux_release_tag                             = var.flux_release_tag
+  pip4_ip_address                              = module.aks.pip4_ip_address
+  pip6_ip_address                              = module.aks.pip6_ip_address
+  subnet_address_prefixes                      = var.subnet_address_prefixes
+  obs_kv_uri                                   = module.observability.key_vault_uri
+  obs_client_id                                = module.observability.obs_client_id
+  obs_tenant_id                                = local.tenant_id
+  environment                                  = var.environment
+  syncroot_namespace                           = var.team_name
+  grafana_endpoint                             = module.grafana.grafana_endpoint
+  token_grafana_operator                       = module.grafana.token_grafana_operator
+  enable_dis_identity_operator                 = true
+  enable_grafana_operator                      = true
+  azurerm_dis_identity_resource_group_id       = module.aks.dis_resource_group_id
+  azurerm_kubernetes_cluster_oidc_issuer_url   = module.aks.aks_oidc_issuer_url
+  enable_cert_manager_tls_issuer               = true
+  tls_cert_manager_workload_identity_client_id = module.dns-child-zone.azuread_cert_manager_client_id
+  tls_cert_manager_zone_name                   = module.dns-child-zone.azurerm_dns_zone_name
+  tls_cert_manager_zone_rg_name                = module.dns-child-zone.azurerm_dns_zone_resource_group_name
 }

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/dns.tf
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/dns.tf
@@ -1,0 +1,12 @@
+module "dns-child-zone" {
+  depends_on = [module.aks]
+  source     = "../../modules/dns-child-zone"
+  providers = {
+    azurerm.parent_zone = azurerm.parent_zone
+  }
+  prefix               = var.team_name
+  environment          = var.environment
+  cluster_ipv4_address = module.aks.pip4_ip_address
+  cluster_ipv6_address = module.aks.pip6_ip_address
+  oidc_issuer_url      = module.aks.aks_oidc_issuer_url
+}

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/providers.tf
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/providers.tf
@@ -58,6 +58,13 @@ provider "azurerm" {
   ]
 }
 
+provider "azurerm" {
+  features {}
+  subscription_id = var.parent_zone_subscription_id
+  use_oidc        = true
+  alias           = "parent_zone"
+}
+
 provider "grafana" {
   url  = module.grafana.grafana_endpoint
   auth = var.app_access_token

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/variables.tf
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/variables.tf
@@ -3,6 +3,12 @@ variable "subscription_id" {
   description = "Subscription id to deploy services"
 }
 
+variable "parent_zone_subscription_id" {
+  type        = string
+  description = "Subscription id for parent dns zone"
+  sensitive   = true
+}
+
 variable "aks_vnet_address_spaces" {
   type        = list(string)
   description = "vnet address space reserved for AKS"

--- a/infrastructure/modules/aks-resources/tls-issuer.tf
+++ b/infrastructure/modules/aks-resources/tls-issuer.tf
@@ -1,0 +1,44 @@
+resource "azapi_resource" "cert_manager_issuer" {
+  count = var.enable_cert_manager_tls_issuer ? 1 : 0
+  depends_on = [azapi_resource.cert_manager]
+  type       = "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01"
+  name       = "tls-issuer"
+  parent_id  = var.azurerm_kubernetes_cluster_id
+  body = {
+    properties = {
+      kustomizations = {
+        tls-issuer = {
+          force = false
+          path  = "./"
+          postBuild = {
+            substitute = {
+              AZURE_DNS_ZONE_NAME   = "${var.tls_cert_manager_zone_name}"
+              AZURE_RESOURCE_GROUP  = "${var.tls_cert_manager_zone_rg_name}"
+              AZURE_SUBSCRIPTION_ID = "${var.subscription_id}"
+              IDENTITY_CLIENT_ID    = "${var.tls_cert_manager_workload_identity_client_id}"
+            }
+          }
+          prune                  = false
+          retryIntervalInSeconds = 300
+          syncIntervalInSeconds  = 300
+          timeoutInSeconds       = 300
+          wait                   = true
+        }
+      }
+      ociRepository = {
+        insecure = false
+        repositoryRef = {
+          tag = var.flux_release_tag
+        }
+        syncIntervalInSeconds = 300
+        timeoutInSeconds      = 300
+        url                   = "oci://altinncr.azurecr.io/manifests/infra/cert-manager-dns-issuer"
+        useWorkloadIdentity   = true
+      }
+      namespace                  = "flux-system"
+      reconciliationWaitDuration = "PT5M"
+      waitForReconciliation      = true
+      sourceKind                 = "OCIRepository"
+    }
+  }
+}

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -1,3 +1,8 @@
+variable "subscription_id" {
+  type        = string
+  description = "Subscription id where aks cluster and other resources are deployed"
+}
+
 variable "aks_node_resource_group" {
   type        = string
   description = "AKS node resource group name"
@@ -122,5 +127,41 @@ variable "azurerm_dis_identity_resource_group_id" {
   validation {
     condition     = var.enable_dis_identity_operator == false || (var.enable_dis_identity_operator == true && length(var.azurerm_dis_identity_resource_group_id) > 0)
     error_message = "You must provide a value for azurerm_dis_identity_resource_group_id when enable_dis_identity_operator is true."
+  }
+}
+
+variable "enable_cert_manager_tls_issuer" {
+  type        = bool
+  default     = true
+  description = "Enable cert-manager issuer for TLS certificates"
+}
+
+variable "tls_cert_manager_workload_identity_client_id" {
+  type        = string
+  description = "Client id for cert-manager workload identity"
+  default     = ""
+  validation {
+    condition     = var.enable_cert_manager_tls_issuer == false || (var.enable_cert_manager_tls_issuer == true && length(var.tls_cert_manager_workload_identity_client_id) > 0)
+    error_message = "You must provide a value for tls_cert_manager_workload_identity_client_id when enable_cert_manager_tls_issuer is true."
+  }
+}
+
+variable "tls_cert_manager_zone_name" {
+  type        = string
+  description = "Azure DNS zone name for TLS certificates"
+  default     = ""
+  validation {
+    condition     = var.enable_cert_manager_tls_issuer == false || (var.enable_cert_manager_tls_issuer == true && length(var.tls_cert_manager_zone_name) > 0)
+    error_message = "You must provide a value for tls_cert_manager_zone_name when enable_cert_manager_tls_issuer is true."
+  }
+}
+
+variable "tls_cert_manager_zone_rg_name" {
+  type        = string
+  description = "Azure DNS zone resource group name for TLS certificates"
+  default     = ""
+  validation {
+    condition     = var.enable_cert_manager_tls_issuer == false || (var.enable_cert_manager_tls_issuer == true && length(var.tls_cert_manager_zone_rg_name) > 0)
+    error_message = "You must provide a value for tls_cert_manager_zone_rg_name when enable_cert_manager_tls_issuer is true."
   }
 }

--- a/infrastructure/modules/dns-child-zone/child-zone.tf
+++ b/infrastructure/modules/dns-child-zone/child-zone.tf
@@ -1,0 +1,44 @@
+
+
+resource "azurerm_resource_group" "dns_child_zone_rg" {
+  name     = var.child_dns_zone_rg_name != "" ? var.child_dns_zone_rg_name : "${var.prefix}-${var.environment}-dns-rg"
+  location = var.location
+}
+
+resource "azurerm_dns_zone" "child_zone" {
+  name                = var.child_dns_zone_name != "" ? var.child_dns_zone_name : "${var.environment}.${var.prefix}.altinn.cloud"
+  resource_group_name = azurerm_resource_group.dns_child_zone_rg.name
+}
+
+resource "azurerm_dns_a_record" "wildcard_record" {
+  name                = "*"
+  zone_name           = azurerm_dns_zone.child_zone.name
+  resource_group_name = azurerm_dns_zone.child_zone.resource_group_name
+  records             = toset(["${var.cluster_ipv4_address}"])
+  ttl                 = 300
+}
+
+resource "azurerm_dns_aaaa_record" "wildcard_record" {
+  name                = "*"
+  zone_name           = azurerm_dns_zone.child_zone.name
+  resource_group_name = azurerm_dns_zone.child_zone.resource_group_name
+  records             = toset(["${var.cluster_ipv6_address}"])
+  ttl                 = 300
+}
+
+resource "azurerm_dns_caa_record" "issue_lets_encrypt" {
+  name                = "@"
+  zone_name           = azurerm_dns_zone.child_zone.name
+  resource_group_name = azurerm_dns_zone.child_zone.resource_group_name
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+  record {
+    flags = 0
+    tag   = "issuewild"
+    value = "letsencrypt.org"
+  }
+  ttl = 300
+}

--- a/infrastructure/modules/dns-child-zone/identity.tf
+++ b/infrastructure/modules/dns-child-zone/identity.tf
@@ -1,0 +1,25 @@
+resource "azuread_application" "cert_manager_app" {
+  display_name     = "${var.prefix}-${var.environment}-cert-manager"
+  sign_in_audience = "AzureADMyOrg"
+}
+
+resource "azuread_service_principal" "cert_manager_sp" {
+  client_id = azuread_application.cert_manager_app.client_id
+}
+
+resource "azuread_application_federated_identity_credential" "cert_manager_fed_identity" {
+  application_id = azuread_application.cert_manager_app.id
+  display_name   = "fed-identity-${var.prefix}-${var.environment}-cert-manager"
+  description    = "The federated identity used to federate K8s with Azure AD for ${var.prefix}-${var.environment}-cert-manager"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = var.oidc_issuer_url
+  subject        = "system:serviceaccount:cert-manager:cert-manager"
+}
+
+# Gives key vault reader to the whole subscription
+resource "azurerm_role_assignment" "dns_zone_contributor_cert_manager" {
+  scope                            = azurerm_dns_zone.child_zone.id
+  role_definition_name             = "DNS Zone Contributor"
+  principal_id                     = azuread_service_principal.cert_manager_sp.object_id
+  skip_service_principal_aad_check = true
+}

--- a/infrastructure/modules/dns-child-zone/ns-records.tf
+++ b/infrastructure/modules/dns-child-zone/ns-records.tf
@@ -1,0 +1,8 @@
+resource "azurerm_dns_ns_record" "child_zone" {
+  name                = replace(azurerm_dns_zone.child_zone.name, "/\\.${var.parent_dns_zone_name}$/", "")
+  zone_name           = var.parent_dns_zone_name
+  resource_group_name = var.parent_dns_zone_rg
+  ttl                 = 300
+  records             = azurerm_dns_zone.child_zone.name_servers
+  provider            = azurerm.parent_zone
+}

--- a/infrastructure/modules/dns-child-zone/output.tf
+++ b/infrastructure/modules/dns-child-zone/output.tf
@@ -1,0 +1,12 @@
+output "azuread_cert_manager_client_id" {
+  sensitive = true
+  value     = azuread_application.cert_manager_app.client_id
+}
+
+output "azurerm_dns_zone_name" {
+  value = azurerm_dns_zone.child_zone.name
+}
+
+output "azurerm_dns_zone_resource_group_name" {
+  value = azurerm_dns_zone.child_zone.resource_group_name
+}

--- a/infrastructure/modules/dns-child-zone/providers.tf
+++ b/infrastructure/modules/dns-child-zone/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+      configuration_aliases = [
+        azurerm.parent_zone
+      ]
+    }
+  }
+}

--- a/infrastructure/modules/dns-child-zone/variables.tf
+++ b/infrastructure/modules/dns-child-zone/variables.tf
@@ -1,0 +1,63 @@
+variable "prefix" {
+  type        = string
+  description = "Resources prefixes"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment"
+}
+
+variable "cluster_ipv4_address" {
+  type        = string
+  description = "Cluster ipv4 address"
+  validation {
+    condition     = can(regex("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.cluster_ipv4_address))
+    error_message = "The cluster_ipv4_address must be a valid IPv4 address."
+  }
+}
+
+variable "cluster_ipv6_address" {
+  type        = string
+  description = "Cluster ipv6 address"
+  validation {
+    # This regex checks for most standard IPv6 notations, including compressed.
+    condition     = can(regex("^((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,7}:)|(:(:[0-9a-fA-F]{1,4}){1,7})|(([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2})|(([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3})|(([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4})|(([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5})|([0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6}))|(::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])))$", var.cluster_ipv6_address))
+    error_message = "The cluster_ipv6_address must be a valid IPv6 address."
+  }
+}
+
+variable "oidc_issuer_url" {
+  type        = string
+  description = "Oidc issuer url needed for federation"
+}
+
+variable "location" {
+  type        = string
+  description = "Location for resources"
+  default     = "norwayeast"
+}
+
+variable "child_dns_zone_rg_name" {
+  type        = string
+  description = "Override generated name for resource group for child dns zone."
+  default     = ""
+}
+
+variable "parent_dns_zone_name" {
+  type        = string
+  description = "Parent zone name"
+  default     = "altinn.cloud"
+}
+
+variable "child_dns_zone_name" {
+  type        = string
+  description = "Child zone name"
+  default     = ""
+}
+
+variable "parent_dns_zone_rg" {
+  type        = string
+  description = "Resource group for parent dns zone"
+  default     = "DNS"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Setup child dns zone for container runtime clusters and create a clusterissuer for lets-encrypt

## Related Issue(s)
- #2125 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automated TLS certificates via cert-manager (Let’s Encrypt staging & production) using DNS-01 validation.
  - Azure Workload Identity enabled for cert-manager pods and service account.
  - DNS child-zone delegation with wildcard A/AAAA records, CAA, federated identity and NS delegation.
  - Flux integration to deploy a TLS issuer from an OCI repository per-cluster.

- Chores
  - CI workflow exposes a subscription variable for parent-zone DNS operations.
  - Terraform extended for multi-subscription DNS, identity, and TLS issuer configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->