### PR TITLE
fix: reusable workflow for autoupgrading kubebuilder operators

### DIFF
--- a/.github/workflows/reusable-auto-update-kubebuilder.yml
+++ b/.github/workflows/reusable-auto-update-kubebuilder.yml
@@ -61,10 +61,8 @@ jobs:
 
     # Step 4: Install Kubebuilder.
     - name: Install Kubebuilder
-      env:
-        KUBEBUILDER_VERSION: ${{ inputs.kubebuilder-version }}
       run: |
-        curl -L -o kubebuilder "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_$(go env GOOS)_$(go env GOARCH)"
+        curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
         chmod +x kubebuilder
         sudo mv kubebuilder /usr/local/bin/
         kubebuilder version
@@ -78,6 +76,9 @@ jobs:
     # Step 6: Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
+      env:
+        TARGET_VERSION: ${{ inputs.kubebuilder-version }}
+        OPERATOR_WORKDIR: ${{ inputs.workdir }}
       run: |
        # Executes the update command with specified flags.
        # --force: Completes the merge even if conflicts occur, leaving conflict markers.
@@ -90,5 +91,7 @@ jobs:
           --force \
           --push \
           --restore-path .github/workflows \
+          --to-version ${TARGET_VERSION}
+          --output-branch kubebuilder-update-${OPERATOR_WORKDIR}-to-${TARGET_VERSION}
           --open-gh-issue \
           --use-gh-models


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubebuilder installation to use the latest available release.
  * Enhanced the automated update workflow with improved version targeting and updated branch naming conventions for update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->