### PR TITLE
fix: add crds to monitor namespace

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus.tf
@@ -4,6 +4,7 @@ resource "helm_release" "prometheus_operator_crds" {
   ]
   lint       = true
   name       = "prometheus-operator-crds"
+  namespace  = "monitoring"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "prometheus-operator-crds"
   version    = "24.0.2"

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/kube_prometheus.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/kube_prometheus.tf
@@ -20,6 +20,7 @@ resource "azuread_application_federated_identity_credential" "prometheus" {
 resource "helm_release" "prometheus_operator_crds" {
   lint       = true
   name       = "prometheus-operator-crds"
+  namespace  = "monitoring"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "prometheus-operator-crds"
   version    = "24.0.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Scoped Prometheus monitoring resources to a dedicated "monitoring" namespace in test infrastructure, ensuring monitoring components are isolated and consistently deployed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->