### PR TITLE
chore: bump versions in k6-action-image

### DIFF
--- a/infrastructure/images/k6-action/.trivyignore
+++ b/infrastructure/images/k6-action/.trivyignore
@@ -1,32 +1,23 @@
-# Calling Verify with a VerifyOptions.KeyUsages that contains ExtKeyUsageAny unintentionally disabledpolicy validation.
-# This only affected certificate chains which contain policy graphs, which are rather uncommon.
-CVE-2025-22874
-
-# Calling Decoder.Decode on a message which contains deeply nested structures can cause a panic due to stack exhaustion. This is a follow-up to CVE-2022-30635.
+# https://avd.aquasec.com/nvd/cve-2024-34156
 CVE-2024-34156
 
-# database/sql: Postgres Scan Race Condition https://avd.aquasec.com/nvd/cve-2025-47907
+# https://avd.aquasec.com/nvd/cve-2025-47907
 CVE-2025-47907
 
-# If the PATH environment variable contains paths which are executables (rather than just directories), passing certain strings to LookPath (, ., and ..), can result in the binaries listed in the PATH being unexpectedly returned.
-CVE-2025-47906
-
-# The Parse function permits values other than IPv6 addresses to be included in square brackets within the host component of a URL
-CVE-2025-47912
-
-# tar.Reader does not set a maximum size on the number of sparse region data blocks in GNU tar pax 1.0 sparse files. A maliciously-crafted archive containing a large number of sparse regions can cause a Reader to read an unbounded amount of data from the archive into memory. When reading from a compressed source, a small compressed input can result in large allocations.
+# https://avd.aquasec.com/nvd/cve-2025-58183
 CVE-2025-58183
 
-# Despite HTTP headers having a default limit of 1MB, the number of cookies that can be parsed does not have a limit. By sending a lot of very small cookies such as a=;, an attacker can make an HTTP server allocate a large amount of structs, causing large memory consumption.
-CVE-2025-58186
-
-# Due to the design of the name constraint checking algorithm, the processing time of some inputs scals non-linearly with respect to the size of the certificate. This affects programs which validate arbitrary certificate chains.
-CVE-2025-58187
-
-# Validating certificate chains which contain DSA public keys can cause programs to panic, due to a interface cast that assumes they implement the Equal method. This affects programs which validate arbitrary certificate chains.
-CVE-2025-58188
-
-# The Reader.ReadResponse function constructs a response string through repeated string concatenation of lines. When the number of lines in a response is large, this can cause excessive CPU consumption.
-CVE-2025-61724
-# Within HostnameError.Error(), when constructing an error string, there is no limit to the number of hosts that will be printed out. Furthermore, the error string is constructed by repeated string concatenation, leading to quadratic runtime. Therefore, a certificate provided by a malicious actor can result in excessive resource consumption.
+# https://avd.aquasec.com/nvd/cve-2025-61729
 CVE-2025-61729
+
+# https://avd.aquasec.com/nvd/cve-2025-68121
+CVE-2025-68121
+
+# https://avd.aquasec.com/nvd/cve-2025-61726
+CVE-2025-61726
+
+# https://avd.aquasec.com/nvd/cve-2025-61728
+CVE-2025-61728
+
+# https://avd.aquasec.com/nvd/cve-2025-61730
+CVE-2025-61730

--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.25-alpine@sha256:d9b2e14101f27ec8d09674cd01186798d227bb0daec90e032aeb1cd22ac0f029 AS builder
+FROM golang:1.26-alpine@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5 AS builder
 # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
-ARG KUBECTL_VERSION=1.35.0
+ARG KUBECTL_VERSION=1.35.1
 # renovate: datasource=github-releases depName=kubeseal packageName=bitnami-labs/sealed-secrets versioning=semver extractVersion=^sealed-secrets-(?<version>.*)$
 ARG KUBESEAL_VERSION=0.34.0
 # renovate: datasource=github-releases depName=jsonnet packageName=google/jsonnet versioning=semver
@@ -56,10 +56,10 @@ RUN go build . && \
     chmod +x generate-k6-manifests && \
     mv generate-k6-manifests /usr/local/bin
 
-FROM ghcr.io/altinn/altinn-platform/k6-image:v1.5.0@sha256:2ae4a209e8fed3c524f585162e2c7df8216159662c89a3627a67d302723585f3 AS k6image
+FROM ghcr.io/altinn/altinn-platform/k6-image:v1.6@sha256:278928e7ec44d5881f9041e24e29732c814567433ebd48be137b9dadf45af1af  AS k6image
 
 # Final image with the needed binaries and helper files
-FROM alpine:3.23.2@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /jsonnet/vendor /jsonnet/vendor
 COPY --from=k6image /usr/bin/k6 /usr/bin/k6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base images and build tooling to newer stable versions.
  * Added additional tooling and runtime dependencies to the build image to support manifest generation.
  * Adjusted image assembly to include infrastructure assets.
* **Security**
  * Revised vulnerability ignore list to reference updated advisories and reflect newer CVE entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->