### PR TITLE
add take_ownership as per release notes

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring.tf
@@ -5,6 +5,7 @@ resource "helm_release" "grafana_k8s_monitoring" {
   lint             = true
   name             = "k8s-monitoring"
   namespace        = "monitoring"
+  take_ownership   = true
   create_namespace = false
   repository       = "https://grafana.github.io/helm-charts"
   chart            = "k8s-monitoring"

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring.tf
@@ -5,6 +5,7 @@ resource "helm_release" "grafana_k8s_monitoring" {
   lint             = true
   name             = "k8s-monitoring"
   namespace        = "monitoring"
+  take_ownership   = true
   create_namespace = false
   repository       = "https://grafana.github.io/helm-charts"
   chart            = "k8s-monitoring"


### PR DESCRIPTION
## Related Issue(s)
- #2505 


https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/README.md#version-34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Grafana k8s monitoring infrastructure configuration to enable automatic ownership transfer during release management. Updated deployment settings across test environments for improved operational consistency and release stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->