### PR TITLE
feat: clean up and add new service principals to acr-push list

### DIFF
--- a/infrastructure/adminservices-prod/altinncr/iam.tf
+++ b/infrastructure/adminservices-prod/altinncr/iam.tf
@@ -32,31 +32,3 @@ resource "azurerm_role_assignment" "altinncr_acrpush_altinn_platform" {
   scope                            = azurerm_container_registry.acr.id
   skip_service_principal_aad_check = true
 }
-
-resource "azurerm_role_assignment" "altinncr_writer_corr" {
-  principal_id         = "27bfa3f2-2b60-4de5-a3b9-09dd3b01b490"
-  role_definition_name = "AcrPush"
-  principal_type       = "ServicePrincipal"
-  scope                = azurerm_container_registry.acr.id
-}
-
-resource "azurerm_role_assignment" "altinncr_writer_corr_test" {
-  principal_id         = "d3c35a12-5465-4ba3-b50d-8ab1bedbef2a"
-  role_definition_name = "AcrPush"
-  principal_type       = "ServicePrincipal"
-  scope                = azurerm_container_registry.acr.id
-}
-
-resource "azurerm_role_assignment" "altinncr_writer_broker" {
-  principal_id         = "3f5e6dcb-b782-49ca-939f-fd21dda34e4e"
-  role_definition_name = "AcrPush"
-  principal_type       = "ServicePrincipal"
-  scope                = azurerm_container_registry.acr.id
-}
-
-resource "azurerm_role_assignment" "altinncr_writer_broker_test" {
-  principal_id         = "e5213800-3bdc-4f13-a212-0f4c8cd6c1ea"
-  role_definition_name = "AcrPush"
-  principal_type       = "ServicePrincipal"
-  scope                = azurerm_container_registry.acr.id
-}

--- a/infrastructure/adminservices-prod/altinncr/terraform.tfvars
+++ b/infrastructure/adminservices-prod/altinncr/terraform.tfvars
@@ -61,6 +61,34 @@ acr_push_object_ids = [
     object_id = "fc900cb0-fb05-45f9-be11-f4a663b3c9a3" # SP: GitHub: altinn/altinn-tools
     type      = "ServicePrincipal"
   },
+  {
+    object_id = "27bfa3f2-2b60-4de5-a3b9-09dd3b01b490" # SP: Github: altinn/correspondence-prod
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "d3c35a12-5465-4ba3-b50d-8ab1bedbef2a" # SP: Github: altinn/correspondence-test
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "e3d2ce71-0d61-4332-9d44-278aac2846ab" # SP: Github: altinn/correspondence-staging
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "3f5e6dcb-b782-49ca-939f-fd21dda34e4e" # SP: Github: altinn/broker-prod
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "e5213800-3bdc-4f13-a212-0f4c8cd6c1ea" # SP: Github: altinn/broker-test
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "512341b6-a349-4d08-8301-154a48a43b13" # SP: Github: altinn/altinn-studio dev
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "99357379-c461-45bc-b9e7-6a2a51ccdac0" # SP: Github: altinn/altinn-studio prod
+    type      = "ServicePrincipal"
+  }
 ]
 
 acr_pull_object_ids = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove explicit resources and leverage existing list for acr push permissions
Adde new service principals:
* correspondence staging
* altinn-studio dev
* altinn-studio prod

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Chores
  - Consolidated container registry push access and removed several individual push role assignments.
  - Extended the list of identities granted push access in configuration.
- Security
  - Updated mappings for who can push to the container registry; pull permissions unchanged.
- Impact
  - No downtime or functional changes expected for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->