### PR TITLE
feat(grafana): grant grafana monitor reader and grant auth grafana editor

### DIFF
--- a/.github/workflows/altinn-monitor-test-rg-deploy.yml
+++ b/.github/workflows/altinn-monitor-test-rg-deploy.yml
@@ -52,6 +52,8 @@ jobs:
     name: Plan
     environment: reader
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_subs_to_monitor: '{platform-test:"${{secrets.AZR_PLATFORM_TEST_SUB_ID}}",platform-staging:"${{secrets.AZR_PLATFORM_STAGING_SUB_ID}}",platform-prod:"${{secrets.AZR_PLATFORM_PROD_SUB_ID}}"}'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -101,6 +103,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: plan
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_subs_to_monitor: '{platform-test:"${{secrets.AZR_PLATFORM_TEST_SUB_ID}}",platform-staging:"${{secrets.AZR_PLATFORM_STAGING_SUB_ID}}",platform-prod:"${{secrets.AZR_PLATFORM_PROD_SUB_ID}}"}'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -143,6 +143,13 @@ resource "azurerm_role_assignment" "grafana_identity_reader_rg_studio_prod" {
   skip_service_principal_aad_check = true
 }
 
+resource "azurerm_role_assignment" "grafna_identity_monitor_reader" {
+  for_each                         = local.additional_subs_to_monitor
+  scope                            = "/subscriptions/${each.value}"
+  role_definition_name             = "Monitoring Reader"
+  principal_id                     = azurerm_dashboard_grafana.grafana.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
 
 locals {
   altinn_30_appmigration_test_developers  = "8ea6868e-317e-45b5-8437-464fb8e48e7e"
@@ -156,6 +163,8 @@ locals {
   altinn_30_operations_prod               = "5a5ed585-9f7c-4b94-80af-9ceee8124db3"
   dialogporten_developers                 = "857b3aa1-bde3-469c-a052-a24c81503646"
   dialogporten_developers_prod            = "415cfc7b-40f6-4540-9aef-cb9c9050aada"
+  product_auth_developers_dev             = "6d54df21-3547-41a2-8d0d-529fad054807"
+  product_auth_developers_prod            = "c410f062-def4-44f5-9a45-b23ddcdd57c3"
 
   grafana_editor = [
     local.altinn_30_appmigration_test_developers,
@@ -166,9 +175,13 @@ locals {
     local.altinn_30_developers,
     local.altinn_30_developers_prod,
     local.dialogporten_developers,
-    local.dialogporten_developers_prod
+    local.dialogporten_developers_prod,
+    local.product_auth_developers_dev,
+    local.product_auth_developers_prod
   ]
   grafana_admin = [local.altinn_30_operations, local.altinn_30_operations_prod]
+
+  additional_subs_to_monitor = { for k, v in var.subs_to_monitor : k => sensitive(v) } # Create map where the value is sensitive to remove log outputs
 }
 
 resource "azurerm_role_assignment" "grafana_admin" {

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/variables.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/variables.tf
@@ -5,3 +5,8 @@ variable "insights_workspace_test_dp" {
     "dp-be-yt01-insightsWorkspace" = "dp-be-yt01-rg"
   }
 }
+
+variable "subs_to_monitor" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #2005 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Grafana granted cross-subscription monitoring read access so it can read monitoring data across multiple Azure subscriptions.
  - Editor access expanded to include additional developer groups for dashboard management.

- **Chores**
  - Deployment pipeline now supplies monitored subscription IDs to plan and deploy jobs from secrets.
  - Added a new subscriptions input to configure which subscriptions to monitor; values are handled sensitively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->