### PR TITLE
Use Annotations instead of labels. Populate Loki log label from annotations

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -83,13 +84,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "prod-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "prod-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -83,13 +84,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "prod-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "prod-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "tt02-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "tt02-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -83,13 +84,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "tt02-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "tt02-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "yt01-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "yt01-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -83,13 +84,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "yt01-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "yt01-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -71,13 +72,14 @@
          ],
          "image": "grafana/k6:master-with-browser",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-pre-determined"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-pre-determined",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-pre-determined"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-pre-determined",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments-smoke"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments-smoke",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments-smoke"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments-smoke",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "yt01-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "yt01-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "yt01-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "yt01-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -67,13 +68,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-daemonsets",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "yt01-get-daemonsets"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-daemonsets",
-         "test_name": "get-daemonsets",
-         "test_scope": "k8s-wrapper",
-         "testid": "yt01-get-daemonsets",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -75,13 +76,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-daemonsets",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "yt01-get-daemonsets"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-daemonsets",
-               "test_name": "get-daemonsets",
-               "test_scope": "k8s-wrapper",
-               "testid": "yt01-get-daemonsets",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -83,13 +84,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -77,13 +78,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -2,13 +2,14 @@
    "apiVersion": "k6.io/v1alpha1",
    "kind": "TestRun",
    "metadata": {
+      "annotations": {
+         "k6-action-image/test_name": "get-deployments",
+         "k6-action-image/test_scope": "k8s-wrapper",
+         "k6-action-image/testid": "at22-get-deployments"
+      },
       "labels": {
          "generated-by": "k6-action-image",
-         "k6-test": "get-deployments",
-         "test_name": "get-deployments",
-         "test_scope": "k8s-wrapper",
-         "testid": "at22-get-deployments",
-         "uniq-name": "{{ .UniqName }}"
+         "uniq_name": "{{ .UniqName }}"
       },
       "name": "{{ .UniqName }}",
       "namespace": "platform"
@@ -79,13 +80,14 @@
          ],
          "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
          "metadata": {
+            "annotations": {
+               "k6-action-image/test_name": "get-deployments",
+               "k6-action-image/test_scope": "k8s-wrapper",
+               "k6-action-image/testid": "at22-get-deployments"
+            },
             "labels": {
                "generated-by": "k6-action-image",
-               "k6-test": "get-deployments",
-               "test_name": "get-deployments",
-               "test_scope": "k8s-wrapper",
-               "testid": "at22-get-deployments",
-               "uniq-name": "{{ .UniqName }}"
+               "uniq_name": "{{ .UniqName }}"
             }
          },
          "nodeSelector": { },

--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -408,11 +408,12 @@ func (r K8sManifestGenerator) CallKubectl(dirName string, configMapName string, 
 	}
 	temp.SetLabels(map[string]string{
 		"generated-by": "k6-action-image",
-		"k6-test":      testName,
-		"test_name":    testName,
-		"test_scope":   testScope,
-		"testid":       testId,
-		"uniq-name":    uniqName,
+		"uniq_name":    uniqName,
+	})
+	temp.SetAnnotations(map[string]string{
+		"k6-action-image/test_name":  testName,
+		"k6-action-image/test_scope": testScope,
+		"k6-action-image/testid":     testId,
 	})
 
 	tempMarshalled, err := json.MarshalIndent(temp, "", "  ")

--- a/actions/generate-k6-manifests/cmd/generator_test.go
+++ b/actions/generate-k6-manifests/cmd/generator_test.go
@@ -106,8 +106,8 @@ func validateConfigMap(path, testVersion, dirName string, t *testing.T) {
 	if !strings.Contains(generatedConfigMap.Name, dirName) {
 		t.Errorf("generate %s: expected \n%s to contain \n%s", testVersion, generatedConfigMap.Name, dirName)
 	}
-	if !strings.Contains(generatedConfigMap.Labels["testid"], dirName) {
-		t.Errorf("generate %s: expected \n%s, to contain \n%s", testVersion, generatedConfigMap.Labels["testid"], dirName)
+	if !strings.Contains(generatedConfigMap.Annotations["k6-action-image/testid"], dirName) {
+		t.Errorf("generate %s: expected \n%s, to contain \n%s", testVersion, generatedConfigMap.Annotations["k6-action-image/testid"], dirName)
 	}
 	if !(len(generatedConfigMap.Data["archive.tar"]) > 0) {
 		t.Errorf("generate %s: expected length of data in key archive.tar to be over 0 , actual %d", testVersion, len(generatedConfigMap.Data["archive.tar"]))

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring_values.tftpl
@@ -33,6 +33,10 @@ podLogs:
     app_kubernetes_io_name: app.kubernetes.io/name
     testid: testid
     test_name: test_name
+  annotations:
+    testid: "k6-action-image/testid"
+    test_scope: "k6-action-image/test_scope"
+    test_name: "k6-action-image/test_name"
   labelsToKeep:
     - app.kubernetes.io/name
     - container
@@ -53,7 +57,9 @@ podLogs:
     - k8s.node.name
     # custom
     - testid
+    - test_scope
     - test_name
+
 
 # Collectors
 alloy-singleton:

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring_values.tftpl
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring_values.tftpl
@@ -33,6 +33,10 @@ podLogs:
     app_kubernetes_io_name: app.kubernetes.io/name
     testid: testid
     test_name: test_name
+  annotations:
+    testid: "k6-action-image/testid"
+    test_scope: "k6-action-image/test_scope"
+    test_name: "k6-action-image/test_name"
   labelsToKeep:
     - app.kubernetes.io/name
     - container
@@ -53,7 +57,9 @@ podLogs:
     - k8s.node.name
     # custom
     - testid
+    - test_scope
     - test_name
+
 
 # Collectors
 alloy-singleton:

--- a/infrastructure/images/k6-action/jsonnet/main.jsonnet
+++ b/infrastructure/images/k6-action/jsonnet/main.jsonnet
@@ -49,12 +49,13 @@ local default_env = [
 ];
 
 local common_labels = {
-  'k6-test': test_name,
-  testid: testid,
-  test_name: test_name,
-  test_scope: test_scope,
-  'uniq-name': unique_name,
+  uniq_name: unique_name,
   'generated-by': 'k6-action-image',
+};
+local common_annotations = {
+  'k6-action-image/test_name': test_name,
+  'k6-action-image/test_scope': test_scope,
+  'k6-action-image/testid': testid,
 };
 
 local slo = {
@@ -100,7 +101,9 @@ local testrun = {
       name: unique_name,
       namespace: namespace,
       labels: common_labels,
+      annotations: common_annotations,
     },
+
     spec: {
       cleanup: 'post',
       arguments: std.stripChars(
@@ -118,6 +121,7 @@ local testrun = {
         env: default_env,
         metadata: {
           labels: common_labels,
+          annotations: common_annotations,
         },
         resources: resources,
         envFrom+: [{


### PR DESCRIPTION
Labels have a 60-ish character limitation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved test identity metadata from labels into annotations across TestRun manifests and embedded image metadata.
  * Standardized the test label to uniq_name (renamed from uniq-name) everywhere.
  * Propagated new annotations into runner/image sections and monitoring templates so test identifiers are preserved in pod logs and config outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->