### PR TITLE
fix(dis-identity): add correct client-id annotation to service account

### DIFF
--- a/services/dis-identity-operator/api/v1alpha1/applicationidentity_extensions.go
+++ b/services/dis-identity-operator/api/v1alpha1/applicationidentity_extensions.go
@@ -96,7 +96,7 @@ func (a *ApplicationIdentity) OutdatedServiceAccount(serviceAccount *corev1.Serv
 	if serviceAccount == nil {
 		return true
 	}
-	id, ok := serviceAccount.Annotations["serviceaccount.azure.com/azure-identity"]
+	id, ok := serviceAccount.Annotations["azure.workload.identity/client-id"]
 	if !ok && a.Status.ClientID != nil {
 		return true
 	}

--- a/services/dis-identity-operator/internal/controller/applicationidentity_controller_sa.go
+++ b/services/dis-identity-operator/internal/controller/applicationidentity_controller_sa.go
@@ -23,6 +23,7 @@ func (r *ApplicationIdentityReconciler) createServiceAccount(ctx context.Context
 			Labels:    applicationIdentity.Spec.Tags,
 			Annotations: map[string]string{
 				"serviceaccount.azure.com/azure-identity": *applicationIdentity.Status.ClientID,
+				"azure.workload.identity/client-id":       *applicationIdentity.Status.ClientID,
 			},
 		},
 		Secrets:                      nil,
@@ -45,6 +46,7 @@ func (r *ApplicationIdentityReconciler) updateServiceAccount(ctx context.Context
 		serviceAccount.Labels = applicationIdentity.Spec.Tags
 		serviceAccount.Annotations = map[string]string{
 			"serviceaccount.azure.com/azure-identity": *applicationIdentity.Status.ClientID,
+			"azure.workload.identity/client-id":       *applicationIdentity.Status.ClientID,
 		}
 		if err := r.Patch(ctx, serviceAccount, patch); err != nil {
 			return fmt.Errorf("unable to update ServiceAccount: %w", err)

--- a/services/dis-identity-operator/internal/controller/applicationidentity_controller_test.go
+++ b/services/dis-identity-operator/internal/controller/applicationidentity_controller_test.go
@@ -204,6 +204,7 @@ var _ = Describe("ApplicationIdentity Controller", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(serviceAccount.Annotations).NotTo(BeEmpty())
 				g.Expect(serviceAccount.Annotations["serviceaccount.azure.com/azure-identity"]).To(Equal(*appIdentity.Status.ClientID))
+				g.Expect(serviceAccount.Annotations["azure.workload.identity/client-id"]).To(Equal(*appIdentity.Status.ClientID))
 				err = k8sClient.Get(ctx, typeNamespacedName, appIdentity)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(appIdentity.Status.Conditions).NotTo(BeEmpty())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Correct the annotation according to https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#service-account-annotations

Let the old remain as I have no idea how I dreamed up that annotation, afraid i had som legacy function.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated service account annotations to support Azure Workload Identity standard format. Service accounts now include the `azure.workload.identity/client-id` annotation alongside existing annotations, with backward compatibility maintained through fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->