### PR TITLE
feat(admin-test): deploy ASO and dis-identity in cluster

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
@@ -33,26 +33,29 @@ module "aks" {
 }
 
 module "aks_resources" {
-  depends_on                       = [module.aks, module.observability]
-  source                           = "../../modules/aks-resources"
-  aks_node_resource_group          = module.aks.aks_node_resource_group
-  azurerm_kubernetes_cluster_id    = module.aks.azurerm_kubernetes_cluster_id
-  flux_release_tag                 = var.flux_release_tag
-  pip4_ip_address                  = module.aks.pip4_ip_address
-  pip6_ip_address                  = module.aks.pip6_ip_address
-  subnet_address_prefixes          = var.subnet_address_prefixes
-  obs_kv_uri                       = module.observability.key_vault_uri
-  obs_client_id                    = module.observability.obs_client_id
-  obs_tenant_id                    = local.tenant_id
-  environment                      = local.environment
-  syncroot_namespace               = local.team_name
-  grafana_endpoint                 = var.grafana_endpoint
-  token_grafana_operator           = var.token_grafana_operator
-  grafana_dashboard_release_branch = "main"
-  enable_grafana_operator          = true
-  lakmus_client_id                 = module.observability.lakmus_client_id
-  subscription_id                  = var.subscription_id
-  enable_cert_manager_tls_issuer   = false
-  developer_entra_id_group         = var.developer_entra_id_group
-  grafana_redirect_dns             = "grafana.altinn.cloud"
+  depends_on                                 = [module.aks, module.observability]
+  source                                     = "../../modules/aks-resources"
+  aks_node_resource_group                    = module.aks.aks_node_resource_group
+  azurerm_kubernetes_cluster_id              = module.aks.azurerm_kubernetes_cluster_id
+  flux_release_tag                           = var.flux_release_tag
+  pip4_ip_address                            = module.aks.pip4_ip_address
+  pip6_ip_address                            = module.aks.pip6_ip_address
+  subnet_address_prefixes                    = var.subnet_address_prefixes
+  obs_kv_uri                                 = module.observability.key_vault_uri
+  obs_client_id                              = module.observability.obs_client_id
+  obs_tenant_id                              = local.tenant_id
+  environment                                = local.environment
+  syncroot_namespace                         = local.team_name
+  grafana_endpoint                           = var.grafana_endpoint
+  token_grafana_operator                     = var.token_grafana_operator
+  grafana_dashboard_release_branch           = "main"
+  enable_grafana_operator                    = true
+  lakmus_client_id                           = module.observability.lakmus_client_id
+  subscription_id                            = var.subscription_id
+  enable_cert_manager_tls_issuer             = false
+  developer_entra_id_group                   = var.developer_entra_id_group
+  grafana_redirect_dns                       = "grafana.altinn.cloud"
+  enable_dis_identity_operator               = true
+  azurerm_dis_identity_resource_group_id     = module.aks.dis_resource_group_id
+  azurerm_kubernetes_cluster_oidc_issuer_url = module.aks.aks_oidc_issuer_url
 }

--- a/infrastructure/adminservices-test/admin-test-aks-rg/azure-service-operator.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/azure-service-operator.tf
@@ -1,0 +1,11 @@
+module "azure_service_operator" {
+  depends_on                                 = [module.aks, module.aks_resources]
+  source                                     = "../../modules/azure-service-operator"
+  prefix                                     = local.team_name
+  environment                                = local.environment
+  azurerm_kubernetes_cluster_oidc_issuer_url = module.aks.aks_oidc_issuer_url
+  azurerm_kubernetes_cluster_id              = module.aks.azurerm_kubernetes_cluster_id
+  azurerm_subscription_id                    = var.subscription_id
+  dis_resource_group_id                      = module.aks.dis_resource_group_id
+  flux_release_tag                           = var.flux_release_tag
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To have a testcluster for the pgsql-operator we should deploy the aso stack to the admin-test cluster

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Enabled distributed identity operator for enhanced cluster identity management and finer-grained access control
  * Integrated Azure Service Operator to enable managed service provisioning, automated lifecycle management, and unified operational oversight for Kubernetes services

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->