### PR TITLE
chore: Upgrade Traefik and enhance monitoring configuration

### DIFF
--- a/flux/traefik/helmrelease.yaml
+++ b/flux/traefik/helmrelease.yaml
@@ -177,15 +177,8 @@ spec:
           metricRelabelings:
             - sourceLabels: [__name__]
               separator: ;
-              regex: >-
-                ^(traefik_service_requests_total|
-                  traefik_entrypoint_requests_total|
-                  traefik_service_request_duration_seconds_bucket|
-                  traefik_entrypoint_open_connections|
-                  traefik_service_open_connections|
-                  traefik_config_reloads_total|
-                  traefik_config_last_reload_success|
-                  traefik_tls_certs_not_after)$
+              # Metrics: requests, duration, connections, config health, TLS certs
+              regex: ^(traefik_service_requests_total|traefik_entrypoint_requests_total|traefik_service_request_duration_seconds_bucket|traefik_entrypoint_open_connections|traefik_service_open_connections|traefik_config_reloads_total|traefik_config_last_reload_success|traefik_tls_certs_not_after)$
               action: keep
           relabelings:
             - sourceLabels: [__meta_kubernetes_pod_node_name]


### PR DESCRIPTION
Updates Helm chart versions, adds Prometheus scraping annotations, and improves metrics collection by refining ServiceMonitor configuration and adding PrometheusRule API version.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Azure-compatible Prometheus integration (serviceMonitor/prometheusRule exposure), scrape annotations, refined relabeling to keep key Traefik metrics, and node-name relabeling for metrics; added public scrape settings (jobLabel, interval, honorLabels, namespaceSelector).

- **Bug Fixes**
  - Extended Linkerd skip-inbound-ports to include port 9100 to avoid tracing/metrics conflicts.

- **Chores**
  - Upgraded Traefik chart releases to newer versions and introduced Traefik label length limits.

- **Style**
  - Added explicit HTTP/HTTPS port mappings (internal 8000→80, 8443→443) with explanatory comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->