### PR TITLE
fix(aks-resources): use aks RG instead og node pool RG in dis-pgsql

### DIFF
--- a/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
+++ b/infrastructure/adminservices-test/admin-test-aks-rg/aks.tf
@@ -64,4 +64,5 @@ module "aks_resources" {
   dis_pgsql_uami_client_id                   = module.test-pgsql-vnet.dispgsql_uami_client_id
   enable_dis_pgsql_operator                  = true
   aks_workpool_vnet_name                     = module.aks.aks_workpool_vnet_name
+  aks_resource_group                         = module.aks.aks_workpool_vnet_resource_group_name
 }

--- a/infrastructure/modules/aks-resources/dis-pgsql.tf
+++ b/infrastructure/modules/aks-resources/dis-pgsql.tf
@@ -17,7 +17,7 @@ resource "azapi_resource" "dis_pgsql_operator" {
               DISPG_DB_RESOURCE_GROUP = "${var.dis_resource_group_name}"
               DISPG_DB_VNET_NAME = "${var.dis_db_vnet_name}"
               DISPG_AKS_VNET_NAME = "${var.aks_workpool_vnet_name}"
-              DISPG_AKS_RESOURCE_GROUP = "${var.aks_node_resource_group}"
+              DISPG_AKS_RESOURCE_GROUP = "${var.aks_resource_group}"
               DISPG_WORKLOAD_IDENTITY_CLIENT_ID = "${var.dis_pgsql_uami_client_id}"
             }
           }

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -8,6 +8,11 @@ variable "aks_node_resource_group" {
   description = "AKS node resource group name"
 }
 
+variable "aks_resource_group" {
+  type        = string
+  description = "AKS resource group name"
+}
+
 variable "azurerm_kubernetes_cluster_id" {
   type        = string
   description = "AKS cluster resource id"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It was using the wrong RG
## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration for AKS resource group references and module input wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->