### PR TITLE
fix(dis-pgsql-operator): reference armID in private dns zone owner

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_dns.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_dns.go
@@ -77,7 +77,11 @@ func (r *DatabaseReconciler) ensurePrivateDNSZone(
 			AzureName: zoneName,
 			Location:  &loc,
 			Owner: &genruntime.KnownResourceReference{
-				Name: r.Config.ResourceGroup,
+				ARMID: fmt.Sprintf(
+					"/subscriptions/%s/resourceGroups/%s",
+					r.Config.SubscriptionId,
+					r.Config.ResourceGroup,
+				),
 			},
 			Tags: map[string]string{
 				"dis-database": db.Name,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Seems that for a private zone ownership one can choose between [a k8s resource (via ASO) or an armID ](https://github.com/Azure/azure-service-operator/blob/fc1d989d6f2d2137995aa467b6c992cbfe21c4e9/v2/pkg/genruntime/resource_reference.go#L25)
- Since our resource group has been already created when the operator is deployed, we should just use armId
- The way it is set up now leads to an error as there's no such ASO resource group

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Private DNS Zone association with Resource Groups using a more robust identifier mechanism for enhanced reliability and consistency in DNS configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->