### PR TITLE
K6 cluster: Configure the allocated outbound ports

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -90,7 +90,7 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
   }
 
   network_profile {
-    network_plugin = "azure"
+    network_plugin = "kubenet"
     load_balancer_profile {
       outbound_ports_allocated = 5000 # https://learn.microsoft.com/en-us/azure/aks/configure-load-balancer-standard?tabs=create-cluster-ip-based%2Cupdate-cluster-managed-outbound-ips%2Ccreate-cluster-custom-ips%2Ccreate-cluster-custom-ip-prefixes%2Ccreate-cluster-outbound-ports-ips%2Ccreate-cluster-idle-timeout#configure-the-allocated-outbound-ports
     }

--- a/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/foundational/k8s.tf
@@ -42,7 +42,7 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
   }
 
   network_profile {
-    network_plugin = "azure"
+    network_plugin = "kubenet"
     load_balancer_profile {
       outbound_ports_allocated = 5000 # https://learn.microsoft.com/en-us/azure/aks/configure-load-balancer-standard?tabs=create-cluster-ip-based%2Cupdate-cluster-managed-outbound-ips%2Ccreate-cluster-custom-ips%2Ccreate-cluster-custom-ip-prefixes%2Ccreate-cluster-outbound-ports-ips%2Ccreate-cluster-idle-timeout#configure-the-allocated-outbound-ports
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced Kubernetes cluster networking by allocating additional outbound ports on the load balancer to improve connection handling, stability and scalability across test environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->