### PR TITLE
Fix: App cluster env post assignment team name

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-cluster-establishment.yml
+++ b/.github/ISSUE_TEMPLATE/app-cluster-establishment.yml
@@ -57,7 +57,7 @@ body:
           required: false
         - label: "Add DNS record for cluster"
           required: false
-        - label: "Assign CRM ticket to Team Studio"
+        - label: "Assign CRM ticket to \"Altinn servicedesk\""
           required: false
 
   - type: textarea


### PR DESCRIPTION
Team name changed as the handler of the app-cluster environment in the GitHub template.

## Description
Team name changed as the handler of the app-cluster environment in the GitHub template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue template assignment label for infrastructure tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->