### PR TITLE
chore: bump grafana/k6 to 1.5.0

### DIFF
--- a/infrastructure/images/k6-image/Dockerfile
+++ b/infrastructure/images/k6-image/Dockerfile
@@ -9,5 +9,5 @@ RUN xk6 build \
     --with github.com/phymbert/xk6-sse \
     --output /k6
 
-FROM grafana/k6:1.4.2@sha256:3656673de3f30424e8ebcfa46acd9558d83b6a43612d0f668ffeac953950c6c7
+FROM grafana/k6:1.5.0@sha256:2072ea9eafa596532d9aee0cc0e0a50cfb0e7fb703981a46179af5f4f22c5ea4
 COPY --from=builder /k6 /usr/bin/k6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated k6 performance testing tool to version 1.5.0, incorporating latest enhancements and stability improvements.
  * Improved build integration to ensure k6 is properly configured and available in the testing environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->