### PR TITLE
fix(admin-aks): new variable not added to adminservices test cluster

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
@@ -51,4 +51,5 @@ module "aks_resources" {
   grafana_dashboard_release_branch = "main"
   enable_grafana_operator          = true
   subscription_id                  = var.subscription_id
+  enable_cert_manager_tls_issuer   = false
 }

--- a/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
@@ -50,4 +50,5 @@ module "aks_resources" {
   token_grafana_operator           = var.token_grafana_operator
   grafana_dashboard_release_branch = "main"
   enable_grafana_operator          = true
+  subscription_id                  = var.subscription_id
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Standardized AKS provisioning for the admin services test environment by adding subscription context and disabling the cert-manager TLS issuer.
  * Enhances deployment consistency across environments; no functional, performance, or UI changes.
  * No expected downtime or user impact.
  * CI/CD pipelines will apply the updated configuration on the next deployment cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->