### PR TITLE
chore: bump and parameterize AKS Kubernetes version

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/terraform.tfvars
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/terraform.tfvars
@@ -2,7 +2,7 @@
 name_prefix        = "admin-test"
 flux_release_tag   = "at_ring1"
 subscription_id    = "1ce8e9af-c2d6-44e7-9c5e-099a308056fe"
-kubernetes_version = "1.32"
+kubernetes_version = "1.33"
 vnet_address_space = [
   "10.90.0.0/16",
   "fdac:524d:afaf::/56"

--- a/infrastructure/adminservices-test/admin-test-aks-rg/variables.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/variables.tf
@@ -29,7 +29,8 @@ variable "grafana_endpoint" {
 }
 
 variable "kubernetes_version" {
-  type = string
+  description = "Kubernetes version to use"
+  type        = string
 }
 
 variable "name_prefix" {

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/aks.tf
@@ -13,7 +13,7 @@ module "aks" {
   prefix             = local.team_name
   environment        = local.environment
   subscription_id    = var.subscription_id
-  kubernetes_version = "1.32"
+  kubernetes_version = var.kubernetes_version
   vnet_address_space = [
     "10.202.72.0/21",
     "fd0a:7204:c37f:900::/56"

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/terraform.tfvars
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/terraform.tfvars
@@ -3,4 +3,5 @@ subnet_address_prefixes = {
   aks_syspool  = ["fd0a:7204:c37f:901::/64", "10.202.72.0/24"]
   aks_workpool = ["fd0a:7204:c37f:902::/64", "10.202.73.0/24"]
 }
+kubernetes_version       = "1.33"
 developer_entra_id_group = "416302ed-fbab-41a4-8c8d-61f486fa79ca" # Altinn-30-Test-developers

--- a/infrastructure/altinn-auth-test/auth-at22-aks-rg/variables.tf
+++ b/infrastructure/altinn-auth-test/auth-at22-aks-rg/variables.tf
@@ -25,3 +25,8 @@ variable "developer_entra_id_group" {
   description = "EntraID group that should have access to grafana and kubernetes cluster"
   type        = string
 }
+
+variable "kubernetes_version" {
+  description = "Kubernetes version to use"
+  type        = string
+}

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/aks.tf
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/aks.tf
@@ -10,7 +10,7 @@ module "aks" {
   prefix                  = var.team_name
   environment             = var.environment
   subscription_id         = var.subscription_id
-  kubernetes_version      = "1.32"
+  kubernetes_version      = var.kubernetes_version
   vnet_address_space      = var.aks_vnet_address_spaces
   subnet_address_prefixes = var.subnet_address_prefixes
   pool_configs = {

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/terraform.tfvars
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/terraform.tfvars
@@ -7,6 +7,7 @@ subnet_address_prefixes = {
   aks_syspool  = ["fd96:20bf:3235:1::/64", "10.203.1.0/24"]
   aks_workpool = ["fd96:20bf:3235:2::/64", "10.203.2.0/24"]
 }
+kubernetes_version       = "1.33"
 team_name                = "corr"
 environment              = "at22"
 flux_release_tag         = "at_ring2"

--- a/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/variables.tf
+++ b/infrastructure/altinn-correspondence-test/corr-at22-aks-rg/variables.tf
@@ -51,3 +51,8 @@ variable "developer_entra_id_group" {
   description = "EntraID group that should have access to grafana and kubernetes cluster"
   type        = string
 }
+
+variable "kubernetes_version" {
+  description = "Kubernetes version to use"
+  type        = string
+}


### PR DESCRIPTION
Introduce a kubernetes_version variable (with description) and replace hardcoded "1.32" values in AKS modules with var.kubernetes_version. Set kubernetes_version = "1.33" in the impacted terraform.tfvars and apply minor newline/format fixes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Updated Kubernetes cluster version to 1.33 across multiple environments.
  * Made Kubernetes version configurable for improved deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->