### PR TITLE
fix(dis-cr): fix oci image name for cert manager lets encrypt issuer

### DIFF
--- a/infrastructure/modules/aks-resources/tls-issuer.tf
+++ b/infrastructure/modules/aks-resources/tls-issuer.tf
@@ -32,7 +32,7 @@ resource "azapi_resource" "cert_manager_issuer" {
         }
         syncIntervalInSeconds = 300
         timeoutInSeconds      = 300
-        url                   = "oci://altinncr.azurecr.io/manifests/infra/cert-manager-dns-issuer"
+        url                   = "oci://altinncr.azurecr.io/manifests/infra/certm-lets-encrypt-dns-issuer"
         useWorkloadIdentity   = true
       }
       namespace                  = "flux-system"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wrong name in oci source for tls issuer resource

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
