### PR TITLE
Add a few more node pools to the k6 cluster

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -142,6 +142,48 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
   temporary_name_for_rotation = "tmpd8c28g"
 }
 
+resource "azurerm_kubernetes_cluster_node_pool" "spot1c3g" {
+  name                  = "spot1c3g"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D1_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 40
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot1cpu3gbmem : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+  temporary_name_for_rotation = "tmpd1c3g"
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot2c7g" {
+  name                  = "spot2c7g"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D2_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 20
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot2cpu7gbmem : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+  temporary_name_for_rotation = "tmpd2c7g"
+}
+
 resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
   name                  = "prometheus"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
@@ -92,6 +92,49 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot8c28g" {
   temporary_name_for_rotation = "tmpd8c28g"
 }
 
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot1c3g" {
+  name                  = "spot1c3g"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D1_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 40
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot1cpu3gbmem : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+  temporary_name_for_rotation = "tmpd1c3g"
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot2c7g" {
+  name                  = "spot2c7g"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id
+  vm_size               = "Standard_D2_v2"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = 20
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1 # (the current on-demand price for a Virtual Machine)
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" : "spot", # Automatically added by Azure
+    spot2cpu7gbmem : true
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule", # Automatically added by Azure
+  ]
+  temporary_name_for_rotation = "tmpd2c7g"
+}
+
 resource "azurerm_kubernetes_cluster_node_pool" "prometheus" {
   name                  = "prometheus"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k6tests.id

--- a/infrastructure/images/k6-action/infra/k6_cluster_conf.yaml
+++ b/infrastructure/images/k6-action/infra/k6_cluster_conf.yaml
@@ -22,6 +22,28 @@ node_types:
         operator: "Equal"
         value: "spot"
         effect: "NoSchedule"
+  spot1cpu3gbmem:
+    nodeSelector:
+      - label: "kubernetes.azure.com/scalesetpriority"
+        value: "spot"
+      - label: spot1cpu3gbmem
+        value: true
+    tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
+  spot2cpu7gbmem:
+    nodeSelector:
+      - label: "kubernetes.azure.com/scalesetpriority"
+        value: "spot"
+      - label: spot2cpu7gbmem
+        value: true
+    tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
   default:
     nodeSelector: []
     tolerations: []


### PR DESCRIPTION
Some tests from Dialogporten require a lot of TCP connections to be opened but don't tax the nodes a lot in terms of CPU/memory.

Adding 2 more node pools with weak nodes to run some tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Kubernetes cluster infrastructure configuration for improved resource scaling
  * Enhanced test environment capacity with improved node pool configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->