### PR TITLE
feat: configurable breakpoint tests

### DIFF
--- a/actions/generate-k6-manifests/cmd/default_scenarios.go
+++ b/actions/generate-k6-manifests/cmd/default_scenarios.go
@@ -1,0 +1,18 @@
+package cmd
+
+type BreakpointConfig struct {
+	Executor   string                 `json:"executor"`
+	Stages     []Stage                `json:"stages"`
+	Thresholds map[string][]Threshold `json:"thresholds"`
+}
+
+type Stage struct {
+	Duration string `json:"duration"`
+	Target   int    `json:"target"`
+}
+
+type Threshold struct {
+	Threshold      string `json:"threshold"`
+	AbortOnFail    bool   `json:"abortOnFail"`
+	DelayAbortEval string `json:"delayAbortEval"`
+}

--- a/infrastructure/images/k6-action/default_scenarios/breakpoint.json
+++ b/infrastructure/images/k6-action/default_scenarios/breakpoint.json
@@ -2,23 +2,23 @@
     "executor": "ramping-arrival-rate",
     "stages": [
         {
-            "duration": "2h",
-            "target": 20000
+            "duration": "10m",
+            "target": 100
         }
     ],
     "thresholds": {
         "http_req_failed": [
             {
-                "threshold": "rate<0.01",
+                "threshold": "rate==0.0",
                 "abortOnFail": true,
-                "delayAbortEval": "1s"
+                "delayAbortEval": "10s"
             }
         ],
         "http_req_duration": [
             {
-                "threshold": "p(95)<200",
+                "threshold": "max<5000",
                 "abortOnFail": true,
-                "delayAbortEval": "1s"
+                "delayAbortEval": "10s"
             }
         ]
     }


### PR DESCRIPTION
Hacky first attempt.

I've tested it in the new setup with a test from both Auth and Core and worked as expected. I think the interface will work for now but will definitely need a refactor in the future.

The interface matches what Dagfinn is running today so I'd rather keep this as is and finish migrating his tests to the new setup and then I can clean this up.


## Related Issue(s)
- #2273 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated support for "breakpoint" k6 scenarios with env-variable driven configuration.
  * New handling merges default breakpoint scenarios with BREAKPOINT_* environment overrides.

* **Changes**
  * Default "breakpoint" scenario ramp reduced to 10m and target set to 100.
  * Thresholds updated: http_req_failed -> rate==0.0; http_req_duration -> max<5000.
  * Abort-evaluation delays increased to 10s for relevant thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->