### PR TITLE
Don't add a default scenario if user has configured the workload

### DIFF
--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -336,8 +336,11 @@ func (r K8sManifestGenerator) HandleConfigFile(defaultConfigFile string, testTyp
 
 	_, okst := mergedOut["stages"]
 	_, oksc := mergedOut["scenarios"]
+	_, okit := mergedOut["iterations"]
+	_, okvus := mergedOut["vus"]
+	_, okduration := mergedOut["duration"]
 	// Don't override if users configured it.
-	if !(okst || oksc) {
+	if !(okst || oksc || okit || okvus || okduration) {
 		defaultScenario, err := os.ReadFile(fmt.Sprintf("%s/%s.json", r.DefaultScenariosDirectory, testType))
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring iterations, virtual users (vus), and duration parameters directly
  * Enhanced configuration behavior to prioritize user-provided settings and only load default scenarios when no custom configuration is present

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->