### PR TITLE
fix: flux blackbox exporter ns linkerd enable true

### DIFF
--- a/flux/blackbox-exporter/base/namespace.yaml
+++ b/flux/blackbox-exporter/base/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  annotations:
+    linkerd.io/inject: enabled


### PR DESCRIPTION
Add annotation to the monitoring namespace to enable Linkerd injection for better service mesh integration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced monitoring namespace configuration with Linkerd service mesh integration to improve infrastructure observability capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->