### PR TITLE
Add variables for resource group creation and dashboard name

### DIFF
--- a/infrastructure/modules/grafana/README.md
+++ b/infrastructure/modules/grafana/README.md
@@ -36,8 +36,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azurerm_resource_group_grafana_name"></a> [azurerm\_resource\_group\_grafana\_name](#input\_azurerm\_resource\_group\_grafana\_name) | Optional explicit name of the grafana resource group | `string` | `""` | no |
 | <a name="input_client_config_current_object_id"></a> [client\_config\_current\_object\_id](#input\_client\_config\_current\_object\_id) | Object id for pipeline runner id | `string` | n/a | yes |
+| <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Whether to create a new resource group. If false, will use an existing resource group specified by resource\_group\_name. | `bool` | `true` | no |
+| <a name="input_dashboard_name"></a> [dashboard\_name](#input\_dashboard\_name) | Name of Grafana dashboard. If not provided, generates 'grafana-{prefix}-{environment}'. | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment for resources | `string` | n/a | yes |
 | <a name="input_grafana_admin_access"></a> [grafana\_admin\_access](#input\_grafana\_admin\_access) | List of user groups to grant admin access to grafana. | `list(string)` | `[]` | no |
 | <a name="input_grafana_editor_access"></a> [grafana\_editor\_access](#input\_grafana\_editor\_access) | List of user groups to grant editor access to grafana. | `list(string)` | `[]` | no |
@@ -47,6 +48,7 @@ No modules.
 | <a name="input_location"></a> [location](#input\_location) | Default region for resources | `string` | `"norwayeast"` | no |
 | <a name="input_monitor_workspace_ids"></a> [monitor\_workspace\_ids](#input\_monitor\_workspace\_ids) | List of azure monitor workspaces to connect grafana. | `map(string)` | `{}` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for resource names | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group. When create\_resource\_group is true, uses this name if provided, otherwise generates 'grafana-{prefix}-{environment}-rg'. When create\_resource\_group is false, this is required and must be the name of an existing resource group. | `string` | `""` | no |
 
 ## Outputs
 

--- a/infrastructure/modules/grafana/grafana.tf
+++ b/infrastructure/modules/grafana/grafana.tf
@@ -1,5 +1,7 @@
+# Create resource group only if create_resource_group is true
 resource "azurerm_resource_group" "grafana" {
-  name     = var.azurerm_resource_group_grafana_name != "" ? var.azurerm_resource_group_grafana_name : "grafana-${var.prefix}-${var.environment}-rg"
+  count    = var.create_resource_group ? 1 : 0
+  name     = var.resource_group_name != "" ? var.resource_group_name : "grafana-${var.prefix}-${var.environment}-rg"
   location = var.location
   tags = merge(var.localtags, {
     submodule = "grafana"
@@ -7,9 +9,9 @@ resource "azurerm_resource_group" "grafana" {
 }
 
 resource "azurerm_dashboard_grafana" "grafana" {
-  name                              = "grafana-${var.prefix}-${var.environment}"
-  resource_group_name               = azurerm_resource_group.grafana.name
-  location                          = azurerm_resource_group.grafana.location
+  name                              = var.dashboard_name != "" ? var.dashboard_name : "grafana-${var.prefix}-${var.environment}"
+  resource_group_name               = var.create_resource_group ? azurerm_resource_group.grafana[0].name : var.resource_group_name
+  location                          = var.location
   api_key_enabled                   = true
   deterministic_outbound_ip_enabled = true
   grafana_major_version             = var.grafana_major_version

--- a/infrastructure/modules/grafana/variables.tf
+++ b/infrastructure/modules/grafana/variables.tf
@@ -1,7 +1,24 @@
-variable "azurerm_resource_group_grafana_name" {
+variable "create_resource_group" {
+  type        = bool
+  default     = true
+  description = "Whether to create a new resource group. If false, will use an existing resource group specified by resource_group_name."
+}
+
+variable "resource_group_name" {
   type        = string
   default     = ""
-  description = "Optional explicit name of the grafana resource group"
+  description = "Name of the resource group. When create_resource_group is true, uses this name if provided, otherwise generates 'grafana-{prefix}-{environment}-rg'. When create_resource_group is false, this is required and must be the name of an existing resource group."
+
+  validation {
+    condition     = var.create_resource_group ? true : var.resource_group_name != ""
+    error_message = "When create_resource_group is false, resource_group_name must be provided."
+  }
+}
+
+variable "dashboard_name" {
+  type        = string
+  default     = ""
+  description = "Name of Grafana dashboard. If not provided, generates 'grafana-{prefix}-{environment}'."
 }
 
 variable "client_config_current_object_id" {


### PR DESCRIPTION
Introduce `create_resource_group` and `resource_group_name` variables to allow conditional resource group creation. Add a `dashboard_name` variable with a description for customizing the Grafana dashboard name.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Infrastructure module now provides flexible resource group management, allowing you to create new resource groups or use existing ones based on your deployment needs
  * Added customizable naming options for resource groups and dashboards with intelligent automatic defaults when not explicitly configured
  * Enhanced tagging support for improved resource organization and tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->