### PR TITLE
Deploy bigger nodes

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -98,17 +98,37 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
 resource "azurerm_kubernetes_cluster_node_pool" "spot" {
   name                  = "spot"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
-  vm_size               = "Standard_DS2_v2"
+  vm_size               = "Standard_D3_v2"
   auto_scaling_enabled  = true
   node_count            = 0
   min_count             = 0
-  max_count             = 1
+  max_count             = 3
   priority              = "Spot"
   eviction_policy       = "Delete"
   spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
   node_labels = {
     "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
     spot : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
+  name                  = "spot8c28g"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D4_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 3
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot8cpu28gbmem : true
   }
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
@@ -45,17 +45,38 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
 resource "azurerm_kubernetes_cluster_node_pool" "spot" {
   name                  = "spot"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
-  vm_size               = "Standard_DS2_v2"
+  vm_size               = "Standard_D3_v2"
   auto_scaling_enabled  = true
   node_count            = 0
   min_count             = 0
-  max_count             = 10
+  max_count             = 3
   priority              = "Spot"
   eviction_policy       = "Delete"
   spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
   max_pods              = 200
   node_labels = {
     "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
+  name                  = "spot8c28g"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D4_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 3
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot8cpu28gbmem : true
   }
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure

--- a/infrastructure/images/k6-action/infra/k6_cluster_conf.yaml
+++ b/infrastructure/images/k6-action/infra/k6_cluster_conf.yaml
@@ -11,6 +11,17 @@ node_types:
         operator: "Equal"
         value: "spot"
         effect: "NoSchedule"
+  spot8cpu28gbmem:
+    nodeSelector:
+      - label: "kubernetes.azure.com/scalesetpriority"
+        value: "spot"
+      - label: spot8cpu28gbmem
+        value: true
+    tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
   default:
     nodeSelector: []
     tolerations: []


### PR DESCRIPTION
When I first tested having a spot node pool I deployed less powerful nodes to keep costs down.
Yesterday we were running some breakpoint tests and realized that 😅.

This PR bumps the nodes of the spot node pool and deploys a second node pool with even beefier nodes that we can use if we think the bottleneck is the node we are running the tests from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a high-capacity Spot node pool (8 vCPU/28 GB) with autoscaling for test clusters.
  - Introduced a corresponding node type in the k6 cluster config to target the new pool.

- Chores
  - Updated existing Spot pool VM size and autoscaling limits.
  - Standardized labels and taints for Spot scheduling across node pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->