### PR TITLE
feat: Add Linkerd default inbound policy configuration

### DIFF
--- a/flux/linkerd/helmrelease.yaml
+++ b/flux/linkerd/helmrelease.yaml
@@ -99,3 +99,4 @@ spec:
     podMonitor:
       enabled: true
     disableIPv6: "${DISABLE_IPV6:=false}"
+    defaultInboundPolicy: "${DEFAULT_INBOUND_POLICY:=all-unauthenticated}"

--- a/flux/linkerd/helmrelease.yaml
+++ b/flux/linkerd/helmrelease.yaml
@@ -93,10 +93,10 @@ spec:
     proxy:
       image:
         name: altinncr.azurecr.io/linkerd/proxy
+      defaultInboundPolicy: "${DEFAULT_INBOUND_POLICY:=all-unauthenticated}"
     proxyInit:
       image:
         name: altinncr.azurecr.io/linkerd/proxy-init
     podMonitor:
       enabled: true
     disableIPv6: "${DISABLE_IPV6:=false}"
-    defaultInboundPolicy: "${DEFAULT_INBOUND_POLICY:=all-unauthenticated}"

--- a/infrastructure/modules/aks-resources/linkerd.tf
+++ b/infrastructure/modules/aks-resources/linkerd.tf
@@ -11,8 +11,8 @@ resource "azapi_resource" "linkerd" {
           path  = "./"
           postBuild = {
             substitute = {
-              DISABLE_IPV6           = "false"
-              DEFAULT_INBOUND_POLICY = var.linkerd_default_inbound_policy
+              DISABLE_IPV6 : "${var.linkerd_disable_ipv6}"
+              DEFAULT_INBOUND_POLICY : "${var.linkerd_default_inbound_policy}"
             }
           }
           prune                  = false

--- a/infrastructure/modules/aks-resources/linkerd.tf
+++ b/infrastructure/modules/aks-resources/linkerd.tf
@@ -11,7 +11,8 @@ resource "azapi_resource" "linkerd" {
           path  = "./"
           postBuild = {
             substitute = {
-              DISABLE_IPV6 = "false"
+              DISABLE_IPV6           = "false"
+              DEFAULT_INBOUND_POLICY = var.linkerd_default_inbound_policy
             }
           }
           prune                  = false

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -58,6 +58,10 @@ variable "linkerd_default_inbound_policy" {
   description = "Default inbound policy for Linkerd"
   type        = string
   default     = "all-unauthenticated"
+  validation {
+    condition     = contains(["all-unauthenticated", "all-authenticated", "cluster-authenticated", "deny"], var.linkerd_default_inbound_policy)
+    error_message = "linkerd_default_inbound_policy must be one of: all-unauthenticated, all-authenticated, cluster-authenticated, deny."
+  }
 }
 
 variable "obs_client_id" {

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -54,6 +54,12 @@ variable "grafana_endpoint" {
   }
 }
 
+variable "linkerd_default_inbound_policy" {
+  description = "Default inbound policy for Linkerd"
+  type        = string
+  default     = "all-unauthenticated"
+}
+
 variable "obs_client_id" {
   type        = string
   description = "Client id for the obs app"

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -64,6 +64,16 @@ variable "linkerd_default_inbound_policy" {
   }
 }
 
+variable "linkerd_disable_ipv6" {
+  description = "Disable IPv6 for Linkerd"
+  type        = bool
+  default     = false
+  validation {
+    condition     = var.linkerd_disable_ipv6 == true || var.linkerd_disable_ipv6 == false
+    error_message = "linkerd_disable_ipv6 must be either true or false."
+  }
+}
+
 variable "obs_client_id" {
   type        = string
   description = "Client id for the obs app"

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -66,11 +66,11 @@ variable "linkerd_default_inbound_policy" {
 
 variable "linkerd_disable_ipv6" {
   description = "Disable IPv6 for Linkerd"
-  type        = bool
-  default     = false
+  type        = string
+  default     = "false"
   validation {
-    condition     = var.linkerd_disable_ipv6 == true || var.linkerd_disable_ipv6 == false
-    error_message = "linkerd_disable_ipv6 must be either true or false."
+    condition     = contains(["true", "false"], var.linkerd_disable_ipv6)
+    error_message = "linkerd_disable_ipv6 must be either 'true' or 'false'."
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a configurable default inbound policy for the service mesh (default "all-unauthenticated"); options: all-unauthenticated, all-authenticated, cluster-authenticated, deny. Policy can be overridden via deployment configuration.

- Chores
  - Added a configurable IPv6 disable toggle (default false) with validation and propagated into deployment templates for consistent platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->