### PR TITLE
Define mandatory temporary_name_for_rotation

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -113,6 +113,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
   ]
+
+  temporary_name_for_rotation = "tmpspot"
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
@@ -133,6 +135,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
   ]
+  temporary_name_for_rotation = "tmpd8c28g"
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
@@ -153,4 +156,5 @@ resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
     max_surge                     = "10%"
     node_soak_duration_in_minutes = 0
   }
+  temporary_name_for_rotation = "tmpprom"
 }

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
@@ -61,6 +61,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
   ]
+  temporary_name_for_rotation = "tmpspot"
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
@@ -81,6 +82,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
   node_taints = [
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
   ]
+  temporary_name_for_rotation = "tmpd8c28g"
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
@@ -101,4 +103,5 @@ resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
     max_surge                     = "10%"
     node_soak_duration_in_minutes = 0
   }
+  temporary_name_for_rotation = "tmpprom"
 }


### PR DESCRIPTION
>  │ Error: `temporary_name_for_rotation` must be specified when updating any of the following properties ["fips_enabled" "host_encryption_enabled" "kubelet_config" "kubelet_disk_type" "linux_os_config" "max_pods" "node_public_ip_enabled" "os_disk_size_gb" "os_disk_type" "pod_subnet_id" "snapshot_id" "ultra_ssd_enabled" "vm_size" "vnet_subnet_id" "zones"]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced k6 test Kubernetes node pools with temporary names to enable safe rotation.
  * Improves stability and maintenance of spot-based and monitoring node pools during updates.
  * No user-facing behavior changes; operational resilience in the test environment is increased.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->