### PR TITLE
chore(deps): update ghcr.io/altinn/altinn-platform/k6-action-image docker tag to v0.0.14

### DIFF
--- a/actions/generate-k6-manifests/Dockerfile
+++ b/actions/generate-k6-manifests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/altinn/altinn-platform/k6-action-image:v0.0.13@sha256:c947c451de4a41632b5985f71ba4cb5cbc835620fcfaf8651bc050f8b7ef9ac1
+FROM ghcr.io/altinn/altinn-platform/k6-action-image:v0.0.14@sha256:02065e5e68914e9082bc032bc4ca5e287d3b76b56fe814d57cfdbad74bef0041
 
 COPY generate.sh /generate.sh
 RUN chmod +x /generate.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image for the k6 manifests generator from v0.0.13 to v0.0.14.
  * No changes to behavior or configuration; users should not notice differences during execution.
  * The action now runs on the latest image version, and pipelines using this action will automatically adopt the update on their next run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->