### PR TITLE
fix: Add folder permissions to Grafana manifests

### DIFF
--- a/flux/grafana-manifests/dashboards/folders.yaml
+++ b/flux/grafana-manifests/dashboards/folders.yaml
@@ -8,6 +8,14 @@ spec:
     matchLabels:
       dashboards: "external-grafana"
   title: Altinn
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -19,6 +27,14 @@ spec:
     matchLabels:
       dashboards: "external-grafana"
   title: Fluxcd
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -30,3 +46,11 @@ spec:
     matchLabels:
       dashboards: "external-grafana"
   title: Linkerd
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }

--- a/flux/grafana-operator/grafana-manifests/base/folders.yaml
+++ b/flux/grafana-operator/grafana-manifests/base/folders.yaml
@@ -8,6 +8,14 @@ spec:
     matchLabels:
       dashboards: "external-grafana"
   title: Altinn
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -19,6 +27,14 @@ spec:
     matchLabels:
       dashboards: "external-grafana"
   title: Fluxcd
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -30,3 +46,11 @@ spec:
     matchLabels:
       dashboards: "external-grafana"
   title: Linkerd
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }


### PR DESCRIPTION
Add explicit permissions for Altinn, Fluxcd and Linkerd folders (Admin=4, Editor=1, Viewer=1)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured role-based access permissions for Grafana dashboard folders, specifying Admin, Editor, and Viewer roles with corresponding permission levels across three folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->