### PR TITLE
Add missing config to esbuild

### DIFF
--- a/libs/k6/package.json
+++ b/libs/k6/package.json
@@ -14,7 +14,7 @@
     "scripts": {
         "lint": "eslint --max-warnings 0 src",
         "fix": "eslint --fix src",
-        "build": "esbuild ./src/index.js --external:k6/http --bundle --sourcemap --minify --format=cjs --legal-comments=none --outfile=./build/index.js",
+        "build": "esbuild ./src/index.js --external:k6/http --external:k6/encoding --bundle --sourcemap --minify --format=cjs --legal-comments=none --outfile=./build/index.js",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "keywords": [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to treat the k6/encoding module as external, alongside k6/http, preventing it from being bundled and aligning with existing externalization behavior.
  * Results in leaner bundles and improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->