### PR TITLE
Add the xk6-sse extension to the k6 image

### DIFF
--- a/infrastructure/images/k6-image/Dockerfile
+++ b/infrastructure/images/k6-image/Dockerfile
@@ -6,6 +6,7 @@ RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build \
     --with github.com/grafana/xk6-dns \
     --with github.com/grafana/xk6-tls \
+    --with github.com/phymbert/xk6-sse \
     --output /k6
 
 FROM grafana/k6:1.4.2@sha256:3656673de3f30424e8ebcfa46acd9558d83b6a43612d0f668ffeac953950c6c7


### PR DESCRIPTION
Need it for the dialogporten tests:

https://github.com/Altinn/dialogporten/blob/performance/subscriptions/tests/k6/tests/graphql/performance/graphqlSubscriptions.js#L1

Part of the community extensions: https://grafana.com/docs/k6/latest/extensions/explore/#community-extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Server-Sent Events (SSE) module support to load testing infrastructure, expanding available testing capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->