### PR TITLE
fix(acr): necessary roles for correspondence and broker

### DIFF
--- a/infrastructure/adminservices-prod/altinncr/iam.tf
+++ b/infrastructure/adminservices-prod/altinncr/iam.tf
@@ -35,72 +35,28 @@ resource "azurerm_role_assignment" "altinncr_acrpush_altinn_platform" {
 
 resource "azurerm_role_assignment" "altinncr_writer_corr" {
   principal_id         = "27bfa3f2-2b60-4de5-a3b9-09dd3b01b490"
-  role_definition_name = "Container Registry Repository Writer"
+  role_definition_name = "AcrPush"
   principal_type       = "ServicePrincipal"
   scope                = azurerm_container_registry.acr.id
-  condition            = <<-EOT
-(
- (
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/content/write'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/content/read'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/metadata/read'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/metadata/write'})
- )
- OR 
- (
-  @Request[Microsoft.ContainerRegistry/registries/repositories:name] StringStartsWith 'corr'
- )
-)
-EOT
 }
 
 resource "azurerm_role_assignment" "altinncr_writer_corr_test" {
   principal_id         = "d3c35a12-5465-4ba3-b50d-8ab1bedbef2a"
-  role_definition_name = "Container Registry Repository Writer"
+  role_definition_name = "AcrPush"
   principal_type       = "ServicePrincipal"
   scope                = azurerm_container_registry.acr.id
-  condition            = <<-EOT
-(
- (
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/content/write'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/content/read'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/metadata/read'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/metadata/write'})
- )
- OR 
- (
-  @Request[Microsoft.ContainerRegistry/registries/repositories:name] StringStartsWith 'corr'
- )
-)
-EOT
 }
 
 resource "azurerm_role_assignment" "altinncr_writer_broker" {
   principal_id         = "3f5e6dcb-b782-49ca-939f-fd21dda34e4e"
-  role_definition_name = "Container Registry Repository Writer"
+  role_definition_name = "AcrPush"
   principal_type       = "ServicePrincipal"
   scope                = azurerm_container_registry.acr.id
-  condition            = <<-EOT
-(
- (
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/content/write'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/content/read'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/metadata/read'})
-  AND
-  !(ActionMatches{'Microsoft.ContainerRegistry/registries/repositories/metadata/write'})
- )
- OR 
- (
-  @Request[Microsoft.ContainerRegistry/registries/repositories:name] StringStartsWith 'corr'
- )
-)
-EOT
+}
+
+resource "azurerm_role_assignment" "altinncr_writer_broker_test" {
+  principal_id         = "e5213800-3bdc-4f13-a212-0f4c8cd6c1ea"
+  role_definition_name = "AcrPush"
+  principal_type       = "ServicePrincipal"
+  scope                = azurerm_container_registry.acr.id
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed abac roles and use rbac roles until abac is GA

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added writer access for a new test identity to the container registry.
- Refactor
  - Standardized container registry writer permissions to the AcrPush role across existing identities.
- Chores
  - Removed conditional RBAC rules on relevant role assignments to simplify access control.
  - Maintained existing scope and service principal usage for all assignments.

Impact: Consistent and simplified permissions for pushing images to the container registry, with expanded test coverage for write access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->