### PR TITLE
chore: lock flux cli version.

### DIFF
--- a/actions/flux/setup-flux-acr/action.yaml
+++ b/actions/flux/setup-flux-acr/action.yaml
@@ -5,7 +5,8 @@ inputs:
   flux_version:
     description: "Version of flux to use"
     required: false
-    default: "latest"
+    # renovate: datasource=github-releases depName=flux-cli packageName=fluxcd/flux2 versioning=semver
+    default: "2.6.4"
     type: string
   azure_app_id:
     description: "Azure application id used to authenticate to altinncr"


### PR DESCRIPTION
2.7.0 broke the azure provider login again. Downgrade to previous version until fix is released

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the default Flux version to 2.6.4 (previously used “latest”) to ensure consistent, reproducible installs for users who don’t specify a version.
  * Added metadata to support automated dependency updates for the Flux version.
  * Impact: Workflows that don’t set flux_version will now use Flux 2.6.4 by default; workflows that already specify a version are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->