### PR TITLE
fix: eso - Use CreateReplace for CRDs and set image repo

### DIFF
--- a/flux/external-secrets-operator/helmrelease.yaml
+++ b/flux/external-secrets-operator/helmrelease.yaml
@@ -16,12 +16,22 @@ spec:
   interval: 1h
   timeout: 5m
   install:
+    crds: CreateReplace
     remediation:
       retries: 5
   upgrade:
+    crds: CreateReplace
     remediation:
       retries: 5
   values:
+    image:
+      repository: altinncr.azurecr.io/ghcr.io/external-secrets/external-secrets
+    webhook:
+      image:
+        repository: altinncr.azurecr.io/ghcr.io/external-secrets/external-secrets
+    certController:
+      image:
+        repository: altinncr.azurecr.io/ghcr.io/external-secrets/external-secrets
     installCRDs: true
     # we run the controller **without** Azure identity;
     # actual auth is delegated via SecretStore.serviceAccountRef


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enables customization of container image repositories for external-secrets operator and all its components, including the webhook service and certificate controller
  * Implements improved CRD handling strategy using CreateReplace during installation and upgrade operations for better resource management
  * Adds new configuration option to control automatic service account creation, providing greater flexibility during deployment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->