### PR TITLE
feat: Add conditional User Access Administrator for ACR

### DIFF
--- a/infrastructure/adminservices-prod/altinncr/iam.tf
+++ b/infrastructure/adminservices-prod/altinncr/iam.tf
@@ -32,3 +32,14 @@ resource "azurerm_role_assignment" "altinncr_acrpush_altinn_platform" {
   scope                            = azurerm_container_registry.acr.id
   skip_service_principal_aad_check = true
 }
+
+resource "azurerm_role_assignment" "altinncr_user_access_admin_acr_pull" {
+  for_each                         = { for assignee in var.user_access_admin_acr_pull_object_ids : assignee.object_id => assignee }
+  principal_id                     = each.value.object_id
+  role_definition_name             = "User Access Administrator"
+  principal_type                   = each.value.type
+  scope                            = azurerm_container_registry.acr.id
+  skip_service_principal_aad_check = true
+  condition                        = "@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {7f951dda-4ed3-4680-a7ca-43fe172d538d}"
+  condition_version                = "2.0"
+}

--- a/infrastructure/adminservices-prod/altinncr/terraform.tfvars
+++ b/infrastructure/adminservices-prod/altinncr/terraform.tfvars
@@ -93,7 +93,22 @@ acr_push_object_ids = [
 
 acr_pull_object_ids = [
   {
-    object_id = "416302ed-fbab-41a4-8c8d-61f486fa79ca" # Group: Altinn-30-Test-Developers 
+    object_id = "416302ed-fbab-41a4-8c8d-61f486fa79ca" # Group: Altinn-30-Test-Developers
     type      = "Group"
+  }
+]
+
+user_access_admin_acr_pull_object_ids = [
+  {
+    object_id = "4da564b5-c526-42f2-aa01-108c5b4932f2" # uami: github-core_dis-core-test
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "476e7604-4701-48da-953e-e6616cfedd15" # uami: github-core_dis-core-staging
+    type      = "ServicePrincipal"
+  },
+  {
+    object_id = "9bfd0ad4-9f59-4ad5-b8e5-a9664ec375fd" # uami: github-core_dis-core-prod
+    type      = "ServicePrincipal"
   }
 ]

--- a/infrastructure/adminservices-prod/altinncr/variables.tf
+++ b/infrastructure/adminservices-prod/altinncr/variables.tf
@@ -38,3 +38,12 @@ variable "acr_pull_object_ids" {
   description = "{object_id, type} objects that should be granted AcrPull and Reader role on the container registry. Type should be either ServicePrincipal, Group or User."
   default     = []
 }
+
+variable "user_access_admin_acr_pull_object_ids" {
+  type = set(object({
+    object_id = string
+    type      = string
+  }))
+  description = "{object_id, type} objects that should be granted User Access Administrator role with condition to only assign AcrPull role on the container registry. Type should be either ServicePrincipal, Group or User."
+  default     = []
+}


### PR DESCRIPTION
Create azurerm_role_assignment with a condition restricting role assignments to the AcrPull role (role definition GUID). Add variable user_access_admin_acr_pull_object_ids and populate terraform.tfvars with three service principals to grant the conditional access.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated role-based access control configurations for container registry service management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->