### PR TITLE
fix(dis-pgsql): reconcile existent pdvnet links

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_dns.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_dns.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
+	k8sutil "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/k8s"
 	networkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20240601"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
@@ -118,6 +119,32 @@ func (r *DatabaseReconciler) ensurePrivateDNSVNetLink(
 	vnetID string,
 ) error {
 	ns := db.Namespace
+	loc := "global"
+	regFalse := false
+	desiredLabels := map[string]string{
+		"dis.altinn.cloud/database-name": db.Name,
+	}
+	desiredSpec := networkv1.PrivateDnsZonesVirtualNetworkLink_Spec{
+		AzureName: linkName,
+		Location:  &loc,
+
+		// REQUIRED: owner is the PrivateDnsZone CR
+		Owner: &genruntime.KnownResourceReference{
+			Name: zoneName,
+		},
+
+		RegistrationEnabled: &regFalse,
+
+		VirtualNetwork: &networkv1.SubResource{
+			Reference: &genruntime.ResourceReference{
+				ARMID: vnetID,
+			},
+		},
+
+		Tags: map[string]string{
+			"dis-database": db.Name,
+		},
+	}
 
 	key := types.NamespacedName{
 		Name:      linkName,
@@ -126,43 +153,36 @@ func (r *DatabaseReconciler) ensurePrivateDNSVNetLink(
 
 	var existing networkv1.PrivateDnsZonesVirtualNetworkLink
 	if err := r.Get(ctx, key, &existing); err == nil {
+		var updated bool
+		existing.Labels, updated = k8sutil.SyncSpecAndLabels(
+			&existing.Spec,
+			desiredSpec,
+			existing.Labels,
+			desiredLabels,
+		)
+		if updated {
+			logger.Info("updating private DNS VNet link",
+				"linkName", existing.Name,
+				"zoneName", zoneName,
+				"vnetName", targetVNetName,
+				"vnetID", vnetID,
+			)
+			if err := r.Update(ctx, &existing); err != nil {
+				return fmt.Errorf("update PrivateDnsZonesVirtualNetworkLink %s/%s: %w", existing.Namespace, existing.Name, err)
+			}
+		}
 		return nil
 	} else if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("get PrivateDnsZonesVirtualNetworkLink %s/%s: %w", key.Namespace, key.Name, err)
 	}
 
-	loc := "global"
-	regFalse := false
-
 	link := &networkv1.PrivateDnsZonesVirtualNetworkLink{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      linkName,
 			Namespace: ns,
-			Labels: map[string]string{
-				"dis.altinn.cloud/database-name": db.Name,
-			},
+			Labels:    desiredLabels,
 		},
-		Spec: networkv1.PrivateDnsZonesVirtualNetworkLink_Spec{
-			AzureName: linkName,
-			Location:  &loc,
-
-			// REQUIRED: owner is the PrivateDnsZone CR
-			Owner: &genruntime.KnownResourceReference{
-				Name: zoneName,
-			},
-
-			RegistrationEnabled: &regFalse,
-
-			VirtualNetwork: &networkv1.SubResource{
-				Reference: &genruntime.ResourceReference{
-					ARMID: vnetID,
-				},
-			},
-
-			Tags: map[string]string{
-				"dis-database": db.Name,
-			},
-		},
+		Spec: desiredSpec,
 	}
 
 	logger.Info("creating private DNS VNet link",

--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -14,6 +14,7 @@ import (
 	dbUtil "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/database"
 	dbforpostgresqlv1 "github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v20250801"
 	networkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20240601"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	asoconditions "github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -425,6 +426,68 @@ var _ = Describe("Database controller", func() {
 			Namespace: ns,
 		}, &dbLink)).To(Succeed())
 		Expect(dbLink.Namespace).To(Equal(ns))
+	})
+
+	It("reconciles existing Private DNS AKS VNet link when ARM ID drifts", func() {
+		db := &storagev1alpha1.Database{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-app-db-vnet-drift",
+				Namespace: ns,
+			},
+			Spec: storagev1alpha1.DatabaseSpec{
+				Version:    17,
+				ServerType: "dev",
+				Auth: directAuth(
+					"admin-mi",
+					"admin-mi-id",
+					"admin-mi",
+					"user-mi",
+					"user-mi-id",
+				),
+			},
+		}
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+
+		expectedAKSLinkName := vnetLinkNameForAKS(db)
+		expectedAKSVNetARMID := "/subscriptions/my-subscription-id/resourceGroups/aks-vnet-rg/providers/Microsoft.Network/virtualNetworks/aks-vnet-dis-dev-001"
+
+		Eventually(func(g Gomega) string {
+			var link networkv1.PrivateDnsZonesVirtualNetworkLink
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      expectedAKSLinkName,
+				Namespace: ns,
+			}, &link)).To(Succeed())
+			if link.Spec.VirtualNetwork == nil || link.Spec.VirtualNetwork.Reference == nil {
+				return ""
+			}
+			return link.Spec.VirtualNetwork.Reference.ARMID
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(expectedAKSVNetARMID))
+
+		var link networkv1.PrivateDnsZonesVirtualNetworkLink
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      expectedAKSLinkName,
+			Namespace: ns,
+		}, &link)).To(Succeed())
+		link.Spec.VirtualNetwork = &networkv1.SubResource{
+			Reference: &genruntime.ResourceReference{
+				ARMID: "/subscriptions/another-sub/resourceGroups/wrong-rg/providers/Microsoft.Network/virtualNetworks/wrong-vnet",
+			},
+		}
+		Expect(k8sClient.Update(ctx, &link)).To(Succeed())
+
+		Eventually(func(g Gomega) string {
+			var current networkv1.PrivateDnsZonesVirtualNetworkLink
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      expectedAKSLinkName,
+				Namespace: ns,
+			}, &current)).To(Succeed())
+			if current.Spec.VirtualNetwork == nil || current.Spec.VirtualNetwork.Reference == nil {
+				return ""
+			}
+			return current.Spec.VirtualNetwork.Reference.ARMID
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(expectedAKSVNetARMID))
 	})
 
 	// Database testing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the reconciliation process for DNS zone virtual network links to ensure existing resources are properly synchronized with the desired specification and labels.

* **Tests**
  * Added test case to validate that drifted ARM IDs in Private DNS virtual network links are correctly detected and restored during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->