### PR TITLE
Add Terraform module for standardized Azure tags

### DIFF
--- a/infrastructure/modules/tags/README.md
+++ b/infrastructure/modules/tags/README.md
@@ -1,0 +1,176 @@
+# Tags Terraform Module
+
+This Terraform module provides standardized tags for Azure resources following Altinn FinOps requirements (Fase 1: Kostnadsfordeling). It creates a consistent set of tags that can be applied across all resources in your infrastructure to improve cost tracking, governance, and resource management.
+
+## Features
+
+- Standardized FinOps tags for cost allocation and tracking
+- Automatic creation and modification timestamps
+- Lowercase normalization of key values
+- Repository tracking for infrastructure as code traceability
+
+## Usage
+
+### Basic Example
+
+```hcl
+module "tags" {
+  source                      = "./modules/tags"
+  finops_environment          = "prod"
+  finops_product              = "dialogporten"
+  finops_serviceownercode     = "skd"
+  finops_serviceownerorgnr    = "974761076"
+  finops_capacity             = "2vcpu"
+  repository                  = "github.com/altinn/dialogporten"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "mystorageaccount"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  tags                     = module.tags.tags
+}
+```
+
+### Complete Example with Resource Group
+
+```hcl
+module "tags" {
+  source                      = "./modules/tags"
+  finops_environment          = "dev"
+  finops_product              = "studio"
+  finops_serviceownercode     = "skd"
+  finops_serviceownerorgnr    = "974761076"
+  finops_capacity             = "4vcpu"
+  repository                  = "github.com/altinn/altinn-studio"
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "rg-studio-dev"
+  location = "Norway East"
+  tags     = module.tags.tags
+}
+
+resource "azurerm_app_service_plan" "main" {
+  name                = "plan-studio-dev"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+  
+  tags = module.tags.tags
+}
+```
+
+## Variables
+
+| Name | Description | Type | Required | Validation | Example |
+|------|-------------|------|----------|------------|---------|
+| `finops_environment` | Environment designation for cost allocation | `string` | Yes | Must be one of: `dev`, `test`, `prod`, `at22`, `at23`, `at24`, `yt01`, `tt02` | `"prod"` |
+| `finops_product` | Product name for cost allocation | `string` | Yes | Must be one of: `studio`, `dialogporten`, `formidling`, `autorisasjon`, `varsling`, `melding`, `altinn2` | `"dialogporten"` |
+| `finops_serviceownercode` | Service owner code for billing attribution | `string` | Yes | Must be `skd`, `udir`, `nav`, `na`, or 2-5 lowercase letters | `"skd"` |
+| `finops_serviceownerorgnr` | Service owner organization number (9 digits) | `string` | Yes | Exactly 9 digits | `"974761076"` |
+| `finops_capacity` | Capacity specification for cost optimization | `string` | Yes | Format: `{number}vcpu` (e.g., 2vcpu, 4vcpu, 8vcpu) | `"2vcpu"` |
+| `repository` | Repository URL for infrastructure traceability | `string` | Yes | Must be from `github.com/altinn/` organization | `"github.com/altinn/dialogporten"` |
+| `createdby` | Who or what created the resource | `string` | No (default: "terraform") | Must be `terraform`, `azure-policy`, or valid username | `"terraform"` |
+| `modifiedby` | Who or what last modified the resource | `string` | No (default: "terraform") | Must be `terraform`, `azure-policy`, or valid username | `"terraform"` |
+
+## Outputs
+
+| Name | Description | Type |
+|------|-------------|------|
+| `tags` | Map of all standardized tags | `map(string)` |
+| `finops_environment` | Normalized environment name | `string` |
+| `finops_product` | Normalized product name | `string` |
+| `finops_serviceownercode` | Normalized service owner code | `string` |
+| `finops_serviceownerorgnr` | Service owner organization number | `string` |
+| `finops_capacity` | Normalized capacity specification | `string` |
+| `repository` | Normalized repository URL | `string` |
+| `createdby` | Who or what created the resource | `string` |
+| `modifiedby` | Who or what last modified the resource | `string` |
+| `created_date` | Date when the tags were created | `string` |
+| `modified_date` | Date when the tags were last modified | `string` |
+
+## Generated Tags
+
+The module automatically generates the following tags according to Altinn FinOps requirements:
+
+### FinOps Tags (5 tags with "finops_" prefix)
+| Tag Name | Description | Example Value |
+|----------|-------------|---------------|
+| `finops_environment` | Environment for cost separation | `"prod"` |
+| `finops_product` | Main product allocation for cost distribution | `"dialogporten"` |
+| `finops_serviceownercode` | Service owner code for billing | `"skd"` |
+| `finops_serviceownerorgnr` | Formal service owner identification | `"974761076"` |
+| `finops_capacity` | Capacity planning and cost optimization | `"2vcpu"` |
+
+### Traceability Tags (5 tags)
+| Tag Name | Description | Example Value |
+|----------|-------------|---------------|
+| `createdby` | Who/what created the resource | `"terraform"` |
+| `createddate` | Resource creation date (YYYY-MM-DD) | `"2024-01-15"` |
+| `modifiedby` | Who/what last modified the resource | `"terraform"` |
+| `modifieddate` | Last modification date (YYYY-MM-DD) | `"2024-01-15"` |
+| `repository` | IaC repository for traceability | `"github.com/altinn/dialogporten"` |
+
+## Best Practices
+
+1. **Consistent Application**: Apply the same tags module across all your Azure resources for consistent cost tracking and governance.
+
+2. **Environment Naming**: Use only the approved environment values: `dev`, `test`, `prod`, `at22`, `at23`, `at24`, `yt01`, `tt02`.
+
+3. **Product Names**: Use only approved product names: `studio`, `dialogporten`, `formidling`, `autorisasjon`, `varsling`, `melding`, `altinn2`.
+
+4. **Capacity Format**: Always use the format `{number}vcpu` (e.g., `2vcpu`, `4vcpu`, `8vcpu`) for capacity specification.
+
+5. **Service Owner Codes**: Use approved codes (`skd`, `udir`, `nav`, `na`) or follow the 2-5 lowercase letter pattern.
+
+6. **Repository URLs**: Always use repositories from `github.com/altinn/` organization for traceability.
+
+7. **Lowercase Convention**: All tag names are lowercase and singular, values are normalized to lowercase where appropriate.
+
+## FinOps Integration
+
+These tags are designed to support FinOps practices by providing:
+
+- **Cost Allocation**: Tags enable accurate cost allocation across products, environments, and teams
+- **Resource Governance**: Consistent tagging helps with resource lifecycle management
+- **Compliance**: Standardized tags support compliance and audit requirements
+- **Automation**: Tags can be used for automated resource management and policies
+
+## Module Structure
+
+The module is organized into the following files:
+
+- `variables.tf` - Input variable definitions with validation rules
+- `locals.tf` - Tag computation and normalization logic
+- `outputs.tf` - Output definitions for consuming modules
+- `versions.tf` - Terraform and provider version constraints
+- `tags.tf` - Main module documentation and organization
+- `README.md` - This documentation file
+
+## Validation Rules
+
+The module includes built-in validation to ensure compliance with Altinn FinOps requirements:
+
+- **Environment**: Must be exactly one of `dev`, `test`, `prod`, `at22`, `at23`, `at24`, `yt01`, `tt02`
+- **Product**: Must be exactly one of `studio`, `dialogporten`, `formidling`, `autorisasjon`, `varsling`, `melding`, `altinn2`
+- **Service Owner Code**: Must be `skd`, `udir`, `nav`, `na`, or 2-5 lowercase letters
+- **Organization Number**: Must be exactly 9 digits
+- **Capacity**: Must follow format `{number}vcpu` (e.g., 2vcpu, 4vcpu, 8vcpu)
+- **Repository**: Must be from `github.com/altinn/` organization
+- **Created/Modified By**: Must be `terraform`, `azure-policy`, or valid username format
+
+## Requirements
+
+- Terraform >= 1.0
+- Time Provider ~> 0.9
+
+## License
+
+This module is maintained as part of the Altinn platform infrastructure.

--- a/infrastructure/modules/tags/locals.tf
+++ b/infrastructure/modules/tags/locals.tf
@@ -1,0 +1,17 @@
+locals {
+  today = formatdate("YYYY-MM-DD", timestamp())
+
+  # Normalize values to lowercase where appropriate and build standardized tags
+  tags = {
+    finops_environment       = lower(var.finops_environment)
+    finops_product           = lower(var.finops_product)
+    finops_serviceownercode  = lower(var.finops_serviceownercode)
+    finops_serviceownerorgnr = var.finops_serviceownerorgnr
+    finops_capacity          = lower(var.finops_capacity)
+    createdby                = lower(var.createdby)
+    createddate              = local.today
+    modifiedby               = lower(var.modifiedby)
+    modifieddate             = local.today
+    repository               = lower(var.repository)
+  }
+}

--- a/infrastructure/modules/tags/outputs.tf
+++ b/infrastructure/modules/tags/outputs.tf
@@ -1,0 +1,54 @@
+output "tags" {
+  description = "Map of all standardized tags for resource tagging"
+  value       = local.tags
+}
+
+output "finops_environment" {
+  description = "Normalized environment name"
+  value       = local.tags.finops_environment
+}
+
+output "finops_product" {
+  description = "Normalized product name"
+  value       = local.tags.finops_product
+}
+
+output "finops_serviceownercode" {
+  description = "Normalized service owner code"
+  value       = local.tags.finops_serviceownercode
+}
+
+output "finops_serviceownerorgnr" {
+  description = "Service owner organization number"
+  value       = local.tags.finops_serviceownerorgnr
+}
+
+output "finops_capacity" {
+  description = "Normalized capacity specification"
+  value       = local.tags.finops_capacity
+}
+
+output "repository" {
+  description = "Normalized repository URL"
+  value       = local.tags.repository
+}
+
+output "createdby" {
+  description = "Who or what created the resource"
+  value       = local.tags.createdby
+}
+
+output "modifiedby" {
+  description = "Who or what last modified the resource"
+  value       = local.tags.modifiedby
+}
+
+output "created_date" {
+  description = "Date when the tags were created"
+  value       = local.tags.createddate
+}
+
+output "modified_date" {
+  description = "Date when the tags were last modified"
+  value       = local.tags.modifieddate
+}

--- a/infrastructure/modules/tags/tags.tf
+++ b/infrastructure/modules/tags/tags.tf
@@ -1,0 +1,10 @@
+# Main tags configuration file
+# This file serves as the primary entry point for the tags module
+
+# All logic is defined in other files:
+# - variables.tf: Input variable definitions and validation
+# - locals.tf: Tag computation and normalization logic
+# - outputs.tf: Output definitions for consuming modules
+# - providers.tf: Provider requirements and version constraints
+
+# This file intentionally kept minimal to maintain clear separation of concerns

--- a/infrastructure/modules/tags/variables.tf
+++ b/infrastructure/modules/tags/variables.tf
@@ -1,0 +1,81 @@
+variable "finops_environment" {
+  description = "Environment designation for cost allocation"
+  type        = string
+
+  validation {
+    condition     = can(regex("^(dev|test|prod|at22|at23|at24|yt01|tt02)$", var.finops_environment))
+    error_message = "Environment must be one of: dev, test, prod, at22, at23, at24, yt01, tt02."
+  }
+}
+
+variable "finops_product" {
+  description = "Product name for cost allocation"
+  type        = string
+
+  validation {
+    condition     = can(regex("^(studio|dialogporten|formidling|autorisasjon|varsling|melding|altinn2)$", var.finops_product))
+    error_message = "Product must be one of: studio, dialogporten, formidling, autorisasjon, varsling, melding, altinn2."
+  }
+}
+
+variable "finops_serviceownercode" {
+  description = "Service owner code for billing attribution"
+  type        = string
+
+  validation {
+    condition     = can(regex("^(skd|udir|nav|na|[a-z]{2,5})$", var.finops_serviceownercode))
+    error_message = "Service owner code must be skd, udir, nav, na, or 2-5 lowercase letters."
+  }
+}
+
+variable "finops_serviceownerorgnr" {
+  description = "Service owner organization number (9 digits)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{9}$", var.finops_serviceownerorgnr))
+    error_message = "Service owner organization number must be exactly 9 digits."
+  }
+}
+
+variable "finops_capacity" {
+  description = "Capacity specification (e.g., 2vcpu, 4vcpu, 8vcpu)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]+vcpu$", var.finops_capacity))
+    error_message = "Capacity must be in format: {number}vcpu (e.g., 2vcpu, 4vcpu, 8vcpu)."
+  }
+}
+
+variable "repository" {
+  description = "Repository URL for infrastructure as code traceability"
+  type        = string
+
+  validation {
+    condition     = can(regex("^github\\.com/altinn/", var.repository))
+    error_message = "Repository must be from github.com/altinn/ organization."
+  }
+}
+
+variable "createdby" {
+  description = "Who or what created the resource"
+  type        = string
+  default     = "terraform"
+
+  validation {
+    condition     = can(regex("^(terraform|azure-policy|[a-z0-9._-]+)$", var.createdby))
+    error_message = "createdby must be 'terraform', 'azure-policy', or a valid username."
+  }
+}
+
+variable "modifiedby" {
+  description = "Who or what last modified the resource"
+  type        = string
+  default     = "terraform"
+
+  validation {
+    condition     = can(regex("^(terraform|azure-policy|[a-z0-9._-]+)$", var.modifiedby))
+    error_message = "modifiedby must be 'terraform', 'azure-policy', or a valid username."
+  }
+}

--- a/infrastructure/modules/tags/versions.tf
+++ b/infrastructure/modules/tags/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+}


### PR DESCRIPTION
The above commit adds a new Terraform module for managing standardized Azure resource tags according to Altinn FinOps requirements. It provides a consistent way to apply and validate cost allocation, governance, and traceability tags.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
