### PR TITLE
chore(grafana): add grafana viewer role to skjermbruker

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -202,6 +202,13 @@ resource "azurerm_role_assignment" "grafana_editors" {
   skip_service_principal_aad_check = true
 }
 
+resource "azurerm_role_assignment" "grafna_monitors_viewer" {
+  scope                = azurerm_dashboard_grafana.grafana.id
+  role_definition_name = "Grafana Viewer"
+  principal_id         = "07a416db-8783-459b-a469-1e17ae37000d"
+  principal_type       = "User"
+}
+
 resource "azurerm_role_assignment" "log_analytics_reader" {
   principal_id                     = azurerm_dashboard_grafana.grafana.identity[0].principal_id
   scope                            = azurerm_log_analytics_workspace.application.id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Granted viewer access to Grafana dashboards in the adminservices-test environment by adding a new role assignment for read-only monitoring.
  - Change is limited to the test resource group and does not affect production or existing permissions.
  - No changes to scopes or roles already in place; purely additive access.
  - No downtime or user-facing disruptions expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->