### PR TITLE
chore: Update Ubuntu 24.04 base image digest

### DIFF
--- a/infrastructure/images/azure-devops-agent/Dockerfile
+++ b/infrastructure/images/azure-devops-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252
+FROM ubuntu:24.04@sha256:e96e81f410a9f9cae717e6cdd88cc2a499700ff0bb5061876ad24377fcc517d7
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Fix scan and build pipeline for runners

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base container image to a new pinned digest to preserve reproducible builds.
  * Relaxed the infrastructure provider version constraint to allow newer provider releases.

* **Configuration**
  * AKS diagnostic settings no longer collect metrics; only logs will be retained (metrics will not appear in monitoring).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->