### PR TITLE
Update OCIRepository API version to v1

### DIFF
--- a/flux/dis-apim/oci-repository.yaml
+++ b/flux/dis-apim/oci-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: dis-apim-operator

--- a/flux/dis-identity/oci-repository.yaml
+++ b/flux/dis-identity/oci-repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: dis-identity-operator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The following Flux APIs are being deprecated and will be removed 25 October 2025:

Deprecated APIs in group source.toolkit.fluxcd.io/v1beta1
Deprecated APIs in group kustomize.toolkit.fluxcd.io/v1beta1
Deprecated APIs in group helm.toolkit.fluxcd.io/v2beta1
Deprecated APIs in group notification.toolkit.fluxcd.io/v1beta1
Deprecated APIs in group image.toolkit.fluxcd.io/v1beta1



## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
