### PR TITLE
bugfix: fix possible weird behavior due to race condition

### DIFF
--- a/infrastructure/images/k6-action/.trivyignore
+++ b/infrastructure/images/k6-action/.trivyignore
@@ -10,3 +10,21 @@ CVE-2025-47907
 
 # If the PATH environment variable contains paths which are executables (rather than just directories), passing certain strings to LookPath (, ., and ..), can result in the binaries listed in the PATH being unexpectedly returned.
 CVE-2025-47906
+
+# The Parse function permits values other than IPv6 addresses to be included in square brackets within the host component of a URL
+CVE-2025-47912
+
+# tar.Reader does not set a maximum size on the number of sparse region data blocks in GNU tar pax 1.0 sparse files. A maliciously-crafted archive containing a large number of sparse regions can cause a Reader to read an unbounded amount of data from the archive into memory. When reading from a compressed source, a small compressed input can result in large allocations.
+CVE-2025-58183
+
+# Despite HTTP headers having a default limit of 1MB, the number of cookies that can be parsed does not have a limit. By sending a lot of very small cookies such as a=;, an attacker can make an HTTP server allocate a large amount of structs, causing large memory consumption.
+CVE-2025-58186
+
+# Due to the design of the name constraint checking algorithm, the processing time of some inputs scals non-linearly with respect to the size of the certificate. This affects programs which validate arbitrary certificate chains.
+CVE-2025-58187
+
+# Validating certificate chains which contain DSA public keys can cause programs to panic, due to a interface cast that assumes they implement the Equal method. This affects programs which validate arbitrary certificate chains.
+CVE-2025-58188
+
+# The Reader.ReadResponse function constructs a response string through repeated string concatenation of lines. When the number of lines in a response is large, this can cause excessive CPU consumption.
+CVE-2025-61724

--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.25-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc
 # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
 ARG KUBECTL_VERSION=1.34.1
 # renovate: datasource=github-releases depName=kubeseal packageName=bitnami-labs/sealed-secrets versioning=semver extractVersion=^sealed-secrets-(?<version>.*)$
-ARG KUBESEAL_VERSION=0.30.0
+ARG KUBESEAL_VERSION=0.33.1
 # renovate: datasource=github-releases depName=jsonnet packageName=google/jsonnet versioning=semver
 ARG JSONNET_VERSION=0.21.0
 # renovate: datasource=github-releases depName=k6 packageName=grafana/k6 versioning=semver

--- a/infrastructure/images/k6-action/jsonnet/main.jsonnet
+++ b/infrastructure/images/k6-action/jsonnet/main.jsonnet
@@ -2,7 +2,7 @@ local k = import 'github.com/jsonnet-libs/k8s-libsonnet/1.32/main.libsonnet';
 local k6ClusterYamlConf = std.parseYaml(std.extVar('k6clusterconfig'));
 // Global
 local unique_name = std.extVar('unique_name');
-local dir_name = std.extVar('dir_name');
+local configmap_name = std.extVar('configmap_name');
 local test_name = std.extVar('test_name');
 local manifest_generation_timestamp = std.extVar('manifest_generation_timestamp');
 local namespace = std.extVar('namespace');
@@ -103,7 +103,7 @@ local testrun = {
       parallelism: parallelism,
       script: {
         configMap: {
-          name: dir_name,
+          name: configmap_name,
           file: 'archive.tar',
         },
       },


### PR DESCRIPTION
I need to have a look at the code more deeply as I'm sure I can simplify some stuff now that we have a tested and working setup.

This is a quick PR just to fix possible race condition problems due to the configmap name being the same for all the different test types. e.g. since a breakpoint test is using spot nodes and those scale down to 0, it can happen than the test is triggered and the configmap updated, but as the pod is waiting for a node, a functional test might update the configmap and then the configmap that gets mounted into the pod is the one with the functional test config instead of the breakpoint config.

```
yt01-so-should-send-notification         1      31d
yt01-so-should-send-notification-break   1      8m13s
```

Hijacking the PR and bumping the kubeseal version as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated manifests now use a stable configMap name (adds "-break" for breakpoint tests) and include a runner envFrom reference so runner env vars can come from the ConfigMap.

* **Chores**
  * Bumped kubeseal to 0.33.1.
  * Added several CVE entries to the image vulnerability ignore list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->