### PR TITLE
fix: Bump Ubuntu base image digest; update Trivy ignore

### DIFF
--- a/infrastructure/images/azure-devops-agent/Dockerfile
+++ b/infrastructure/images/azure-devops-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:e96e81f410a9f9cae717e6cdd88cc2a499700ff0bb5061876ad24377fcc517d7
+FROM ubuntu:24.04@sha256:4fdf0125919d24aec972544669dcd7d6a26a8ad7e6561c73d5549bd6db258ac2
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \

--- a/infrastructure/images/terraform-azure-devops-agent/.trivyignore
+++ b/infrastructure/images/terraform-azure-devops-agent/.trivyignore
@@ -1,3 +1,4 @@
 # Checkd against kubectl with govulncheck and kubectl is not affected (false positiv)
 CVE-2025-47907
 CVE-2025-47906
+CVE-2025-58188


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image in build infrastructure to a new revision.
  * Modified security vulnerability management configuration during image builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->