### PR TITLE
fix: deploy altinn-uptime admin-test-aks

### DIFF
--- a/flux/altinn-uptime/scripts/generate_targets.sh
+++ b/flux/altinn-uptime/scripts/generate_targets.sh
@@ -363,7 +363,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
             apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "blackbox-exporter-${UNIQUE_ID}-${org}-tt02-ipv4"
@@ -425,7 +425,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
             apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "blackbox-exporter-${UNIQUE_ID}-${org}-tt02-ipv6"
@@ -490,7 +490,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
             apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "blackbox-exporter-${UNIQUE_ID}-${org}-prod-ipv4"
@@ -552,7 +552,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
             apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "blackbox-exporter-${UNIQUE_ID}-${org}-prod-ipv6"
@@ -626,7 +626,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
                 apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "$sm_name"
@@ -698,7 +698,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
                 apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "$sm_name"
@@ -772,7 +772,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
                 apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "$sm_name"
@@ -846,7 +846,7 @@ spec:
     - $NAMESPACE
   selector:
     matchLabels:
-      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: monitoring-prometheus-blackbox-exporter
       app.kubernetes.io/name: prometheus-blackbox-exporter
 EOF
                 apply_servicemonitor "$(cat "$TEMP_DIR/servicemonitor.yaml")" "$sm_name"

--- a/flux/blackbox-exporter/altinn-uptime/helmrelease-patch.yaml
+++ b/flux/blackbox-exporter/altinn-uptime/helmrelease-patch.yaml
@@ -1,0 +1,85 @@
+- patch: |-
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    metadata:
+      name: prometheus-blackbox-exporter
+    spec:
+      values:
+        config:
+          modules:
+            http_2xx_ipv6:
+              prober: http
+              timeout: 5s
+              http:
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: []
+                method: GET
+                follow_redirects: false
+                fail_if_ssl: false
+                fail_if_not_ssl: false
+                preferred_ip_protocol: ip6
+                ip_protocol_fallback: false
+            http_2xx_ipv4:
+              prober: http
+              timeout: 5s
+              http:
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: []
+                method: GET
+                follow_redirects: false
+                fail_if_ssl: false
+                fail_if_not_ssl: false
+                preferred_ip_protocol: ip4
+                ip_protocol_fallback: false
+            tcp_connect_ipv4:
+              prober: tcp
+              timeout: 5s
+              tcp:
+                preferred_ip_protocol: ip4
+                ip_protocol_fallback: false
+            tcp_connect_ipv6:
+              prober: tcp
+              timeout: 5s
+              tcp:
+                preferred_ip_protocol: ip6
+                ip_protocol_fallback: false
+            icmp_ipv4:
+              prober: icmp
+              timeout: 5s
+              icmp:
+                preferred_ip_protocol: ip4
+                ip_protocol_fallback: false
+            icmp_ipv6:
+              prober: icmp
+              timeout: 5s
+              icmp:
+                preferred_ip_protocol: ip6
+                ip_protocol_fallback: false
+            http_2xx_ipv6_kuberneteswrapper:
+              prober: http
+              timeout: 5s
+              http:
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: []
+                method: GET
+                follow_redirects: false
+                fail_if_ssl: false
+                fail_if_not_ssl: false
+                preferred_ip_protocol: ip6
+                ip_protocol_fallback: false
+                fail_if_body_not_matches_regexp:
+                  - "kuberneteswrapper"
+            http_2xx_ipv4_kuberneteswrapper:
+              prober: http
+              timeout: 5s
+              http:
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: []
+                method: GET
+                follow_redirects: false
+                fail_if_ssl: false
+                fail_if_not_ssl: false
+                preferred_ip_protocol: ip4
+                ip_protocol_fallback: false
+                fail_if_body_not_matches_regexp:
+                  - "kuberneteswrapper"

--- a/flux/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/flux/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: helmrelease-patch.yaml
+    target:
+      kind: HelmRelease
+      name: prometheus-blackbox-exporter

--- a/infrastructure/adminservices-test/admin-test-aks-rg/blackbox-exporter.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/blackbox-exporter.tf
@@ -8,7 +8,7 @@ resource "azapi_resource" "blackbox_exporter" {
       kustomizations = {
         blackbox-exporter = {
           force                  = false
-          path                   = "./base/"
+          path                   = "./altinn-uptime/"
           prune                  = true
           retryIntervalInSeconds = 300
           syncIntervalInSeconds  = 300


### PR DESCRIPTION
Change ServiceMonitor selector to use app.kubernetes.io/instance = monitoring-prometheus-blackbox-exporter

Add HelmRelease patch and Kustomization under
flux/blackbox-exporter/altinn-uptime to define IPv4/IPv6 http, tcp and icmp modules including kuberneteswrapper checks

Update Terraform kustomization path to ./altinn-uptime/

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring probe configurations for service availability tracking, including HTTP, TCP, and ICMP probe types across multiple network configurations.
  * Reorganized infrastructure deployment structure for monitoring system components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->