### PR TITLE
fix: Increase blackbox-exporter timeouts to 10s

### DIFF
--- a/flux/blackbox-exporter/altinn-uptime/kustomization.yaml
+++ b/flux/blackbox-exporter/altinn-uptime/kustomization.yaml
@@ -13,7 +13,7 @@ patches:
           modules:
             http_2xx_ipv6:
               prober: http
-              timeout: 5s
+              timeout: 10s
               http:
                 valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
                 valid_status_codes: []
@@ -25,7 +25,7 @@ patches:
                 ip_protocol_fallback: false
             http_2xx_ipv4:
               prober: http
-              timeout: 5s
+              timeout: 10s
               http:
                 valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
                 valid_status_codes: []
@@ -37,31 +37,31 @@ patches:
                 ip_protocol_fallback: false
             tcp_connect_ipv4:
               prober: tcp
-              timeout: 5s
+              timeout: 10s
               tcp:
                 preferred_ip_protocol: ip4
                 ip_protocol_fallback: false
             tcp_connect_ipv6:
               prober: tcp
-              timeout: 5s
+              timeout: 10s
               tcp:
                 preferred_ip_protocol: ip6
                 ip_protocol_fallback: false
             icmp_ipv4:
               prober: icmp
-              timeout: 5s
+              timeout: 10s
               icmp:
                 preferred_ip_protocol: ip4
                 ip_protocol_fallback: false
             icmp_ipv6:
               prober: icmp
-              timeout: 5s
+              timeout: 10s
               icmp:
                 preferred_ip_protocol: ip6
                 ip_protocol_fallback: false
             http_2xx_ipv6_kuberneteswrapper:
               prober: http
-              timeout: 5s
+              timeout: 10s
               http:
                 valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
                 valid_status_codes: []
@@ -75,7 +75,7 @@ patches:
                   - "kuberneteswrapper"
             http_2xx_ipv4_kuberneteswrapper:
               prober: http
-              timeout: 5s
+              timeout: 10s
               http:
                 valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
                 valid_status_codes: []


### PR DESCRIPTION
- updated all monitoring modules to use a 10-second timeout instead of 5 seconds.
- This change should help reduce the false negatives you were seeing in your monitoring checks while still maintaining a reasonable response time for detecting actual issues.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout thresholds for network health checks (HTTP, TCP, and ICMP protocols) to improve reliability and reduce false failures during network delays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->