### PR TITLE
fix: postbuild subsctitute replaces workload identity setup.

### DIFF
--- a/flux/otel-collector/collector.yaml
+++ b/flux/otel-collector/collector.yaml
@@ -42,9 +42,9 @@ spec:
         scopes:
           - https://monitor.azure.com/.default
         workload_identity:
-          tenant_id: "${env:AZURE_TENANT_ID}"
-          client_id: "${env:AZURE_CLIENT_ID}"
-          federated_token_file: "${env:AZURE_FEDERATED_TOKEN_FILE}"
+          tenant_id: "$${env:AZURE_TENANT_ID}"
+          client_id: "$${env:AZURE_CLIENT_ID}"
+          federated_token_file: "$${env:AZURE_FEDERATED_TOKEN_FILE}"
     processors:
       batch: {}
       # Extract aks cluster name


### PR DESCRIPTION
…$ should result in no replace and correct value after substitute

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding double dollar signs ($$) should result in output of single dollar sign after postBuild substitute is done.
$${env:AZURE_TENANT_ID} should after substitute be ${env:AZURE_TENANT_ID} keeping the neccessary style required by the otel collector

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure authentication configuration to properly preserve environment variable references in the OpenTelemetry collector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->