### PR TITLE
chore: add syncroot integration for dis-demo-aalma

### DIFF
--- a/infrastructure/syncroots/terraform.tfvars.json
+++ b/infrastructure/syncroots/terraform.tfvars.json
@@ -34,6 +34,15 @@
       "branches": [
         "main"
       ]
+    },
+    "aalma": {
+      "repo_name": "dis-demo-aalma",
+      "environments": [
+        "at22"
+      ],
+      "branches": [
+        "main"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds federated credentials for the `dis-demo-aalma` product to push OCI syncroot images from `Altinn/dis-demo-aalma` repo
- Targets `at22` environment, `main` branch

## Related
- Companion PR in dis-way/core for deploying the Flux sync resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new repository synchronization mapping for an additional service repository and environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->