### PR TITLE
toil: add altinn-platform-validation-tests repo to platform product

### DIFF
--- a/products.yaml
+++ b/products.yaml
@@ -11,6 +11,7 @@ products:
       repositories:
         - altinn-platform
         - terraform-azurerm-altinn-modules
+        - altinn-platform-validation-tests
 
   - name: Authorization
     slug: PAA # Product Altinn Authorization


### PR DESCRIPTION
Need it to be able to trigger the tests in the K6 cluster via a Github Action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Platform product configuration to include an additional validation tests repository in its GitHub repositories list.
  * Ensures the repository inventory for Platform is current and complete, improving visibility and coordination across related codebases.
  * No changes to functionality or user interface; other products remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->