### PR TITLE
Ignore trivy warning and enable latest in the k6 image

### DIFF
--- a/.github/workflows/k6-action-image-release.yml
+++ b/.github/workflows/k6-action-image-release.yml
@@ -43,7 +43,7 @@ jobs:
     name: Build, scan and release
     uses: ./.github/workflows/reusable-image-scan-and-release-ghcr.yml
     with:
-      release_latest: false
+      release_latest: true
       image_name: k6-action-image
       tag_prefix: k6-action-image-
       workdir: .

--- a/infrastructure/images/k6-action/.trivyignore
+++ b/infrastructure/images/k6-action/.trivyignore
@@ -28,3 +28,5 @@ CVE-2025-58188
 
 # The Reader.ReadResponse function constructs a response string through repeated string concatenation of lines. When the number of lines in a response is large, this can cause excessive CPU consumption.
 CVE-2025-61724
+# Within HostnameError.Error(), when constructing an error string, there is no limit to the number of hosts that will be printed out. Furthermore, the error string is constructed by repeated string concatenation, leading to quadratic runtime. Therefore, a certificate provided by a malicious actor can result in excessive resource consumption.
+CVE-2025-61729


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the k6-action-image release workflow to enable publication of the "latest" tag alongside version-specific tags when new versions are released
  * Enhanced security documentation by adding a new entry to the vulnerability monitoring ignore list to document a known resource-exhaustion vulnerability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->