### PR TITLE
fix: Move Renovate helm annotations to own lines

### DIFF
--- a/flux/azure-service-operator/helm-release.yaml
+++ b/flux/azure-service-operator/helm-release.yaml
@@ -14,7 +14,8 @@ spec:
   chart:
     spec:
       chart: azure-service-operator
-      version: "v2.14.0" # renovate: datasource=helm registryUrl=https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts packageName=azure-service-operator
+      # renovate: datasource=helm registryUrl=https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts packageName=azure-service-operator
+      version: "v2.14.0"
       sourceRef:
         kind: HelmRepository
         name: aso2

--- a/flux/blackbox-exporter/base/helmrelease.yaml
+++ b/flux/blackbox-exporter/base/helmrelease.yaml
@@ -11,7 +11,8 @@ spec:
         kind: HelmRepository
         name: prometheus-community
         namespace: monitoring
-      version: 11.4.1 # renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts packageName=prometheus-blackbox-exporter
+      # renovate: datasource=helm registryUrl=https://prometheus-community.github.io/helm-charts packageName=prometheus-blackbox-exporter
+      version: 11.4.1
   interval: 1h
   timeout: 5m
   install:

--- a/flux/cert-manager/helmrelease.yaml
+++ b/flux/cert-manager/helmrelease.yaml
@@ -11,7 +11,8 @@ spec:
         kind: HelmRepository
         name: jetstack
         namespace: cert-manager
-      version: 1.18.2 # renovate: datasource=helm registryUrl=https://charts.jetstack.io packageName=cert-manager
+      # renovate: datasource=helm registryUrl=https://charts.jetstack.io packageName=cert-manager
+      version: 1.18.2
   interval: 1h
   timeout: 5m
   install:

--- a/flux/external-secrets-operator/helmrelease.yaml
+++ b/flux/external-secrets-operator/helmrelease.yaml
@@ -7,7 +7,8 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 0.16.2 # renovate: datasource=helm registryUrl=oci://ghcr.io/external-secrets/charts packageName=external-secrets
+      # renovate: datasource=helm registryUrl=oci://ghcr.io/external-secrets/charts packageName=external-secrets
+      version: 0.16.2
       sourceRef:
         kind: HelmRepository
         name: external-secrets

--- a/flux/grafana-operator/helmrelease.yaml
+++ b/flux/grafana-operator/helmrelease.yaml
@@ -12,7 +12,8 @@ spec:
         kind: HelmRepository
         name: grafana
         namespace: grafana
-      version: v5.20.0 # renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts packageName=grafana-operator
+      # renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts packageName=grafana-operator
+      version: v5.20.0
   interval: 1h
   timeout: 5m
   install:

--- a/flux/linkerd/helmrelease.yaml
+++ b/flux/linkerd/helmrelease.yaml
@@ -12,7 +12,8 @@ spec:
         kind: HelmRepository
         name: linkerd
         namespace: linkerd
-      version: 2025.7.6 # renovate: datasource=helm registryUrl=https://helm.linkerd.io/edge packageName=linkerd-crds
+      # renovate: datasource=helm registryUrl=https://helm.linkerd.io/edge packageName=linkerd-crds
+      version: 2025.7.6
   interval: 1h
   timeout: 5m
   install:
@@ -36,7 +37,8 @@ spec:
         kind: HelmRepository
         name: linkerd
         namespace: linkerd
-      version: 2025.7.6 # renovate: datasource=helm registryUrl=https://helm.linkerd.io/edge packageName=linkerd-control-plane
+      # renovate: datasource=helm registryUrl=https://helm.linkerd.io/edge packageName=linkerd-control-plane
+      version: 2025.7.6
   interval: 1h
   timeout: 10m
   dependsOn:

--- a/flux/otel-operator/helmrelease.yaml
+++ b/flux/otel-operator/helmrelease.yaml
@@ -19,7 +19,8 @@ spec:
         kind: HelmRepository
         name: otel-oci
         namespace: monitoring
-      version: 0.99.0 # renovate: datasource=helm registryUrl=oci://ghcr.io/open-telemetry/opentelemetry-helm-charts packageName=opentelemetry-operator
+      # renovate: datasource=helm registryUrl=oci://ghcr.io/open-telemetry/opentelemetry-helm-charts packageName=opentelemetry-operator
+      version: 0.99.0
   values:
     manager:
       image:

--- a/flux/traefik/helmrelease.yaml
+++ b/flux/traefik/helmrelease.yaml
@@ -12,7 +12,8 @@ spec:
         kind: HelmRepository
         name: traefik
         namespace: traefik
-      version: 1.11.0 # renovate: datasource=helm registryUrl=https://traefik.github.io/charts packageName=traefik-crds
+      # renovate: datasource=helm registryUrl=https://traefik.github.io/charts packageName=traefik-crds
+      version: 1.11.0
   interval: 1h
   timeout: 5m
   install:
@@ -36,7 +37,8 @@ spec:
         kind: HelmRepository
         name: traefik
         namespace: traefik
-      version: 37.1.1 # renovate: datasource=helm registryUrl=https://traefik.github.io/charts packageName=traefik
+      # renovate: datasource=helm registryUrl=https://traefik.github.io/charts packageName=traefik
+      version: 37.1.1
   interval: 1h
   timeout: 5m
   dependsOn:

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s+?default: (?<currentValue>.+?)\\s",
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?(?: extractVersion=(?<extractVersion>.+?))?\\s+?.+?_VERSION\\s?=\\s?\"?v?(?<currentValue>.+?)\"?(\\s|$)",
-        "version:\\s*['\"]?(?<currentValue>[0-9A-Za-z._+-]+)['\"]?\\s*#\\s*renovate:\\s*datasource=(?<datasource>helm)\\s+registryUrl=(?<registryUrl>(?:https://|oci://)[^\\s]+)\\s+packageName=(?<packageName>[^\\s]+)"
+        "# renovate: datasource=(?<datasource>helm) registryUrl=(?<registryUrl>(?:https://|oci://)[^\\s]+) packageName=(?<packageName>.+?)\\s+?version:\\s['\"]?(?<currentValue>[^\\s'\"#]+)['\"]?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
Adjust renovate.json matchStrings to detect the comment-before-version format used in HelmRelease files.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted YAML configuration files to improve readability by reorganizing inline comments into preceding comment lines across multiple Helm release configurations.

* **Chores**
  * Updated Renovate configuration pattern to refine version detection logic for Helm chart dependencies, improving consistency in version tracking and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->