### PR TITLE
chore(deps): update ghcr.io/altinn/altinn-platform/k6-action-image docker tag to v0.0.11

### DIFF
--- a/actions/generate-k6-manifests/Dockerfile
+++ b/actions/generate-k6-manifests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/altinn/altinn-platform/k6-action-image:v0.0.10@sha256:03d342a41d7db0ebd3179970617380a389b180754c05d9b2fcf036df8f9f2a70
+FROM ghcr.io/altinn/altinn-platform/k6-action-image:v0.0.11@sha256:30c448bd02cda6b34bb215d625760930c2a05feace5debea59c9a77a05027f24
 
 COPY generate.sh /generate.sh
 RUN chmod +x /generate.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the base runtime used for generating k6 manifests to a newer patch version, improving stability and security.
  * Set a default execution command to streamline container usage and reduce setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->