### PR TITLE
chore: make azuread version requirements allow all newer versions

### DIFF
--- a/infrastructure/modules/observability/providers.tf
+++ b/infrastructure/modules/observability/providers.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.5.0"
+      version = ">= 3.6.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To avoid having to upgrade for every version lets allow all versions newer than 3.6.0 (latest)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure provider version constraint to require a minimum version, ensuring compatibility with newer provider releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->