### PR TITLE
fix(observability): support existing AMW DCR and refactor permissions

### DIFF
--- a/infrastructure/modules/observability/amw-collection.tf
+++ b/infrastructure/modules/observability/amw-collection.tf
@@ -56,10 +56,3 @@ resource "azurerm_monitor_data_collection_rule_association" "amw" {
     azurerm_monitor_data_collection_rule.amw
   ]
 }
-
-resource "azurerm_role_assignment" "otel_collector_metrics_publisher" {
-  count                = var.enable_aks_monitoring ? 1 : 0
-  scope                = azurerm_monitor_data_collection_rule.amw[0].id
-  principal_id         = azuread_service_principal.sp.object_id
-  role_definition_name = "Monitoring Metrics Publisher"
-}

--- a/infrastructure/modules/observability/locals.tf
+++ b/infrastructure/modules/observability/locals.tf
@@ -4,6 +4,7 @@ locals {
   reuse_amw = var.reuse_monitor_workspace
   reuse_law = var.reuse_log_analytics_workspace
   reuse_ai  = var.reuse_application_insights
+  reuse_dcr = !var.enable_aks_monitoring 
 }
 
 locals {
@@ -30,6 +31,8 @@ locals {
     name = one(azurerm_monitor_workspace.obs).name
     id   = one(azurerm_monitor_workspace.obs).id
   }
+
+  dcr_id = local.reuse_dcr ? var.monitor_workspace_data_collection_rule_id : one(azurerm_monitor_data_collection_rule.amw).id
 
   ai = local.reuse_ai ? {
     name              = null

--- a/infrastructure/modules/observability/output.tf
+++ b/infrastructure/modules/observability/output.tf
@@ -26,6 +26,6 @@ output "lakmus_client_id" {
 }
 
 output "monitor_workspace_write_endpoint" {
-  value = var.enable_aks_monitoring ? "${azurerm_monitor_data_collection_endpoint.amw[0].metrics_ingestion_endpoint}/dataCollectionRules/${azurerm_monitor_data_collection_rule.amw[0].immutable_id}/streams/Microsoft-PrometheusMetrics/api/v1/write?api-version=2023-04-24" : ""
+  value       = var.enable_aks_monitoring ? "${azurerm_monitor_data_collection_endpoint.amw[0].metrics_ingestion_endpoint}/dataCollectionRules/${azurerm_monitor_data_collection_rule.amw[0].immutable_id}/streams/Microsoft-PrometheusMetrics/api/v1/write?api-version=2023-04-24" : ""
   description = "Metrics ingestion endpoint url. If enable_aks_monitoring is set to false this will return an empty string"
 }

--- a/infrastructure/modules/observability/permissions.tf
+++ b/infrastructure/modules/observability/permissions.tf
@@ -1,0 +1,5 @@
+resource "azurerm_role_assignment" "otel_collector_metrics_publisher" {
+  scope                = local.dcr_id
+  principal_id         = azuread_service_principal.sp.object_id
+  role_definition_name = "Monitoring Metrics Publisher"
+}

--- a/infrastructure/modules/observability/variables.tf
+++ b/infrastructure/modules/observability/variables.tf
@@ -110,6 +110,16 @@ variable "monitor_workspace_id" {
   }
 }
 
+variable "monitor_workspace_data_collection_rule_id" {
+  type        = string
+  default     = null
+  description = "ID of an existing Azure Monitor Workspace Data Collection Rule when reusing."
+  validation {
+    condition     = var.enable_aks_monitoring ? (var.monitor_workspace_data_collection_rule_id == null) : (var.monitor_workspace_data_collection_rule_id != null && trimspace(var.monitor_workspace_data_collection_rule_id) != "") 
+    error_message = "monitor_workspace_data_collection_rule_id must be non-empty when enable_aks_monitoring is false, and null when true."
+  }
+}
+
 variable "monitor_workspace_name" {
   type        = string
   default     = null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introduces monitor_workspace_data_collection_rule_id to allow reusing an existing Data Collection Rule.

Refactors role assignments into permissions.tf and centralizes DCR ID resolution in locals. Ensures strict validation where the DCR ID is mandatory if AKS monitoring creation is disabled.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reusing existing data collection rules in Azure Monitor Workspace, enabling integration with existing monitoring infrastructure without creating duplicate resources.
  * Introduced conditional validation for data collection rule configuration based on monitoring deployment mode.

* **Chores**
  * Reorganized monitoring permission configuration for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->