### PR TITLE
cleanup: Add env vars at archive time

### DIFF
--- a/actions/generate-k6-manifests/action.yml
+++ b/actions/generate-k6-manifests/action.yml
@@ -10,10 +10,6 @@ inputs:
     required: false
     default: ""
 
-  init_stage_env_vars:
-    description: "Extra environmental variables that might be needed in the init stage. e.g.: BROWSER_VUS=3 DURATION=10s"
-    required: false
-    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
This is a cleanup from something I hacked without giving much thought a while back.

The env vars that we configure on the conf.yaml file will only be available at runtime as k8s injects them into the container. The problem is that certain code portions run when we call the archive command and therefore we need to have the variable at that stage.

https://grafana.com/docs/k6/latest/reference/archive/#how-to-create-and-run-an-archive
https://grafana.com/docs/k6/latest/reference/archive/#what-an-archive-file-does-not-contain