### PR TITLE
chore: Remove test infrastrure for k6 cluster

### DIFF
--- a/infrastructure/adminservices-test/k6tests-rg/data.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/data.tf
@@ -1,3 +1,4 @@
+/*
 data "azurerm_kubernetes_cluster" "k6tests" {
   depends_on          = [module.foundational]
   name                = module.foundational.k6tests_cluster_name
@@ -17,5 +18,5 @@ data "azurerm_monitor_data_collection_rule" "k6tests" {
   name                = "k6tests-dcr${local.suffix}"
   resource_group_name = module.foundational.k6tests_resource_group_name
 }
-
+*/
 data "azurerm_client_config" "current" {}

--- a/infrastructure/adminservices-test/k6tests-rg/locals.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/locals.tf
@@ -1,3 +1,4 @@
+/*
 locals {
   tenant_id = data.azurerm_client_config.current.tenant_id
 
@@ -54,3 +55,4 @@ locals {
 
   data_collection_rule_id = data.azurerm_monitor_data_collection_endpoint.k6tests.id
 }
+*/

--- a/infrastructure/adminservices-test/k6tests-rg/main.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/main.tf
@@ -2,7 +2,7 @@ resource "random_string" "suffix" {
   length  = 4
   special = false
 }
-
+/*
 module "foundational" {
   source     = "./modules/foundational"
   tenant_id  = local.tenant_id

--- a/infrastructure/adminservices-test/k6tests-rg/outputs.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/outputs.tf
@@ -1,3 +1,4 @@
+/*
 output "k6tests_cluster_name" {
   value = local.k6tests_cluster_name
 }
@@ -5,3 +6,4 @@ output "k6tests_cluster_name" {
 output "k6tests_resource_group_name" {
   value = local.k6tests_resource_group_name
 }
+*/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled specific infrastructure modules in the test environment while preserving their configurations for potential restoration.
  * Disabled related infrastructure data lookups in the test environment to prevent their use during current test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->