### PR TITLE
fix: add kubernetes wrapper to heavy sampling rule

### DIFF
--- a/flux/otel-collector/collector.yaml
+++ b/flux/otel-collector/collector.yaml
@@ -161,8 +161,12 @@ spec:
                   type: string_attribute
                   string_attribute:
                     key: http.route
-                    values: [/metrics, /health]
+                    values: 
+                      - "^/metrics"
+                      - "^/health"
+                      - "^/kuberneteswrapper/.*"
                     invert_match: true
+                    enabled_regex_matching: true
                 - name: probabilistic-policy
                   type: probabilistic
                   probabilistic:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
we use kuberneteswrapper for up tests, this creates a lot of traces. 
This intoruces heavy sampling on the kuberneteswrapper api

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched telemetry sampling policies to regex-based path matching instead of fixed path lists.
  * Added additional path patterns and enabled regex matching for the affected sampling policies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->