### PR TITLE
chore: bump k6 image to 1.6

### DIFF
--- a/infrastructure/images/k6-image/Dockerfile
+++ b/infrastructure/images/k6-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine@sha256:d9b2e14101f27ec8d09674cd01186798d227bb0daec90e032aeb1cd22ac0f029 AS builder
+FROM golang:1.26-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5 AS builder
 RUN apk update && apk upgrade && apk add git
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
@@ -9,5 +9,5 @@ RUN xk6 build \
     --with github.com/phymbert/xk6-sse \
     --output /k6
 
-FROM grafana/k6:1.5.0@sha256:2072ea9eafa596532d9aee0cc0e0a50cfb0e7fb703981a46179af5f4f22c5ea4
+FROM grafana/k6:1.6@sha256:be2a9ceb1b6ffc573277af4157135882a6d6433968b41e858ab02c5fd5847532
 COPY --from=builder /k6 /usr/bin/k6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated k6 load testing tool to version 1.6 (previously 1.5.0)
  * Upgraded Go builder environment to version 1.26 (previously 1.25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->