### PR TITLE
feat: append env vars passed as extra CLI args to the test run env

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -41,6 +41,22 @@
             {
                "name": "TESTID",
                "value": "{{ .UniqueName }}"
+            },
+            {
+               "name": "orgNoRecipient",
+               "value": "1234"
+            },
+            {
+               "name": "resourceId",
+               "value": "abcd"
+            },
+            {
+               "name": "runFullTestSet",
+               "value": "true"
+            },
+            {
+               "name": "tokenGeneratorUserName",
+               "value": "olanordmenn"
             }
          ],
          "envFrom": [


### PR DESCRIPTION
Allows us to override the certain parameters (e.g. BREAKPOINT_STAGE_DURATION and BREAKPOINT_STAGE_TARGET) in an ad-hoc manner when running it from the Github UI.

cli args of type -e || --env are also added to the TestRun env block now.

## Related Issue(s)
- #2273 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Inject environment variables into k6 test runs via command-line flags (-e/--env key=value); these are merged with per-test settings across enabled test types.
  - TestRun manifests now include additional default environment entries: orgNoRecipient (1234), resourceId (abcd), runFullTestSet (true), and tokenGeneratorUserName (olanordmenn), alongside TESTID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->