### PR TITLE
add ENVIRONMENT env var at archive time

### DIFF
--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -215,7 +215,7 @@ func (r K8sManifestGenerator) Generate() {
 
 				// Add Env Vars to archive
 				mergedEnvs := handleExtraEnvVars(envFileSlice, c.TestRun.Env)
-				var k6ArchiveArgs []string
+				k6ArchiveArgs := []string{"--env", fmt.Sprintf("%s=%s", "ENVIRONMENT", c.Environment)}
 				for _, env := range mergedEnvs {
 					// --env MY_USER_AGENT="hello"
 					k6ArchiveArgs = append(k6ArchiveArgs, "--env", fmt.Sprintf("%s=%s", *env.Name, *env.Value))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensures the ENVIRONMENT variable is always included when generating k6 archives/manifests, preventing misconfigured or environment-agnostic test runs.
  - Improves reliability of environment-specific settings in performance tests.

- **Chores**
  - Streamlined argument construction for k6 archive generation to reduce edge cases and improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->