### PR TITLE
feat(dis-cr): deploy certificate that uses letsencrypt-staging cluster-issuer

### DIFF
--- a/flux/certm-lets-encrypt-dns-issuer/certificate.yaml
+++ b/flux/certm-lets-encrypt-dns-issuer/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls
+  namespace: traefik
+spec:
+  secretName: ssl-cert
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.${AZURE_DNS_ZONE_NAME}"

--- a/flux/certm-lets-encrypt-dns-issuer/certificate.yaml
+++ b/flux/certm-lets-encrypt-dns-issuer/certificate.yaml
@@ -9,4 +9,5 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
+    - "${AZURE_DNS_ZONE_NAME}"
     - "*.${AZURE_DNS_ZONE_NAME}"

--- a/flux/certm-lets-encrypt-dns-issuer/kustomization.yaml
+++ b/flux/certm-lets-encrypt-dns-issuer/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - staging.yaml
   - production.yaml
+  - certificate.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cert issuing tested manually in cluster with staging issuer. Setting up with production issuer

## Related Issue(s)
- #2125 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic provisioning of a TLS certificate covering the apex domain and all subdomains via Let's Encrypt (uses DNS validation; DNS zone is templated).
* **Chores**
  * Deployment manifests updated so the certificate is created and managed as part of regular deployments for seamless rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->