### PR TITLE
chore: Onboard portaler into k6 cluster

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -112,6 +112,11 @@ variable "k8s_rbac" {
       dev_group = "975d2ed6-f3dc-48a3-b014-8d876cb96e25"
       sp_group  = "122986e4-eb3d-4d9e-ab7d-8aec6174f332"
     }
+    portaler = {
+      namespace = "portaler",
+      dev_group = "01505bd1-7216-419d-ae24-bdad763d7e06"
+      sp_group  = "3b2529e7-8fa6-48d8-a4ce-eb4683d79c0c"
+    }
   }
 }
 

--- a/infrastructure/adminservices-test/k6tests-rg/locals.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/locals.tf
@@ -32,6 +32,12 @@ locals {
       dev_group = "c403060d-5c8a-41b0-8c19-84fa60d0ce18"
       sp_group  = "b22b612d-9dc5-4f8b-8816-e551749bd19c"
     }
+
+    portaler = {
+      namespace = "portaler",
+      dev_group = "01505bd1-7216-419d-ae24-bdad763d7e06"
+      sp_group  = "3b2529e7-8fa6-48d8-a4ce-eb4683d79c0c"
+    }
   }
   namespaces                      = toset([for v in local.k8s_rbac : v["namespace"]])
   k6tests_cluster_name            = module.foundational.k6tests_cluster_name


### PR DESCRIPTION

## Related Issue(s)
- #2797


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added "portaler" namespace to Kubernetes RBAC configuration in test environments with corresponding role-based access control settings for development and service principal groups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->