### PR TITLE
fix: Add DIS identity target tenant variable

### DIFF
--- a/infrastructure/modules/aks-resources/dis-identity.tf
+++ b/infrastructure/modules/aks-resources/dis-identity.tf
@@ -14,6 +14,7 @@ resource "azapi_resource" "dis_identity_operator" {
             substitute = {
               DISID_ISSUER_URL            = "${var.azurerm_kubernetes_cluster_oidc_issuer_url}"
               DISID_TARGET_RESOURCE_GROUP = "${var.azurerm_dis_identity_resource_group_id}"
+              DISID_TARGET_TENANT_ID      = "${var.dis_identity_target_tenant_id}"
             }
           }
           prune                  = false

--- a/infrastructure/modules/aks-resources/variables.tf
+++ b/infrastructure/modules/aks-resources/variables.tf
@@ -240,7 +240,7 @@ variable "aks_workpool_vnet_name" {
 }
 
 variable "dis_db_vnet_name" {
-  type = string
+  type        = string
   description = "The name of the VNet where the DIS PostgreSQL instance is deployed"
 }
 
@@ -257,4 +257,15 @@ variable "aks_vnet_ipv4_cidr" {
 variable "aks_vnet_ipv6_cidr" {
   type        = string
   description = "IPv6 CIDR of the AKS VNet"
+}
+
+variable "dis_identity_target_tenant_id" {
+  type        = string
+  description = "Tenant ID where dis-identity ApplicationIdentity will be created"
+  sensitive   = true
+  default     = ""
+  validation {
+    condition     = var.enable_dis_identity_operator == false || (var.enable_dis_identity_operator == true && length(var.dis_identity_target_tenant_id) > 0)
+    error_message = "You must provide a value for dis_identity_target_tenant_id when enable_dis_identity_operator is true."
+  }
 }


### PR DESCRIPTION
Validate the tenant ID when the operator is enabled and pass it to the DIS identity azapi resource substitutions

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for configuring the target tenant ID for Azure identity operations when the dis-identity operator is enabled.
  * Implemented validation to require proper identity target tenant configuration when dis-identity operator is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->