### PR TITLE
fix(dis-apim): set substitute to null if not provided

### DIFF
--- a/infrastructure/modules/dis-apim-operator/dis-apim.tf
+++ b/infrastructure/modules/dis-apim-operator/dis-apim.tf
@@ -14,7 +14,7 @@ resource "azapi_resource" "dis_apim_operator" {
               DISAPIM_RESOURCE_GROUP              = "${var.apim_resource_group_name}"
               DISAPIM_APIM_SERVICE_NAME           = "${var.apim_service_name}"
               DISAPIM_DEFAULT_LOGGER_ID           = "/subscriptions/${var.apim_subscription_id}/resourceGroups/${var.apim_resource_group_name}/providers/Microsoft.ApiManagement/service/${var.apim_service_name}/loggers/${var.default_logger_name}"
-              DISAPIM_NAMESPACE_SUFFIX            = "${var.namespace_suffix}"
+              DISAPIM_NAMESPACE_SUFFIX            = var.namespace_suffix == "" ? null : "${var.namespace_suffix}"
               DISAPIM_TARGET_NAMESPACE            = "${var.target_namespace}"
               DISAPIM_WORKLOAD_IDENTITY_CLIENT_ID = "${azurerm_user_assigned_identity.disapim_identity.client_id}"
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects handling of an optional namespace suffix during deployments, treating empty values as unset. Prevents malformed resource names and unexpected substitutions when the suffix is not provided, improving reliability across environments and pipelines.
- Chores
  - Streamlines configuration to reduce noise and align value handling across stages without impacting other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->