### PR TITLE
remove services module from k6tests-rg

### DIFF
--- a/infrastructure/adminservices-test/k6tests-rg/main.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/main.tf
@@ -16,7 +16,7 @@ module "foundational" {
 
   suffix = local.suffix
 }
-
+/*
 module "services" {
   depends_on = [module.foundational]
   source     = "./modules/services"
@@ -35,3 +35,4 @@ module "services" {
 
   suffix = local.suffix
 }
+*/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Test infrastructure configuration updated: services module is now disabled in the admin services test environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->