### PR TITLE
Add the test_scope as an env var

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -72,6 +72,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -72,6 +72,10 @@
             {
                "name": "TESTID",
                "value": "prod-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
@@ -72,6 +72,10 @@
             {
                "name": "TESTID",
                "value": "tt02-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -72,6 +72,10 @@
             {
                "name": "TESTID",
                "value": "yt01-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -58,6 +58,10 @@
                "value": "at22-get-deployments"
             },
             {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
+            },
+            {
                "name": "ZZZ",
                "value": "Something"
             }

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-pre-determined"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v13/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v13/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments-smoke"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "yt01-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -64,6 +64,10 @@
             {
                "name": "TESTID",
                "value": "yt01-get-daemonsets"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -58,6 +58,10 @@
                "value": "at22-get-deployments"
             },
             {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
+            },
+            {
                "name": "orgNoRecipient",
                "value": "1234"
             },

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -56,6 +56,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -68,6 +68,10 @@
             {
                "name": "TESTID",
                "value": "at22-get-deployments"
+            },
+            {
+               "name": "TEST_SCOPE",
+               "value": "k8s-wrapper"
             }
          ],
          "envFrom": [

--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -136,6 +136,7 @@ func generate(td *TestDefinition, c *TestContext, r K8sManifestGenerator, cf Con
 		"--env", fmt.Sprintf("%s=%s", "ENVIRONMENT", c.Environment),
 		"--env", fmt.Sprintf("%s=%s", "NAMESPACE", cf.Namespace),
 		"--env", fmt.Sprintf("%s=%d", "MANIFEST_GENERATION_TIMESTAMP", manifestGenerationTimestamp),
+		"--env", fmt.Sprintf("%s=%s", "TEST_SCOPE", td.TestScope),
 		"--env", fmt.Sprintf("%s=%s", "TESTID", *c.TestRun.Id),
 		"--env", fmt.Sprintf("%s=%s", "TEST_NAME", *c.TestRun.Name),
 		"--env", fmt.Sprintf("%s=%s", "TESTFILENAME", testFilename),

--- a/infrastructure/images/k6-action/jsonnet/main.jsonnet
+++ b/infrastructure/images/k6-action/jsonnet/main.jsonnet
@@ -55,6 +55,10 @@ local default_env = [
     name: 'TESTFILENAME',
     value: testfilename,
   },
+  {
+    name: 'TEST_SCOPE',
+    value: test_scope,
+  },
 ];
 
 local common_labels = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TEST_SCOPE environment variable to test runner configurations across all versions and deployment scenarios. This variable provides test scope context information to test execution environments.
  * Test runners can now access scope metadata during execution, improving visibility into test environment configuration and execution context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->