### PR TITLE
Refactor K6 Generate Manifests

### DIFF
--- a/actions/generate-k6-manifests/Dockerfile.test
+++ b/actions/generate-k6-manifests/Dockerfile.test
@@ -4,4 +4,5 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 
 COPY actions/generate-k6-manifests /actions/generate-k6-manifests
 WORKDIR /actions/generate-k6-manifests
+RUN go mod download
 RUN go test -v ./...

--- a/actions/generate-k6-manifests/cmd/config_file_test.go
+++ b/actions/generate-k6-manifests/cmd/config_file_test.go
@@ -91,8 +91,8 @@ test_definitions:
 	if configFile.TestDefinitions[0].Contexts[0].Environment != "yt01" {
 		t.Errorf("setDefaults: expected %s, actual %s", "yt01", configFile.TestDefinitions[0].Contexts[0].Environment)
 	}
-	if *configFile.TestDefinitions[0].Contexts[0].NodeType != "spot" {
-		t.Errorf("setDefaults: expected %s, actual %s", "spot", *configFile.TestDefinitions[0].Contexts[0].NodeType)
+	if *configFile.TestDefinitions[0].Contexts[0].NodeType != "default" {
+		t.Errorf("setDefaults: expected %s, actual %s", "default", *configFile.TestDefinitions[0].Contexts[0].NodeType)
 	}
 	if *configFile.TestDefinitions[0].Contexts[0].TestTypeDefinition.Type != "functional" {
 		t.Errorf("setDefaults: expected %s, actual %s", "functional", *configFile.TestDefinitions[0].Contexts[0].TestTypeDefinition.Type)
@@ -165,8 +165,8 @@ test_definitions:
 	if configFile.TestDefinitions[0].Contexts[0].Environment != "at22" {
 		t.Errorf("setDefaults: expected %s, actual %s", "at22", configFile.TestDefinitions[0].Contexts[0].Environment)
 	}
-	if *configFile.TestDefinitions[0].Contexts[0].NodeType != "spot" {
-		t.Errorf("setDefaults: expected %s, actual %s", "spot", *configFile.TestDefinitions[0].Contexts[0].NodeType)
+	if *configFile.TestDefinitions[0].Contexts[0].NodeType != "default" {
+		t.Errorf("setDefaults: expected %s, actual %s", "default", *configFile.TestDefinitions[0].Contexts[0].NodeType)
 	}
 	if *configFile.TestDefinitions[0].Contexts[0].TestTypeDefinition.Type != "functional" {
 		t.Errorf("setDefaults: expected %s, actual %s", "functional", *configFile.TestDefinitions[0].Contexts[0].TestTypeDefinition.Type)

--- a/actions/generate-k6-manifests/cmd/example_configfiles/v12.yaml
+++ b/actions/generate-k6-manifests/cmd/example_configfiles/v12.yaml
@@ -8,4 +8,4 @@ test_definitions:
             type: functional
             enabled: true
             config_file: ""
-          id: pre_determined
+          id: at22-pre-determined

--- a/actions/generate-k6-manifests/cmd/example_configfiles/v6.yaml
+++ b/actions/generate-k6-manifests/cmd/example_configfiles/v6.yaml
@@ -19,6 +19,7 @@ test_definitions:
           config_file: actions/generate-k6-manifests/test_service/test_configs/yt01_config.json
         test_run:
           name: "get-daemonsets"
+          id: "yt01-get-daemonsets" # hardcode id
           env:
             - name: API_VERSION
               value: 3

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -58,9 +62,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -75,7 +81,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/expanded-configfile.yaml
@@ -12,6 +12,7 @@ test_definitions:
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -3,20 +3,28 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
+            },
+            {
+               "name": "GITHUB_REF",
+               "value": "refs/heads/main"
             },
             {
                "name": "GITHUB_REPOSITORY",
@@ -52,7 +60,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -70,34 +78,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/expanded-configfile.yaml
@@ -5,13 +5,14 @@ test_definitions:
       env_file: ""
       contexts:
         - environment: at22
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:
@@ -20,13 +21,14 @@ test_definitions:
             env: []
             secrets: []
         - environment: yt01
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: yt01-get-deployments
             parallelism: 1
             resources:
                 requests:
@@ -35,13 +37,14 @@ test_definitions:
             env: []
             secrets: []
         - environment: tt02
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: tt02-get-deployments
             parallelism: 1
             resources:
                 requests:
@@ -50,13 +53,14 @@ test_definitions:
             env: []
             secrets: []
         - environment: prod
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: prod-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -3,20 +3,28 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "prod-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=prod-get-deployments --tag namespace=platform --tag deploy_env=prod --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "prod"
+            },
+            {
+               "name": "GITHUB_REF",
+               "value": "refs/heads/main"
             },
             {
                "name": "GITHUB_REPOSITORY",
@@ -52,7 +60,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "prod-get-deployments"
             }
          ],
          "envFrom": [
@@ -70,34 +78,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "prod-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "prod-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
@@ -3,20 +3,28 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "tt02-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=tt02-get-deployments --tag namespace=platform --tag deploy_env=tt02 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "tt02"
+            },
+            {
+               "name": "GITHUB_REF",
+               "value": "refs/heads/main"
             },
             {
                "name": "GITHUB_REPOSITORY",
@@ -52,7 +60,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "tt02-get-deployments"
             }
          ],
          "envFrom": [
@@ -70,34 +78,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "tt02-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "tt02-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -3,20 +3,28 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "yt01-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=yt01-get-deployments --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "yt01"
+            },
+            {
+               "name": "GITHUB_REF",
+               "value": "refs/heads/main"
             },
             {
                "name": "GITHUB_REPOSITORY",
@@ -52,7 +60,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "yt01-get-deployments"
             }
          ],
          "envFrom": [
@@ -70,34 +78,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "yt01-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "yt01-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             },
             {
                "name": "ZZZ",
@@ -62,34 +66,26 @@
          "image": "grafana/k6:master-with-browser",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
@@ -5,13 +5,14 @@ test_definitions:
       env_file: ""
       contexts:
         - environment: at22
-          node_type: spot
+          node_type: default
           test_type:
             type: browser
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-pre-determined",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-pre-determined --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-pre-determined"
             }
          ],
          "envFrom": [
@@ -58,34 +62,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-pre-determined",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-pre-determined"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/expanded-configfile.yaml
@@ -5,14 +5,14 @@ test_definitions:
       env_file: ""
       contexts:
         - environment: at22
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
-            id: pre_determined
+            id: at22-pre-determined
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -58,9 +62,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -75,7 +81,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/expanded-configfile.yaml
@@ -12,6 +12,7 @@ test_definitions:
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments-smoke",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments-smoke --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments-smoke"
             }
          ],
          "envFrom": [
@@ -58,9 +62,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments-smoke",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -75,7 +81,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments-smoke"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/expanded-configfile.yaml
@@ -12,6 +12,7 @@ test_definitions:
             config_file: actions/generate-k6-manifests/test_service/test_configs/at_config.json
           test_run:
             name: get-deployments
+            id: at22-get-deployments-smoke
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -58,34 +62,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/expanded-configfile.yaml
@@ -5,13 +5,14 @@ test_definitions:
       env_file: ""
       contexts:
         - environment: at22
-          node_type: spot
+          node_type: default
           test_type:
             type: spike
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env=at22 --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -58,34 +62,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/expanded-configfile.yaml
@@ -5,13 +5,14 @@ test_definitions:
       env_file: ""
       contexts:
         - environment: at22
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:
@@ -20,13 +21,14 @@ test_definitions:
             env: []
             secrets: []
         - environment: yt01
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: yt01-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "yt01-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env=yt01 --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=yt01-get-deployments --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "yt01"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "yt01-get-deployments"
             }
          ],
          "envFrom": [
@@ -58,34 +62,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "yt01-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "250m",
                "memory": "200Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "yt01-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env=at22 --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -58,34 +62,26 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
-         "nodeSelector": {
-            "kubernetes.azure.com/scalesetpriority": "spot",
-            "spot": "true"
-         },
+         "nodeSelector": { },
          "resources": {
             "requests": {
                "cpu": "1",
                "memory": "1000Mi"
             }
          },
-         "tolerations": [
-            {
-               "effect": "NoSchedule",
-               "key": "kubernetes.azure.com/scalesetpriority",
-               "operator": "Equal",
-               "value": "spot"
-            }
-         ]
+         "tolerations": [ ]
       },
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/expanded-configfile.yaml
@@ -5,13 +5,14 @@ test_definitions:
       env_file: ""
       contexts:
         - environment: at22
-          node_type: spot
+          node_type: default
           test_type:
             type: functional
             enabled: true
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:
@@ -31,6 +32,7 @@ test_definitions:
             config_file: actions/generate-k6-manifests/test_service/test_configs/yt01_config.json
           test_run:
             name: get-daemonsets
+            id: yt01-get-daemonsets
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -3,13 +3,17 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-daemonsets",
+         "test_name": "get-daemonsets",
+         "testid": "yt01-get-daemonsets",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-daemonsets --out experimental-prometheus-rw",
+      "arguments": "--tag testid=yt01-get-daemonsets --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-daemonsets --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
@@ -20,7 +24,7 @@
             },
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "yt01"
             },
             {
                "name": "FEATURE_FLAG1",
@@ -48,7 +52,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "yt01-get-daemonsets"
             }
          ],
          "envFrom": [
@@ -66,9 +70,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-daemonsets",
+               "test_name": "get-daemonsets",
+               "testid": "yt01-get-daemonsets",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -83,7 +89,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "yt01-get-daemonsets"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name={{ .TestName }} --out experimental-prometheus-rw -e runFullTestSet=true -e tokenGeneratorUserName=olanordmenn -e orgNoRecipient=1234 -e resourceId=abcd",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw -e runFullTestSet=true -e tokenGeneratorUserName=olanordmenn -e orgNoRecipient=1234 -e resourceId=abcd",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             },
             {
                "name": "orgNoRecipient",
@@ -74,9 +78,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -91,7 +97,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/expanded-configfile.yaml
@@ -12,6 +12,7 @@ test_definitions:
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -3,20 +3,24 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name={{ .TestName }} --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "K6_NO_USAGE_REPORT",
@@ -40,7 +44,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -68,9 +72,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -85,7 +91,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/expanded-configfile.yaml
@@ -12,6 +12,7 @@ test_definitions:
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -3,13 +3,17 @@
    "kind": "TestRun",
    "metadata": {
       "labels": {
-         "generated-by": "k6-action-image"
+         "generated-by": "k6-action-image",
+         "k6-test": "get-deployments",
+         "test_name": "get-deployments",
+         "testid": "at22-get-deployments",
+         "uniq-name": "{{ .UniqName }}"
       },
-      "name": "{{ .UniqueName }}",
+      "name": "{{ .UniqName }}",
       "namespace": "platform"
    },
    "spec": {
-      "arguments": "--tag testid={{ .UniqueName }} --tag namespace=platform --tag deploy_env={{ .DeployEnv }} --tag test_name=get-deployments --out experimental-prometheus-rw",
+      "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --out experimental-prometheus-rw",
       "cleanup": "post",
       "parallelism": 1,
       "runner": {
@@ -24,7 +28,7 @@
             },
             {
                "name": "ENVIRONMENT",
-               "value": "{{ .DeployEnv }}"
+               "value": "at22"
             },
             {
                "name": "FOO",
@@ -52,7 +56,7 @@
             },
             {
                "name": "TESTID",
-               "value": "{{ .UniqueName }}"
+               "value": "at22-get-deployments"
             }
          ],
          "envFrom": [
@@ -70,9 +74,11 @@
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
             "labels": {
-               "k6-test": "{{ .UniqueName }}",
-               "test_name": "{{ .TestName }}",
-               "testid": "{{ .UniqueName }}"
+               "generated-by": "k6-action-image",
+               "k6-test": "get-deployments",
+               "test_name": "get-deployments",
+               "testid": "at22-get-deployments",
+               "uniq-name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },
@@ -87,7 +93,7 @@
       "script": {
          "configMap": {
             "file": "archive.tar",
-            "name": "{{ .DirName }}"
+            "name": "at22-get-deployments"
          }
       }
    }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/expanded-configfile.yaml
@@ -12,6 +12,7 @@ test_definitions:
             config_file: ""
           test_run:
             name: get-deployments
+            id: at22-get-deployments
             parallelism: 1
             resources:
                 requests:

--- a/actions/generate-k6-manifests/cmd/helpers.go
+++ b/actions/generate-k6-manifests/cmd/helpers.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"bufio"
+	"log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+
+	orderedmap "github.com/elliotchance/orderedmap/v3"
+)
+
+func getEnvVarsFromCliArgs(cliArgs string) []*Env {
+	var envOptions []*Env
+	args := strings.Fields(cliArgs)
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-e") || strings.HasPrefix(arg, "--env") {
+			if i < len(args)-1 {
+				keyValue := strings.Split(args[i+1], "=")
+				if len(keyValue) == 2 {
+					key := keyValue[0]
+					value := keyValue[1]
+					envOptions = append(envOptions, &Env{Name: &key, Value: &value})
+				}
+			}
+		}
+	}
+	return envOptions
+}
+
+func sanitizeNameFromTestFileName(pathToTestFile string) *string {
+	// TODO: might need more validation here..
+	tempString := filepath.Base(pathToTestFile)
+	tempString = strings.ReplaceAll(tempString, "_", "-")
+	// Remove .js or .ts
+	tempString = strings.TrimSuffix(tempString, filepath.Ext(tempString))
+	return &tempString
+}
+
+func getGithubRelatedVars() []*Env {
+	var githubRelatedEnvVars []*Env
+	githubEnvKeys := [8]string{
+		"GITHUB_REPOSITORY",
+		"GITHUB_SERVER_URL",
+		"GITHUB_RUN_ID",
+		"GITHUB_BASE_REF",
+		"GITHUB_HEAD_REF",
+		"GITHUB_REF",
+		"GITHUB_REF_NAME",
+		"GITHUB_SHA",
+	}
+	for i := range githubEnvKeys {
+		if val, ok := os.LookupEnv(githubEnvKeys[i]); ok {
+			githubRelatedEnvVars = append(githubRelatedEnvVars, &Env{
+				Name:  &githubEnvKeys[i],
+				Value: &val,
+			})
+		}
+	}
+	return githubRelatedEnvVars
+}
+
+func randomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
+}
+
+func parseEnvFile(filePath string) []*Env {
+	envFromFile := []*Env{}
+	tempFile, err := os.Open(filePath)
+
+	if err != nil {
+		log.Fatalf("error opening file: %s", err)
+	}
+	defer tempFile.Close()
+
+	scanner := bufio.NewScanner(tempFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip empty lines and comments
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		keyValue := strings.Split(line, "=")
+		if len(keyValue) != 2 {
+			log.Fatalf("expected %s to have the format KEY=VALUE", keyValue)
+		}
+		envFromFile = append(envFromFile, &Env{
+			Name:  &keyValue[0],
+			Value: &keyValue[1],
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("error reading from file: %s", err)
+	}
+	return envFromFile
+}
+
+func handleExtraEnvVars(original []*Env, extra []*Env) []*Env {
+	newEnv := []*Env{}
+	m := orderedmap.NewOrderedMap[string, string]()
+	for _, o := range original {
+		m.Set(*o.Name, *o.Value)
+	}
+	for _, e := range extra {
+		m.Set(*e.Name, *e.Value)
+	}
+	for k, v := range m.AllFromFront() {
+		newEnv = append(newEnv, &Env{
+			Name:  &k,
+			Value: &v,
+		})
+	}
+	return newEnv
+}
+
+func chooseCorrectSlackChannel(deploy_env string) string {
+	branch, ok := os.LookupEnv("GITHUB_REF")
+
+	if ok && branch == "refs/heads/main" {
+		aux := map[string]string{
+			"at22": "slack-dev",
+			"at23": "slack-dev",
+			"at24": "slack-dev",
+			"yt01": "slack-dev",
+
+			"tt02": "slack-prod",
+			"prod": "slack-prod",
+		}
+		return aux[deploy_env]
+	}
+
+	return "slack-test"
+}

--- a/actions/generate-k6-manifests/go.mod
+++ b/actions/generate-k6-manifests/go.mod
@@ -1,6 +1,6 @@
 module github.com/Altinn/altinn-platform/actions/generate-k6-manifests
 
-go 1.24.0
+go 1.25
 
 toolchain go1.25.4
 

--- a/actions/generate-k6-manifests/main.go
+++ b/actions/generate-k6-manifests/main.go
@@ -12,13 +12,14 @@ func main() {
 	if !ok {
 		log.Fatal("INPUT_CONFIG_FILE is mandatory")
 	}
+
 	var g cmd.Generator = cmd.K8sManifestGenerator{
-		UserConfigFile:            userConfigFile,
 		ConfigDirectory:           ".conf",
 		DistDirectory:             ".dist",
 		BuildDirectory:            ".build",
 		DefaultScenariosDirectory: "/actions/generate-k6-manifests/default_scenarios",
 		RepoRootDirectory:         ".",
 	}
-	g.Generate()
+	cf := g.Initialize(userConfigFile)
+	g.Generate(*cf)
 }

--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -51,6 +51,7 @@ RUN jb init && \
 # Build Generator code
 WORKDIR /actions/generate-k6-manifests
 COPY actions/generate-k6-manifests .
+RUN go mod download
 RUN go build . && \
     chmod +x generate-k6-manifests && \
     mv generate-k6-manifests /usr/local/bin

--- a/infrastructure/images/k6-action/jsonnet/main.jsonnet
+++ b/infrastructure/images/k6-action/jsonnet/main.jsonnet
@@ -39,13 +39,21 @@ local default_env = [
   },
   {
     name: 'TESTID',
-    value: unique_name,
+    value: testid,
   },
   {
     name: 'ENVIRONMENT',
     value: deploy_env,
   },
 ];
+
+local common_labels = {
+  'k6-test': test_name,
+  testid: testid,
+  test_name: test_name,
+  'uniq-name': unique_name,
+  'generated-by': 'k6-action-image',
+};
 
 local slo = {
   new(slo_name, team, application, url): {
@@ -89,9 +97,7 @@ local testrun = {
     metadata: {
       name: unique_name,
       namespace: namespace,
-      labels: {
-        'generated-by': 'k6-action-image',
-      },
+      labels: common_labels,
     },
     spec: {
       cleanup: 'post',
@@ -109,11 +115,7 @@ local testrun = {
       runner: {
         env: default_env,
         metadata: {
-          labels: {
-            'k6-test': unique_name,
-            testid: testid,
-            test_name: test_name,
-          },
+          labels: common_labels,
         },
         resources: resources,
         envFrom+: [{


### PR DESCRIPTION
#2477 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifests now include stable TestId/TestName/UniqName labels, explicit test_run identifiers, and GITHUB_REF in generated outputs.

* **Behavior Changes**
  * Default test type is now "functional". Breakpoint tests default to larger resources; node_type defaults to "spot" for breakpoints and "default" otherwise.
  * Generated manifests use UniqName for resource names.

* **Chores**
  * Module dependencies are pre-fetched during builds; manifest generation refactored and parallelized for faster output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->