### PR TITLE
feat: add token-generator-creds by default to reduce boilerplate

### DIFF
--- a/actions/generate-k6-manifests/cmd/config_file.go
+++ b/actions/generate-k6-manifests/cmd/config_file.go
@@ -147,6 +147,16 @@ func (cFile *ConfigFile) SetDefaults() {
 				}
 				c.TestRun.Resources.Requests.Cpu = &defaultCpuRequests
 			}
+			found := false
+			tokenGeneratorCreds := "token-generator-creds"
+			for i := range c.TestRun.SecretReferences {
+				if *c.TestRun.SecretReferences[i] == tokenGeneratorCreds {
+					found = true
+				}
+			}
+			if !found {
+				c.TestRun.SecretReferences = append(c.TestRun.SecretReferences, &tokenGeneratorCreds)
+			}
 			if c.NodeType == nil || *c.NodeType == "" {
 				// As of now we have enough capacity in the default node pool to run functional and smoke tests there.
 				nodeType := "default"

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/expanded-configfile.yaml
@@ -19,4 +19,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -71,6 +71,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-dev"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/expanded-configfile.yaml
@@ -19,7 +19,8 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds
         - environment: yt01
           node_type: default
           test_type:
@@ -35,7 +36,8 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds
         - environment: tt02
           node_type: default
           test_type:
@@ -51,7 +53,8 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds
         - environment: prod
           node_type: default
           test_type:
@@ -67,4 +70,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -71,6 +71,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-prod"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
@@ -71,6 +71,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-prod"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -71,6 +71,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-dev"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -59,6 +59,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/expanded-configfile.yaml
@@ -23,4 +23,5 @@ test_definitions:
                   value: Something
                 - name: K6_PROMETHEUS_RW_TREND_STATS
                   value: avg,count,min,med,max,p(75),p(95)
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/expanded-configfile.yaml
@@ -19,4 +19,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/expanded-configfile.yaml
@@ -19,4 +19,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/expanded-configfile.yaml
@@ -19,4 +19,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/expanded-configfile.yaml
@@ -19,4 +19,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/expanded-configfile.yaml
@@ -19,7 +19,8 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds
         - environment: yt01
           node_type: default
           test_type:
@@ -35,4 +36,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -55,6 +55,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/expanded-configfile.yaml
@@ -19,7 +19,8 @@ test_definitions:
                     memory: 1000Mi
                     cpu: "1"
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds
     - test_file: actions/generate-k6-manifests/test_service/k8s_wrapper/get_daemonsets.js
       config_file: ""
       env_file: ""
@@ -43,4 +44,5 @@ test_definitions:
                   value: "3"
                 - name: FEATURE_FLAG1
                   value: enabled
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -63,6 +63,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -71,6 +71,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/expanded-configfile.yaml
@@ -19,4 +19,5 @@ test_definitions:
                     memory: 200Mi
                     cpu: 250m
             env: []
-            secrets: []
+            secrets:
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -65,6 +65,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/expanded-configfile.yaml
@@ -22,3 +22,4 @@ test_definitions:
             secrets:
                 - super-secret-1
                 - super-secret-2
+                - token-generator-creds

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -67,6 +67,11 @@
             },
             {
                "secretRef": {
+                  "name": "token-generator-creds"
+               }
+            },
+            {
+               "secretRef": {
                   "name": "slack-test"
                }
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/expanded-configfile.yaml
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/expanded-configfile.yaml
@@ -21,4 +21,5 @@ test_definitions:
             env:
                 - name: FOO
                   value: BAR
-            secrets: []
+            secrets:
+                - token-generator-creds


### PR DESCRIPTION
Pretty much all tests end up using it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token-generator-creds secret is now automatically provisioned and included across all k6 test run configurations and environment versions. This ensures that credentials are consistently available and properly configured for all test executions throughout the test run lifecycle, making the secret reference an integral part of the managed test environment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->