### PR TITLE
chore(release): add container images to release process

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,5 +15,10 @@
   "flux/otel-collector": "1.0.1",
   "flux/otel-operator": "1.1.1",
   "flux/traefik": "1.5.0",
-  "flux/whoami": "0.1.0"
+  "flux/whoami": "0.1.0",
+  "infrastructure/images/azure-devops-agent": "1.2.5",
+  "infrastructure/images/gh-runner": "0.1.2",
+  "infrastructure/images/k6-action": "0.0.23",
+  "infrastructure/images/k6-image": "1.4.2",
+  "infrastructure/images/terraform-azure-devops-agent": "0.8.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -67,6 +67,31 @@
     "flux/whoami": {
       "release-type": "simple",
       "component": "flux-oci-whoami"
+    },
+    "infrastructure/images/azure-devops-agent": {
+      "release-type": "simple",
+      "component": "azdevops-agent",
+      "include-v-in-tag": false
+    },
+    "infrastructure/images/gh-runner": {
+      "release-type": "simple",
+      "component": "ghrunner",
+      "include-v-in-tag": false
+    },
+    "infrastructure/images/k6-action": {
+      "release-type": "simple",
+      "component": "k6-action-image",
+      "include-v-in-tag": false
+    },
+    "infrastructure/images/k6-image": {
+      "release-type": "simple",
+      "component": "k6-image",
+      "include-v-in-tag": false
+    },
+    "infrastructure/images/terraform-azure-devops-agent": {
+      "release-type": "simple",
+      "component": "tf-azdev-agent",
+      "include-v-in-tag": false
     }
   },
   "separate-pull-requests": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds configuration for container images to the release-please setup.

The following image paths are now included:
- infrastructure/images/azure-devops-agent
- infrastructure/images/gh-runner
- infrastructure/images/k6-action
- infrastructure/images/k6-image
- infrastructure/images/terraform-azure-devops-agent

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release management configurations to support versioning and release automation for five infrastructure image packages: Azure DevOps agent, GitHub runner, K6 action, K6 image, and Terraform Azure DevOps agent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->