### PR TITLE
feat(dis-vault): add group role assignment for owners of the vault

### DIFF
--- a/services/dis-vault-operator/AGENTS.md
+++ b/services/dis-vault-operator/AGENTS.md
@@ -69,6 +69,7 @@ If you touch `api/**`:
 Before opening a PR, ensure:
 - Never run git push by yourself
 - Always suggest to create a new branch in case we are working on main by mistake
+- Do not use `git add -f` / `git add --force` when preparing PRs. If a file is ignored, treat it as local-only unless the user explicitly asks to stage it.
 
 ## PR description file
 - When working on a branch and making changes, always create or update `pr_description.md` in the repository root.
@@ -86,5 +87,7 @@ Before opening a PR, ensure:
 ## Code organization
 - `internal/controller` should only contain high-level controller duties and orchestration.
 - Domain logic should live in dedicated packages (for example `internal/pkg`, `internal/vault`).
+- Role-assignment reconciliation/helper logic in `internal/controller` should live in `vault_controller_role.go`.
+- ESO SecretStore reconciliation/helper logic in `internal/controller` should live in `vault_controller_secret_store.go`.
 - Tests for `internal/controller` code should live in `vault_controller_test.go` (Ginkgo) for high-level behavior coverage.
 - All remaining tests (packages that are not controller packages) should follow standard Go unit test conventions (`x.go` + `x_test.go`).

--- a/services/dis-vault-operator/Dockerfile
+++ b/services/dis-vault-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/services/dis-vault-operator/api/v1alpha1/vault_types.go
+++ b/services/dis-vault-operator/api/v1alpha1/vault_types.go
@@ -52,6 +52,12 @@ type VaultSpec struct {
 	// IdentityRef points to the owning ApplicationIdentity in the same namespace.
 	IdentityRef ApplicationIdentityRef `json:"identityRef"`
 
+	// GroupObjectID grants an optional Entra group access to the Key Vault.
+	// Lowercase is required to keep the identifier canonical in GitOps.
+	// +optional
+	// +kubebuilder:validation:Pattern="^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$"
+	GroupObjectID string `json:"groupObjectId,omitempty"`
+
 	// ExternalSecrets enables operator-managed namespaced SecretStore integration.
 	// +optional
 	// +kubebuilder:default=false
@@ -129,6 +135,7 @@ const (
 	ConditionIdentityReady        ConditionType = "IdentityReady"
 	ConditionVaultReady           ConditionType = "VaultReady"
 	ConditionRoleAssignmentReady  ConditionType = "RoleAssignmentReady"
+	ConditionGroupRoleAssignment  ConditionType = "GroupRoleAssignmentReady"
 	ConditionNetworkPolicyReady   ConditionType = "NetworkPolicyReady"
 	ConditionExternalSecretsReady ConditionType = "ExternalSecretsReady"
 )

--- a/services/dis-vault-operator/config/crd/bases/vault.dis.altinn.cloud_vaults.yaml
+++ b/services/dis-vault-operator/config/crd/bases/vault.dis.altinn.cloud_vaults.yaml
@@ -51,6 +51,12 @@ spec:
                 description: ExternalSecrets enables operator-managed namespaced SecretStore
                   integration.
                 type: boolean
+              groupObjectId:
+                description: |-
+                  GroupObjectID grants an optional Entra group access to the Key Vault.
+                  Lowercase is required to keep the identifier canonical in GitOps.
+                pattern: ^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$
+                type: string
               identityRef:
                 description: IdentityRef points to the owning ApplicationIdentity
                   in the same namespace.

--- a/services/dis-vault-operator/config/samples/vault_v1alpha1_vault.yaml
+++ b/services/dis-vault-operator/config/samples/vault_v1alpha1_vault.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   identityRef:
     name: app-identity-sample
+  groupObjectId: 11111111-1111-1111-1111-111111111111
   sku: standard
   publicNetworkAccess: Enabled
   softDeleteRetentionDays: 90

--- a/services/dis-vault-operator/internal/controller/vault_controller.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller.go
@@ -12,12 +12,10 @@ import (
 	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
 	authorizationv1 "github.com/Azure/azure-service-operator/v2/api/authorization/v1api20220401"
 	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
-	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,11 +32,6 @@ type VaultReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Config config.OperatorConfig
-}
-
-type secretStoreReconcileResult struct {
-	Condition metav1.Condition
-	Name      string
 }
 
 // +kubebuilder:rbac:groups=vault.dis.altinn.cloud,resources=vaults,verbs=get;list;watch;create;update;patch;delete
@@ -91,21 +84,14 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	if !identityPending {
-		if err := ctrl.SetControllerReference(&vaultObj, desiredKeyVault, r.Scheme); err != nil {
-			return ctrl.Result{}, err
-		}
 		if err := r.upsertASOKeyVault(ctx, &vaultObj, desiredKeyVault); err != nil {
 			return ctrl.Result{}, err
 		}
 
-		desiredRoleAssignment, err := vaultpkg.BuildOwnerRoleAssignmentResource(&vaultObj, desiredKeyVault, identity.PrincipalID)
-		if err != nil {
+		if err := r.reconcileOwnerRoleAssignment(ctx, &vaultObj, desiredKeyVault, identity.PrincipalID); err != nil {
 			return ctrl.Result{}, err
 		}
-		if err := ctrl.SetControllerReference(&vaultObj, desiredRoleAssignment, r.Scheme); err != nil {
-			return ctrl.Result{}, err
-		}
-		if err := r.upsertOwnerRoleAssignment(ctx, &vaultObj, desiredRoleAssignment); err != nil {
+		if err := r.reconcileGroupRoleAssignment(ctx, &vaultObj, desiredKeyVault); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -114,11 +100,11 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	roleAssignment, roleAssignmentReady, err := r.getCurrentRoleAssignment(
-		ctx,
-		vaultpkg.BuildOwnerRoleAssignmentName(vaultObj.Name),
-		vaultObj.Namespace,
-	)
+	roleAssignment, roleAssignmentReady, err := r.getOwnerRoleAssignment(ctx, &vaultObj)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	groupRoleAssignmentCondition, err := r.getGroupRoleAssignmentCondition(ctx, &vaultObj)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -137,6 +123,7 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		keyVaultReady,
 		roleAssignment,
 		roleAssignmentReady,
+		groupRoleAssignmentCondition,
 		secretStore,
 	); err != nil {
 		return ctrl.Result{}, err
@@ -160,46 +147,11 @@ func (r *VaultReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: 1,
 		})
 
-	if _, err := mgr.GetRESTMapper().RESTMapping(
-		schema.GroupKind{Group: esov1.Group, Kind: esov1.SecretStoreKind},
-		esov1.Version,
-	); err == nil {
-		builder = builder.Owns(&esov1.SecretStore{})
-	} else if !apimeta.IsNoMatchError(err) {
-		return err
-	}
-
-	return builder.Complete(r)
+	return r.completeWithSecretStoreOwnership(mgr, builder)
 }
 
 func (r *VaultReconciler) upsertASOKeyVault(ctx context.Context, owner *vaultv1alpha1.Vault, desired *keyvaultv1.Vault) error {
 	current := &keyvaultv1.Vault{}
-	current.SetName(desired.GetName())
-	current.SetNamespace(desired.GetNamespace())
-
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, current, func() error {
-		current.Labels = mergeStringMaps(current.Labels, desired.Labels)
-		current.Spec = desired.Spec
-		return ctrl.SetControllerReference(owner, current, r.Scheme)
-	})
-	return err
-}
-
-func (r *VaultReconciler) upsertOwnerRoleAssignment(ctx context.Context, owner *vaultv1alpha1.Vault, desired *authorizationv1.RoleAssignment) error {
-	current := &authorizationv1.RoleAssignment{}
-	current.SetName(desired.GetName())
-	current.SetNamespace(desired.GetNamespace())
-
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, current, func() error {
-		current.Labels = mergeStringMaps(current.Labels, desired.Labels)
-		current.Spec = desired.Spec
-		return ctrl.SetControllerReference(owner, current, r.Scheme)
-	})
-	return err
-}
-
-func (r *VaultReconciler) upsertManagedSecretStore(ctx context.Context, owner *vaultv1alpha1.Vault, desired *esov1.SecretStore) error {
-	current := &esov1.SecretStore{}
 	current.SetName(desired.GetName())
 	current.SetNamespace(desired.GetNamespace())
 
@@ -224,273 +176,6 @@ func (r *VaultReconciler) getCurrentKeyVault(
 	}
 
 	return current, vaultpkg.FromASOConditions(current.Status.Conditions), nil
-}
-
-func (r *VaultReconciler) getCurrentRoleAssignment(
-	ctx context.Context,
-	name, namespace string,
-) (*authorizationv1.RoleAssignment, vaultpkg.ASOReadyCondition, error) {
-	current := &authorizationv1.RoleAssignment{}
-	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, current); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, vaultpkg.ASOReadyCondition{}, nil
-		}
-		return nil, vaultpkg.ASOReadyCondition{}, err
-	}
-
-	return current, vaultpkg.FromASOConditions(current.Status.Conditions), nil
-}
-
-func (r *VaultReconciler) reconcileManagedSecretStore(
-	ctx context.Context,
-	vaultObj *vaultv1alpha1.Vault,
-	keyVault *keyvaultv1.Vault,
-) (secretStoreReconcileResult, error) {
-	name := vaultpkg.DeterministicSecretStoreName(vaultObj.Name)
-	key := types.NamespacedName{Name: name, Namespace: vaultObj.Namespace}
-
-	if !vaultObj.Spec.ExternalSecrets {
-		if err := r.deleteManagedSecretStore(ctx, vaultObj, key); err != nil {
-			return secretStoreReconcileResult{}, err
-		}
-		return secretStoreReconcileResult{
-			Condition: vaultpkg.NewCondition(
-				vaultv1alpha1.ConditionExternalSecretsReady,
-				vaultObj.Generation,
-				metav1.ConditionFalse,
-				"Disabled",
-				"external secrets integration is disabled",
-			),
-		}, nil
-	}
-
-	current := &esov1.SecretStore{}
-	if err := r.Get(ctx, key, current); err != nil {
-		switch {
-		case apierrors.IsNotFound(err):
-			current = nil
-		case apimeta.IsNoMatchError(err):
-			return secretStoreReconcileResult{
-				Condition: vaultpkg.NewCondition(
-					vaultv1alpha1.ConditionExternalSecretsReady,
-					vaultObj.Generation,
-					metav1.ConditionFalse,
-					"CRDNotInstalled",
-					"SecretStore CRD is not installed in the cluster",
-				),
-			}, nil
-		default:
-			return secretStoreReconcileResult{}, err
-		}
-	}
-
-	if current != nil && !metav1.IsControlledBy(current, vaultObj) {
-		return secretStoreReconcileResult{
-			Condition: vaultpkg.NewCondition(
-				vaultv1alpha1.ConditionExternalSecretsReady,
-				vaultObj.Generation,
-				metav1.ConditionFalse,
-				"NameConflict",
-				fmt.Sprintf("SecretStore %q already exists and is not managed by this Vault", name),
-			),
-		}, nil
-	}
-
-	vaultURI := vaultURIFromStatus(keyVault)
-	if vaultURI == "" {
-		if current != nil {
-			return secretStoreReconcileResult{
-				Name: current.Name,
-				Condition: vaultpkg.NewCondition(
-					vaultv1alpha1.ConditionExternalSecretsReady,
-					vaultObj.Generation,
-					metav1.ConditionTrue,
-					"Ready",
-					"managed SecretStore is present",
-				),
-			}, nil
-		}
-		return secretStoreReconcileResult{
-			Condition: vaultpkg.NewCondition(
-				vaultv1alpha1.ConditionExternalSecretsReady,
-				vaultObj.Generation,
-				metav1.ConditionUnknown,
-				"VaultNotReady",
-				"waiting for Vault URI before reconciling SecretStore",
-			),
-		}, nil
-	}
-
-	desired, err := vaultpkg.BuildManagedSecretStore(vaultObj, r.Config.TenantID, vaultURI)
-	if err != nil {
-		return secretStoreReconcileResult{}, err
-	}
-	if err := ctrl.SetControllerReference(vaultObj, desired, r.Scheme); err != nil {
-		return secretStoreReconcileResult{}, err
-	}
-	if err := r.upsertManagedSecretStore(ctx, vaultObj, desired); err != nil {
-		if apimeta.IsNoMatchError(err) {
-			return secretStoreReconcileResult{
-				Condition: vaultpkg.NewCondition(
-					vaultv1alpha1.ConditionExternalSecretsReady,
-					vaultObj.Generation,
-					metav1.ConditionFalse,
-					"CRDNotInstalled",
-					"SecretStore CRD is not installed in the cluster",
-				),
-			}, nil
-		}
-		return secretStoreReconcileResult{}, err
-	}
-
-	return secretStoreReconcileResult{
-		Name: desired.Name,
-		Condition: vaultpkg.NewCondition(
-			vaultv1alpha1.ConditionExternalSecretsReady,
-			vaultObj.Generation,
-			metav1.ConditionTrue,
-			"Ready",
-			"managed SecretStore reconciled",
-		),
-	}, nil
-}
-
-func (r *VaultReconciler) deleteManagedSecretStore(
-	ctx context.Context,
-	owner *vaultv1alpha1.Vault,
-	key types.NamespacedName,
-) error {
-	current := &esov1.SecretStore{}
-	if err := r.Get(ctx, key, current); err != nil {
-		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
-			return nil
-		}
-		return err
-	}
-	if !metav1.IsControlledBy(current, owner) {
-		return nil
-	}
-	return client.IgnoreNotFound(r.Delete(ctx, current))
-}
-
-func (r *VaultReconciler) updateStatus(
-	ctx context.Context,
-	vaultObj *vaultv1alpha1.Vault,
-	azureName string,
-	desiredKeyVault *keyvaultv1.Vault,
-	identityPending bool,
-	principalID string,
-	keyVault *keyvaultv1.Vault,
-	keyVaultReady vaultpkg.ASOReadyCondition,
-	roleAssignment *authorizationv1.RoleAssignment,
-	roleAssignmentReady vaultpkg.ASOReadyCondition,
-	secretStore secretStoreReconcileResult,
-) error {
-	updated := false
-
-	identityCondition := vaultpkg.NewCondition(
-		vaultv1alpha1.ConditionIdentityReady,
-		vaultObj.Generation,
-		metav1.ConditionTrue,
-		"IdentityReady",
-		fmt.Sprintf("ApplicationIdentity %q is ready", vaultObj.Spec.IdentityRef.Name),
-	)
-	if identityPending {
-		identityCondition = vaultpkg.NewCondition(
-			vaultv1alpha1.ConditionIdentityReady,
-			vaultObj.Generation,
-			metav1.ConditionFalse,
-			"IdentityNotReady",
-			fmt.Sprintf("ApplicationIdentity %q is not ready", vaultObj.Spec.IdentityRef.Name),
-		)
-	}
-	if setStatusCondition(vaultObj, identityCondition) {
-		updated = true
-	}
-
-	vaultCondition := asoToStatusCondition(
-		vaultObj.Generation,
-		vaultv1alpha1.ConditionVaultReady,
-		keyVaultReady,
-		"VaultNotReady",
-		"waiting for ASO Key Vault readiness",
-	)
-	if setStatusCondition(vaultObj, vaultCondition) {
-		updated = true
-	}
-
-	roleCondition := asoToStatusCondition(
-		vaultObj.Generation,
-		vaultv1alpha1.ConditionRoleAssignmentReady,
-		roleAssignmentReady,
-		"RoleAssignmentNotReady",
-		"waiting for ASO RoleAssignment readiness",
-	)
-	if setStatusCondition(vaultObj, roleCondition) {
-		updated = true
-	}
-
-	networkCondition := buildNetworkPolicyCondition(vaultObj.Generation, desiredKeyVault, r.Config)
-	if setStatusCondition(vaultObj, networkCondition) {
-		updated = true
-	}
-	if setStatusCondition(vaultObj, secretStore.Condition) {
-		updated = true
-	}
-
-	readyCondition := vaultpkg.AggregateReadyCondition(
-		vaultObj.Generation,
-		identityCondition,
-		vaultCondition,
-		roleCondition,
-		networkCondition,
-		secretStore.Condition,
-	)
-	if setStatusCondition(vaultObj, readyCondition) {
-		updated = true
-	}
-
-	if vaultObj.Status.AzureName != azureName {
-		vaultObj.Status.AzureName = azureName
-		updated = true
-	}
-	nextPrincipalID := principalID
-	if identityPending {
-		nextPrincipalID = ""
-	}
-	if vaultObj.Status.OwnerPrincipalID != nextPrincipalID {
-		vaultObj.Status.OwnerPrincipalID = nextPrincipalID
-		updated = true
-	}
-
-	resourceID := resourceIDFromStatus(keyVault)
-	if vaultObj.Status.ResourceID != resourceID {
-		vaultObj.Status.ResourceID = resourceID
-		updated = true
-	}
-	vaultURI := vaultURIFromStatus(keyVault)
-	if vaultObj.Status.VaultURI != vaultURI {
-		vaultObj.Status.VaultURI = vaultURI
-		updated = true
-	}
-	roleAssignmentID := roleAssignmentIDFromStatus(roleAssignment)
-	if vaultObj.Status.OwnerRoleAssignmentID != roleAssignmentID {
-		vaultObj.Status.OwnerRoleAssignmentID = roleAssignmentID
-		updated = true
-	}
-	if vaultObj.Status.ExternalSecretStoreName != secretStore.Name {
-		vaultObj.Status.ExternalSecretStoreName = secretStore.Name
-		updated = true
-	}
-	if vaultObj.Status.ObservedGeneration != vaultObj.Generation {
-		vaultObj.Status.ObservedGeneration = vaultObj.Generation
-		updated = true
-	}
-
-	if !updated {
-		return nil
-	}
-	return r.Status().Update(ctx, vaultObj)
 }
 
 func asoToStatusCondition(
@@ -608,13 +293,6 @@ func vaultURIFromStatus(keyVault *keyvaultv1.Vault) string {
 		return ""
 	}
 	return *keyVault.Status.Properties.VaultUri
-}
-
-func roleAssignmentIDFromStatus(roleAssignment *authorizationv1.RoleAssignment) string {
-	if roleAssignment == nil || roleAssignment.Status.Id == nil {
-		return ""
-	}
-	return *roleAssignment.Status.Id
 }
 
 func setStatusCondition(vaultObj *vaultv1alpha1.Vault, condition metav1.Condition) bool {

--- a/services/dis-vault-operator/internal/controller/vault_controller_role.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_role.go
@@ -1,0 +1,214 @@
+package controller
+
+import (
+	"context"
+	"strings"
+
+	vaultv1alpha1 "github.com/Altinn/altinn-platform/services/dis-vault-operator/api/v1alpha1"
+	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
+	authorizationv1 "github.com/Azure/azure-service-operator/v2/api/authorization/v1api20220401"
+	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	roleAssignmentLabelName = "vault.dis.altinn.cloud/name"
+	roleAssignmentLabelKind = "vault.dis.altinn.cloud/assignment-kind"
+	roleAssignmentKindGroup = "group"
+)
+
+func (r *VaultReconciler) reconcileOwnerRoleAssignment(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+	keyVault *keyvaultv1.Vault,
+	principalID string,
+) error {
+	desired, err := vaultpkg.BuildOwnerRoleAssignmentResource(vaultObj, keyVault, principalID)
+	if err != nil {
+		return err
+	}
+	return r.upsertRoleAssignment(ctx, vaultObj, desired)
+}
+
+func (r *VaultReconciler) upsertRoleAssignment(
+	ctx context.Context,
+	owner *vaultv1alpha1.Vault,
+	desired *authorizationv1.RoleAssignment,
+) error {
+	current := &authorizationv1.RoleAssignment{}
+	current.SetName(desired.GetName())
+	current.SetNamespace(desired.GetNamespace())
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, current, func() error {
+		current.Labels = mergeStringMaps(current.Labels, desired.Labels)
+		current.Spec = desired.Spec
+		return ctrl.SetControllerReference(owner, current, r.Scheme)
+	})
+	return err
+}
+
+func (r *VaultReconciler) getOwnerRoleAssignment(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+) (*authorizationv1.RoleAssignment, vaultpkg.ASOReadyCondition, error) {
+	return r.getCurrentRoleAssignment(
+		ctx,
+		vaultpkg.BuildOwnerRoleAssignmentName(vaultObj.Name),
+		vaultObj.Namespace,
+	)
+}
+
+func (r *VaultReconciler) getCurrentRoleAssignment(
+	ctx context.Context,
+	name, namespace string,
+) (*authorizationv1.RoleAssignment, vaultpkg.ASOReadyCondition, error) {
+	current := &authorizationv1.RoleAssignment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, current); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, vaultpkg.ASOReadyCondition{}, nil
+		}
+		return nil, vaultpkg.ASOReadyCondition{}, err
+	}
+
+	return current, vaultpkg.FromASOConditions(current.Status.Conditions), nil
+}
+
+func (r *VaultReconciler) reconcileGroupRoleAssignment(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+	keyVault *keyvaultv1.Vault,
+) error {
+	groupObjectID := strings.TrimSpace(vaultObj.Spec.GroupObjectID)
+	desiredName := ""
+	if groupObjectID != "" {
+		desiredName = vaultpkg.BuildGroupRoleAssignmentName(vaultObj.Name)
+		desired, err := vaultpkg.BuildGroupRoleAssignmentResource(vaultObj, keyVault, groupObjectID)
+		if err != nil {
+			return err
+		}
+
+		current, err := r.getRoleAssignment(ctx, desired.Name, desired.Namespace)
+		if err != nil {
+			return err
+		}
+		if current == nil || metav1.IsControlledBy(current, vaultObj) {
+			if err := r.upsertRoleAssignment(ctx, vaultObj, desired); err != nil {
+				return err
+			}
+		}
+	}
+
+	currentAssignments, err := r.listManagedGroupRoleAssignments(ctx, vaultObj)
+	if err != nil {
+		return err
+	}
+
+	for i := range currentAssignments {
+		current := currentAssignments[i]
+		if desiredName != "" && current.Name == desiredName {
+			continue
+		}
+		if err := client.IgnoreNotFound(r.Delete(ctx, &current)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *VaultReconciler) listManagedGroupRoleAssignments(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+) ([]authorizationv1.RoleAssignment, error) {
+	var list authorizationv1.RoleAssignmentList
+	if err := r.List(
+		ctx,
+		&list,
+		client.InNamespace(vaultObj.Namespace),
+		client.MatchingLabels{
+			roleAssignmentLabelName: vaultObj.Name,
+			roleAssignmentLabelKind: roleAssignmentKindGroup,
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	managed := make([]authorizationv1.RoleAssignment, 0, len(list.Items))
+	for i := range list.Items {
+		item := list.Items[i]
+		if !metav1.IsControlledBy(&item, vaultObj) {
+			continue
+		}
+		managed = append(managed, item)
+	}
+
+	return managed, nil
+}
+
+func (r *VaultReconciler) getRoleAssignment(
+	ctx context.Context,
+	name, namespace string,
+) (*authorizationv1.RoleAssignment, error) {
+	current := &authorizationv1.RoleAssignment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, current); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return current, nil
+}
+
+func (r *VaultReconciler) getGroupRoleAssignmentCondition(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+) (metav1.Condition, error) {
+	if strings.TrimSpace(vaultObj.Spec.GroupObjectID) == "" {
+		return vaultpkg.NewCondition(
+			vaultv1alpha1.ConditionGroupRoleAssignment,
+			vaultObj.Generation,
+			metav1.ConditionTrue,
+			"NotConfigured",
+			"no group role assignment is configured",
+		), nil
+	}
+
+	current, ready, err := r.getCurrentRoleAssignment(
+		ctx,
+		vaultpkg.BuildGroupRoleAssignmentName(vaultObj.Name),
+		vaultObj.Namespace,
+	)
+	if err != nil {
+		return metav1.Condition{}, err
+	}
+	if current != nil && !metav1.IsControlledBy(current, vaultObj) {
+		return vaultpkg.NewCondition(
+			vaultv1alpha1.ConditionGroupRoleAssignment,
+			vaultObj.Generation,
+			metav1.ConditionFalse,
+			"NameConflict",
+			"group role assignment conflicts with a non-owned resource",
+		), nil
+	}
+
+	return asoToStatusCondition(
+		vaultObj.Generation,
+		vaultv1alpha1.ConditionGroupRoleAssignment,
+		ready,
+		"GroupRoleAssignmentNotReady",
+		"waiting for group role assignment readiness",
+	), nil
+}
+
+func roleAssignmentIDFromStatus(roleAssignment *authorizationv1.RoleAssignment) string {
+	if roleAssignment == nil || roleAssignment.Status.Id == nil {
+		return ""
+	}
+	return *roleAssignment.Status.Id
+}

--- a/services/dis-vault-operator/internal/controller/vault_controller_secret_store.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_secret_store.go
@@ -1,0 +1,184 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	vaultv1alpha1 "github.com/Altinn/altinn-platform/services/dis-vault-operator/api/v1alpha1"
+	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
+	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
+	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	builderpkg "sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type secretStoreReconcileResult struct {
+	Condition metav1.Condition
+	Name      string
+}
+
+func (r *VaultReconciler) completeWithSecretStoreOwnership(mgr ctrl.Manager, builder *builderpkg.Builder) error {
+	if _, err := mgr.GetRESTMapper().RESTMapping(
+		schema.GroupKind{Group: esov1.Group, Kind: esov1.SecretStoreKind},
+		esov1.Version,
+	); err == nil {
+		builder = builder.Owns(&esov1.SecretStore{})
+	} else if !apimeta.IsNoMatchError(err) {
+		return err
+	}
+
+	return builder.Complete(r)
+}
+
+func (r *VaultReconciler) upsertManagedSecretStore(
+	ctx context.Context,
+	owner *vaultv1alpha1.Vault,
+	desired *esov1.SecretStore,
+) error {
+	current := &esov1.SecretStore{}
+	current.SetName(desired.GetName())
+	current.SetNamespace(desired.GetNamespace())
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, current, func() error {
+		current.Labels = mergeStringMaps(current.Labels, desired.Labels)
+		current.Spec = desired.Spec
+		return ctrl.SetControllerReference(owner, current, r.Scheme)
+	})
+	return err
+}
+
+func (r *VaultReconciler) reconcileManagedSecretStore(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+	keyVault *keyvaultv1.Vault,
+) (secretStoreReconcileResult, error) {
+	name := vaultpkg.DeterministicSecretStoreName(vaultObj.Name)
+	key := types.NamespacedName{Name: name, Namespace: vaultObj.Namespace}
+
+	if !vaultObj.Spec.ExternalSecrets {
+		if err := r.deleteManagedSecretStore(ctx, vaultObj, key); err != nil {
+			return secretStoreReconcileResult{}, err
+		}
+		return secretStoreReconcileResult{
+			Condition: vaultpkg.NewCondition(
+				vaultv1alpha1.ConditionExternalSecretsReady,
+				vaultObj.Generation,
+				metav1.ConditionFalse,
+				"Disabled",
+				"external secrets integration is disabled",
+			),
+		}, nil
+	}
+
+	current := &esov1.SecretStore{}
+	if err := r.Get(ctx, key, current); err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			current = nil
+		case apimeta.IsNoMatchError(err):
+			return secretStoreReconcileResult{
+				Condition: vaultpkg.NewCondition(
+					vaultv1alpha1.ConditionExternalSecretsReady,
+					vaultObj.Generation,
+					metav1.ConditionFalse,
+					"CRDNotInstalled",
+					"SecretStore CRD is not installed in the cluster",
+				),
+			}, nil
+		default:
+			return secretStoreReconcileResult{}, err
+		}
+	}
+
+	if current != nil && !metav1.IsControlledBy(current, vaultObj) {
+		return secretStoreReconcileResult{
+			Condition: vaultpkg.NewCondition(
+				vaultv1alpha1.ConditionExternalSecretsReady,
+				vaultObj.Generation,
+				metav1.ConditionFalse,
+				"NameConflict",
+				fmt.Sprintf("SecretStore %q already exists and is not managed by this Vault", name),
+			),
+		}, nil
+	}
+
+	vaultURI := vaultURIFromStatus(keyVault)
+	if vaultURI == "" {
+		if current != nil {
+			return secretStoreReconcileResult{
+				Name: current.Name,
+				Condition: vaultpkg.NewCondition(
+					vaultv1alpha1.ConditionExternalSecretsReady,
+					vaultObj.Generation,
+					metav1.ConditionTrue,
+					"Ready",
+					"managed SecretStore is present",
+				),
+			}, nil
+		}
+		return secretStoreReconcileResult{
+			Condition: vaultpkg.NewCondition(
+				vaultv1alpha1.ConditionExternalSecretsReady,
+				vaultObj.Generation,
+				metav1.ConditionUnknown,
+				"VaultNotReady",
+				"waiting for Vault URI before reconciling SecretStore",
+			),
+		}, nil
+	}
+
+	desired, err := vaultpkg.BuildManagedSecretStore(vaultObj, r.Config.TenantID, vaultURI)
+	if err != nil {
+		return secretStoreReconcileResult{}, err
+	}
+	if err := r.upsertManagedSecretStore(ctx, vaultObj, desired); err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return secretStoreReconcileResult{
+				Condition: vaultpkg.NewCondition(
+					vaultv1alpha1.ConditionExternalSecretsReady,
+					vaultObj.Generation,
+					metav1.ConditionFalse,
+					"CRDNotInstalled",
+					"SecretStore CRD is not installed in the cluster",
+				),
+			}, nil
+		}
+		return secretStoreReconcileResult{}, err
+	}
+
+	return secretStoreReconcileResult{
+		Name: desired.Name,
+		Condition: vaultpkg.NewCondition(
+			vaultv1alpha1.ConditionExternalSecretsReady,
+			vaultObj.Generation,
+			metav1.ConditionTrue,
+			"Ready",
+			"managed SecretStore reconciled",
+		),
+	}, nil
+}
+
+func (r *VaultReconciler) deleteManagedSecretStore(
+	ctx context.Context,
+	owner *vaultv1alpha1.Vault,
+	key types.NamespacedName,
+) error {
+	current := &esov1.SecretStore{}
+	if err := r.Get(ctx, key, current); err != nil {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
+			return nil
+		}
+		return err
+	}
+	if !metav1.IsControlledBy(current, owner) {
+		return nil
+	}
+	return client.IgnoreNotFound(r.Delete(ctx, current))
+}

--- a/services/dis-vault-operator/internal/controller/vault_controller_status.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_status.go
@@ -33,18 +33,6 @@ func (r *VaultReconciler) updateStatus(
 		}
 		return condition
 	}
-	setString := func(field *string, value string) {
-		if *field != value {
-			*field = value
-			updated = true
-		}
-	}
-	setInt64 := func(field *int64, value int64) {
-		if *field != value {
-			*field = value
-			updated = true
-		}
-	}
 
 	identityCondition := applyCondition(buildIdentityCondition(vaultObj, identityPending))
 	vaultCondition := applyCondition(asoToStatusCondition(
@@ -68,19 +56,19 @@ func (r *VaultReconciler) updateStatus(
 		groupRoleAssignmentCondition,
 	))
 
-	setString(&vaultObj.Status.AzureName, azureName)
+	updated = setIfChanged(&vaultObj.Status.AzureName, azureName) || updated
 	if identityPending {
 		principalID = ""
 	}
-	setString(&vaultObj.Status.OwnerPrincipalID, principalID)
-	setString(&vaultObj.Status.ResourceID, resourceIDFromStatus(keyVault))
-	setString(&vaultObj.Status.VaultURI, vaultURIFromStatus(keyVault))
+	updated = setIfChanged(&vaultObj.Status.OwnerPrincipalID, principalID) || updated
+	updated = setIfChanged(&vaultObj.Status.ResourceID, resourceIDFromStatus(keyVault)) || updated
+	updated = setIfChanged(&vaultObj.Status.VaultURI, vaultURIFromStatus(keyVault)) || updated
 	if identityPending {
 		roleAssignment = nil
 	}
-	setString(&vaultObj.Status.OwnerRoleAssignmentID, roleAssignmentIDFromStatus(roleAssignment))
-	setString(&vaultObj.Status.ExternalSecretStoreName, secretStore.Name)
-	setInt64(&vaultObj.Status.ObservedGeneration, vaultObj.Generation)
+	updated = setIfChanged(&vaultObj.Status.OwnerRoleAssignmentID, roleAssignmentIDFromStatus(roleAssignment)) || updated
+	updated = setIfChanged(&vaultObj.Status.ExternalSecretStoreName, secretStore.Name) || updated
+	updated = setIfChanged(&vaultObj.Status.ObservedGeneration, vaultObj.Generation) || updated
 
 	if !updated {
 		return nil
@@ -130,4 +118,12 @@ func buildOwnerRoleAssignmentCondition(
 		"RoleAssignmentNotReady",
 		"waiting for ASO RoleAssignment readiness",
 	)
+}
+
+func setIfChanged[T comparable](field *T, value T) bool {
+	if *field == value {
+		return false
+	}
+	*field = value
+	return true
 }

--- a/services/dis-vault-operator/internal/controller/vault_controller_status.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_status.go
@@ -1,0 +1,112 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	vaultv1alpha1 "github.com/Altinn/altinn-platform/services/dis-vault-operator/api/v1alpha1"
+	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
+	authorizationv1 "github.com/Azure/azure-service-operator/v2/api/authorization/v1api20220401"
+	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *VaultReconciler) updateStatus(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+	azureName string,
+	desiredKeyVault *keyvaultv1.Vault,
+	identityPending bool,
+	principalID string,
+	keyVault *keyvaultv1.Vault,
+	keyVaultReady vaultpkg.ASOReadyCondition,
+	roleAssignment *authorizationv1.RoleAssignment,
+	roleAssignmentReady vaultpkg.ASOReadyCondition,
+	groupRoleAssignmentCondition metav1.Condition,
+	secretStore secretStoreReconcileResult,
+) error {
+	updated := false
+
+	applyCondition := func(condition metav1.Condition) metav1.Condition {
+		if setStatusCondition(vaultObj, condition) {
+			updated = true
+		}
+		return condition
+	}
+	setString := func(field *string, value string) {
+		if *field != value {
+			*field = value
+			updated = true
+		}
+	}
+	setInt64 := func(field *int64, value int64) {
+		if *field != value {
+			*field = value
+			updated = true
+		}
+	}
+
+	identityCondition := applyCondition(buildIdentityCondition(vaultObj, identityPending))
+	vaultCondition := applyCondition(asoToStatusCondition(
+		vaultObj.Generation,
+		vaultv1alpha1.ConditionVaultReady,
+		keyVaultReady,
+		"VaultNotReady",
+		"waiting for ASO Key Vault readiness",
+	))
+	roleCondition := applyCondition(asoToStatusCondition(
+		vaultObj.Generation,
+		vaultv1alpha1.ConditionRoleAssignmentReady,
+		roleAssignmentReady,
+		"RoleAssignmentNotReady",
+		"waiting for ASO RoleAssignment readiness",
+	))
+	groupRoleAssignmentCondition = applyCondition(groupRoleAssignmentCondition)
+	networkCondition := applyCondition(buildNetworkPolicyCondition(vaultObj.Generation, desiredKeyVault, r.Config))
+	secretStoreCondition := applyCondition(secretStore.Condition)
+	applyCondition(vaultpkg.AggregateReadyCondition(
+		vaultObj.Generation,
+		identityCondition,
+		vaultCondition,
+		roleCondition,
+		networkCondition,
+		secretStoreCondition,
+		groupRoleAssignmentCondition,
+	))
+
+	setString(&vaultObj.Status.AzureName, azureName)
+	if identityPending {
+		principalID = ""
+	}
+	setString(&vaultObj.Status.OwnerPrincipalID, principalID)
+	setString(&vaultObj.Status.ResourceID, resourceIDFromStatus(keyVault))
+	setString(&vaultObj.Status.VaultURI, vaultURIFromStatus(keyVault))
+	setString(&vaultObj.Status.OwnerRoleAssignmentID, roleAssignmentIDFromStatus(roleAssignment))
+	setString(&vaultObj.Status.ExternalSecretStoreName, secretStore.Name)
+	setInt64(&vaultObj.Status.ObservedGeneration, vaultObj.Generation)
+
+	if !updated {
+		return nil
+	}
+	return r.Status().Update(ctx, vaultObj)
+}
+
+func buildIdentityCondition(vaultObj *vaultv1alpha1.Vault, identityPending bool) metav1.Condition {
+	if identityPending {
+		return vaultpkg.NewCondition(
+			vaultv1alpha1.ConditionIdentityReady,
+			vaultObj.Generation,
+			metav1.ConditionFalse,
+			"IdentityNotReady",
+			fmt.Sprintf("ApplicationIdentity %q is not ready", vaultObj.Spec.IdentityRef.Name),
+		)
+	}
+
+	return vaultpkg.NewCondition(
+		vaultv1alpha1.ConditionIdentityReady,
+		vaultObj.Generation,
+		metav1.ConditionTrue,
+		"IdentityReady",
+		fmt.Sprintf("ApplicationIdentity %q is ready", vaultObj.Spec.IdentityRef.Name),
+	)
+}

--- a/services/dis-vault-operator/internal/controller/vault_controller_status.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_status.go
@@ -54,13 +54,7 @@ func (r *VaultReconciler) updateStatus(
 		"VaultNotReady",
 		"waiting for ASO Key Vault readiness",
 	))
-	roleCondition := applyCondition(asoToStatusCondition(
-		vaultObj.Generation,
-		vaultv1alpha1.ConditionRoleAssignmentReady,
-		roleAssignmentReady,
-		"RoleAssignmentNotReady",
-		"waiting for ASO RoleAssignment readiness",
-	))
+	roleCondition := applyCondition(buildOwnerRoleAssignmentCondition(vaultObj, identityPending, roleAssignmentReady))
 	groupRoleAssignmentCondition = applyCondition(groupRoleAssignmentCondition)
 	networkCondition := applyCondition(buildNetworkPolicyCondition(vaultObj.Generation, desiredKeyVault, r.Config))
 	secretStoreCondition := applyCondition(secretStore.Condition)
@@ -81,6 +75,9 @@ func (r *VaultReconciler) updateStatus(
 	setString(&vaultObj.Status.OwnerPrincipalID, principalID)
 	setString(&vaultObj.Status.ResourceID, resourceIDFromStatus(keyVault))
 	setString(&vaultObj.Status.VaultURI, vaultURIFromStatus(keyVault))
+	if identityPending {
+		roleAssignment = nil
+	}
 	setString(&vaultObj.Status.OwnerRoleAssignmentID, roleAssignmentIDFromStatus(roleAssignment))
 	setString(&vaultObj.Status.ExternalSecretStoreName, secretStore.Name)
 	setInt64(&vaultObj.Status.ObservedGeneration, vaultObj.Generation)
@@ -108,5 +105,29 @@ func buildIdentityCondition(vaultObj *vaultv1alpha1.Vault, identityPending bool)
 		metav1.ConditionTrue,
 		"IdentityReady",
 		fmt.Sprintf("ApplicationIdentity %q is ready", vaultObj.Spec.IdentityRef.Name),
+	)
+}
+
+func buildOwnerRoleAssignmentCondition(
+	vaultObj *vaultv1alpha1.Vault,
+	identityPending bool,
+	roleAssignmentReady vaultpkg.ASOReadyCondition,
+) metav1.Condition {
+	if identityPending {
+		return vaultpkg.NewCondition(
+			vaultv1alpha1.ConditionRoleAssignmentReady,
+			vaultObj.Generation,
+			metav1.ConditionFalse,
+			"IdentityNotReady",
+			fmt.Sprintf("waiting for ApplicationIdentity %q before reconciling owner role assignment", vaultObj.Spec.IdentityRef.Name),
+		)
+	}
+
+	return asoToStatusCondition(
+		vaultObj.Generation,
+		vaultv1alpha1.ConditionRoleAssignmentReady,
+		roleAssignmentReady,
+		"RoleAssignmentNotReady",
+		"waiting for ASO RoleAssignment readiness",
 	)
 }

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -590,19 +590,26 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
 			g.Expect(roleAssignments.Items).To(HaveLen(2))
 
-			foundGroup := false
+			groupMatches := 0
+			ownerMatches := 0
 			for i := range roleAssignments.Items {
 				assignment := roleAssignments.Items[i]
-				if assignment.Spec.PrincipalId == nil || *assignment.Spec.PrincipalId != groupObjectID {
+				if assignment.Spec.PrincipalId == nil {
 					continue
 				}
-				foundGroup = true
-				g.Expect(assignment.Spec.PrincipalType).NotTo(BeNil())
-				g.Expect(*assignment.Spec.PrincipalType).To(Equal(authorizationv1.RoleAssignmentProperties_PrincipalType_Group))
-				g.Expect(assignment.Spec.RoleDefinitionReference).NotTo(BeNil())
-				g.Expect(assignment.Spec.RoleDefinitionReference.WellKnownName).To(Equal(expectedWellKnownRole))
+				if *assignment.Spec.PrincipalId == groupObjectID {
+					groupMatches++
+					g.Expect(assignment.Spec.PrincipalType).NotTo(BeNil())
+					g.Expect(*assignment.Spec.PrincipalType).To(Equal(authorizationv1.RoleAssignmentProperties_PrincipalType_Group))
+					g.Expect(assignment.Spec.RoleDefinitionReference).NotTo(BeNil())
+					g.Expect(assignment.Spec.RoleDefinitionReference.WellKnownName).To(Equal(expectedWellKnownRole))
+				}
+				if *assignment.Spec.PrincipalId == identityName+"-principal" {
+					ownerMatches++
+				}
 			}
-			g.Expect(foundGroup).To(BeTrue(), "expected one group role assignment to be reconciled")
+			g.Expect(groupMatches).To(Equal(1), "expected exactly one group role assignment")
+			g.Expect(ownerMatches).To(Equal(1), "expected exactly one owner role assignment")
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
 		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -428,6 +428,80 @@ var _ = Describe("Vault controller", func() {
 		}, 3*time.Second, 500*time.Millisecond).Should(Equal(1), "expected no duplicate owner RoleAssignments")
 	})
 
+	It("clears owner role assignment status when Vault identityRef changes to an unready identity", func() {
+		const (
+			identityReady   = "identity-owner-ready"
+			identityPending = "identity-owner-pending"
+			vaultName       = "my-app-vault-identity-pending"
+		)
+
+		createIdentity(testCtx, identityReady, true)
+		createIdentity(testCtx, identityPending, false)
+		Expect(k8sClient.Create(testCtx, newVault(vaultName, identityReady))).To(Succeed())
+
+		var keyVaultName string
+		var roleAssignmentName string
+		Eventually(func(g Gomega) {
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+			keyVaultName = keyVaults.Items[0].Name
+
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(1))
+			roleAssignmentName = roleAssignments.Items[0].Name
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName
+		vaultURI := "https://" + vaultName + ".vault.azure.net"
+		roleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/role-identity-ready"
+		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
+		setRoleAssignmentReadyStatus(testCtx, roleAssignmentName, roleAssignmentID)
+
+		Eventually(func(g Gomega) {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+			g.Expect(current.Status.OwnerPrincipalID).To(Equal(identityReady + "-principal"))
+			g.Expect(current.Status.OwnerRoleAssignmentID).To(Equal(roleAssignmentID))
+
+			roleCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionRoleAssignmentReady))
+			g.Expect(roleCondition).NotTo(BeNil())
+			g.Expect(roleCondition.Status).To(Equal(metav1.ConditionTrue))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+
+			current.Spec.IdentityRef.Name = identityPending
+			if err := k8sClient.Update(testCtx, &current); err != nil {
+				if apierrors.IsConflict(err) {
+					return false
+				}
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			return true
+		}).WithTimeout(10 * time.Second).WithPolling(300 * time.Millisecond).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+
+			identityCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionIdentityReady))
+			g.Expect(identityCondition).NotTo(BeNil())
+			g.Expect(identityCondition.Status).To(Equal(metav1.ConditionFalse))
+
+			roleCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionRoleAssignmentReady))
+			g.Expect(roleCondition).NotTo(BeNil())
+			g.Expect(roleCondition.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(roleCondition.Reason).To(Equal("IdentityNotReady"))
+
+			g.Expect(current.Status.OwnerPrincipalID).To(BeEmpty())
+			g.Expect(current.Status.OwnerRoleAssignmentID).To(BeEmpty())
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+	})
+
 	It("marks group role assignment ready as NotConfigured when none is specified", func() {
 		const (
 			identityName = "identity-no-groups"

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -98,6 +98,12 @@ var _ = Describe("Vault controller", func() {
 		}
 	}
 
+	newVaultWithGroupObjectID := func(name, identityRef, groupObjectID string) *vaultv1alpha1.Vault {
+		vaultObj := newVault(name, identityRef)
+		vaultObj.Spec.GroupObjectID = groupObjectID
+		return vaultObj
+	}
+
 	createIdentity := func(ctx context.Context, name string, ready bool) {
 		appIdentity := &identityv1alpha1.ApplicationIdentity{
 			ObjectMeta: metav1.ObjectMeta{
@@ -420,6 +426,259 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(k8sClient.List(testCtx, &list, client.InNamespace(ns))).To(Succeed())
 			return len(list.Items)
 		}, 3*time.Second, 500*time.Millisecond).Should(Equal(1), "expected no duplicate owner RoleAssignments")
+	})
+
+	It("marks group role assignment ready as NotConfigured when none is specified", func() {
+		const (
+			identityName = "identity-no-groups"
+			vaultName    = "my-app-vault-no-groups"
+		)
+
+		createIdentity(testCtx, identityName, true)
+		Expect(k8sClient.Create(testCtx, newVault(vaultName, identityName))).To(Succeed())
+
+		var keyVaultName string
+		var roleAssignmentName string
+		Eventually(func(g Gomega) {
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+			keyVaultName = keyVaults.Items[0].Name
+
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(1))
+			roleAssignmentName = roleAssignments.Items[0].Name
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName
+		vaultURI := "https://" + vaultName + ".vault.azure.net"
+		roleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/role-none"
+		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
+		setRoleAssignmentReadyStatus(testCtx, roleAssignmentName, roleAssignmentID)
+
+		Eventually(func(g Gomega) {
+			var vaultObj vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &vaultObj)).To(Succeed())
+
+			groupCondition := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionGroupRoleAssignment))
+			g.Expect(groupCondition).NotTo(BeNil())
+			g.Expect(groupCondition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(groupCondition.Reason).To(Equal("NotConfigured"))
+
+			ready := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionReady))
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+	})
+
+	It("rejects group object IDs that are not canonical lowercase UUIDs", func() {
+		const (
+			identityName = "identity-invalid-group-id"
+			vaultName    = "my-app-vault-invalid-group-id"
+		)
+
+		createIdentity(testCtx, identityName, true)
+		err := k8sClient.Create(testCtx, newVaultWithGroupObjectID(
+			vaultName,
+			identityName,
+			"AAAAAAAA-1111-1111-1111-111111111111",
+		))
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue())
+	})
+
+	It("creates a single group role assignment", func() {
+		const (
+			identityName          = "identity-one-group"
+			vaultName             = "my-app-vault-one-group"
+			groupObjectID         = "11111111-1111-1111-1111-111111111111"
+			expectedWellKnownRole = "Key Vault Secrets Officer"
+		)
+
+		createIdentity(testCtx, identityName, true)
+		Expect(k8sClient.Create(testCtx, newVaultWithGroupObjectID(
+			vaultName,
+			identityName,
+			groupObjectID,
+		))).To(Succeed())
+
+		var keyVaultName string
+		Eventually(func(g Gomega) {
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+			keyVaultName = keyVaults.Items[0].Name
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(2))
+
+			foundGroup := false
+			for i := range roleAssignments.Items {
+				assignment := roleAssignments.Items[i]
+				if assignment.Spec.PrincipalId == nil || *assignment.Spec.PrincipalId != groupObjectID {
+					continue
+				}
+				foundGroup = true
+				g.Expect(assignment.Spec.PrincipalType).NotTo(BeNil())
+				g.Expect(*assignment.Spec.PrincipalType).To(Equal(authorizationv1.RoleAssignmentProperties_PrincipalType_Group))
+				g.Expect(assignment.Spec.RoleDefinitionReference).NotTo(BeNil())
+				g.Expect(assignment.Spec.RoleDefinitionReference.WellKnownName).To(Equal(expectedWellKnownRole))
+			}
+			g.Expect(foundGroup).To(BeTrue(), "expected one group role assignment to be reconciled")
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName
+		vaultURI := "https://" + vaultName + ".vault.azure.net"
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			for i := range roleAssignments.Items {
+				assignment := roleAssignments.Items[i]
+				setRoleAssignmentReadyStatus(
+					testCtx,
+					assignment.Name,
+					resourceID+"/providers/Microsoft.Authorization/roleAssignments/"+assignment.Name,
+				)
+			}
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
+
+		Eventually(func(g Gomega) {
+			var vaultObj vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &vaultObj)).To(Succeed())
+
+			groupCondition := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionGroupRoleAssignment))
+			g.Expect(groupCondition).NotTo(BeNil())
+			g.Expect(groupCondition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(groupCondition.Reason).To(Equal("Ready"))
+
+			ready := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionReady))
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+	})
+
+	It("updates and removes the configured group role assignment", func() {
+		const (
+			identityName = "identity-group-switch"
+			vaultName    = "my-app-vault-group-switch"
+			groupOneID   = "11111111-1111-1111-1111-111111111111"
+			groupTwoID   = "22222222-2222-2222-2222-222222222222"
+		)
+
+		createIdentity(testCtx, identityName, true)
+		Expect(k8sClient.Create(testCtx, newVaultWithGroupObjectID(
+			vaultName,
+			identityName,
+			groupOneID,
+		))).To(Succeed())
+
+		var keyVaultName string
+		Eventually(func(g Gomega) {
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+			keyVaultName = keyVaults.Items[0].Name
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName
+		vaultURI := "https://" + vaultName + ".vault.azure.net"
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(2))
+			for i := range roleAssignments.Items {
+				setRoleAssignmentReadyStatus(
+					testCtx,
+					roleAssignments.Items[i].Name,
+					resourceID+"/providers/Microsoft.Authorization/roleAssignments/"+roleAssignments.Items[i].Name,
+				)
+			}
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
+
+		Eventually(func(g Gomega) {
+			var vaultObj vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &vaultObj)).To(Succeed())
+			groupCondition := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionGroupRoleAssignment))
+			g.Expect(groupCondition).NotTo(BeNil())
+			g.Expect(groupCondition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(groupCondition.Reason).To(Equal("Ready"))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+			current.Spec.GroupObjectID = groupTwoID
+			if err := k8sClient.Update(testCtx, &current); err != nil {
+				if apierrors.IsConflict(err) {
+					return false
+				}
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			return true
+		}).WithTimeout(10 * time.Second).WithPolling(300 * time.Millisecond).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(2))
+
+			principalIDs := make([]string, 0, len(roleAssignments.Items))
+			for i := range roleAssignments.Items {
+				if roleAssignments.Items[i].Spec.PrincipalId != nil {
+					principalIDs = append(principalIDs, *roleAssignments.Items[i].Spec.PrincipalId)
+				}
+			}
+			g.Expect(principalIDs).NotTo(ContainElement(groupOneID))
+			g.Expect(principalIDs).To(ContainElement(groupTwoID))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			for i := range roleAssignments.Items {
+				setRoleAssignmentReadyStatus(
+					testCtx,
+					roleAssignments.Items[i].Name,
+					resourceID+"/providers/Microsoft.Authorization/roleAssignments/"+roleAssignments.Items[i].Name,
+				)
+			}
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) bool {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+			current.Spec.GroupObjectID = ""
+			if err := k8sClient.Update(testCtx, &current); err != nil {
+				if apierrors.IsConflict(err) {
+					return false
+				}
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			return true
+		}).WithTimeout(10 * time.Second).WithPolling(300 * time.Millisecond).Should(BeTrue())
+
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(1))
+			g.Expect(roleAssignments.Items[0].Spec.PrincipalId).NotTo(BeNil())
+			g.Expect(*roleAssignments.Items[0].Spec.PrincipalId).To(Equal(identityName + "-principal"))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			var vaultObj vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &vaultObj)).To(Succeed())
+			groupCondition := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionGroupRoleAssignment))
+			g.Expect(groupCondition).NotTo(BeNil())
+			g.Expect(groupCondition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(groupCondition.Reason).To(Equal("NotConfigured"))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 	})
 
 	It("recreates owned ASO resources when children are deleted", func() {

--- a/services/dis-vault-operator/internal/vault/builders.go
+++ b/services/dis-vault-operator/internal/vault/builders.go
@@ -19,6 +19,13 @@ import (
 
 const defaultManagedResourceBaseName = "vault"
 
+const (
+	roleAssignmentLabelName    = "vault.dis.altinn.cloud/name"
+	roleAssignmentLabelKind    = "vault.dis.altinn.cloud/assignment-kind"
+	roleAssignmentKindGroup    = "group"
+	keyVaultSecretsOfficerRole = "Key Vault Secrets Officer"
+)
+
 // BuildASOKeyVaultResource builds the desired ASO Key Vault resource.
 func BuildASOKeyVaultResource(v *vaultv1alpha1.Vault, cfg config.OperatorConfig, azureName string) (*keyvaultv1.Vault, error) {
 	if v == nil {
@@ -97,7 +104,7 @@ func BuildASOKeyVaultResource(v *vaultv1alpha1.Vault, cfg config.OperatorConfig,
 			Name:      keyVaultK8sName,
 			Namespace: v.Namespace,
 			Labels: map[string]string{
-				"vault.dis.altinn.cloud/name": v.Name,
+				roleAssignmentLabelName: v.Name,
 			},
 		},
 		Spec: keyvaultv1.Vault_Spec{
@@ -123,14 +130,67 @@ func BuildOwnerRoleAssignmentResource(v *vaultv1alpha1.Vault, keyVault *keyvault
 		return nil, fmt.Errorf("principalID must not be empty")
 	}
 
-	principalType := authorizationv1.RoleAssignmentProperties_PrincipalType_ServicePrincipal
-	roleDef := "Key Vault Secrets Officer"
-	roleAssignmentName := BuildOwnerRoleAssignmentName(v.Name)
+	return buildRoleAssignmentResource(
+		v,
+		keyVault,
+		BuildOwnerRoleAssignmentName(v.Name),
+		principalID,
+		authorizationv1.RoleAssignmentProperties_PrincipalType_ServicePrincipal,
+		map[string]string{
+			roleAssignmentLabelName: v.Name,
+		},
+	)
+}
+
+func BuildOwnerRoleAssignmentName(vaultName string) string {
+	return deterministicKubernetesName(vaultName, "owner-ra")
+}
+
+// BuildGroupRoleAssignmentResource builds the desired group RoleAssignment resource.
+func BuildGroupRoleAssignmentResource(
+	v *vaultv1alpha1.Vault,
+	keyVault *keyvaultv1.Vault,
+	groupObjectID string,
+) (*authorizationv1.RoleAssignment, error) {
+	if v == nil {
+		return nil, fmt.Errorf("vault must not be nil")
+	}
+
+	groupObjectID = strings.TrimSpace(groupObjectID)
+	if groupObjectID == "" {
+		return nil, fmt.Errorf("groupObjectId must not be empty")
+	}
+
+	return buildRoleAssignmentResource(
+		v,
+		keyVault,
+		BuildGroupRoleAssignmentName(v.Name),
+		groupObjectID,
+		authorizationv1.RoleAssignmentProperties_PrincipalType_Group,
+		map[string]string{
+			roleAssignmentLabelName: v.Name,
+			roleAssignmentLabelKind: roleAssignmentKindGroup,
+		},
+	)
+}
+
+func BuildGroupRoleAssignmentName(vaultName string) string {
+	return deterministicKubernetesName(vaultName, "group-ra")
+}
+
+func buildRoleAssignmentResource(
+	v *vaultv1alpha1.Vault,
+	keyVault *keyvaultv1.Vault,
+	resourceName string,
+	principalID string,
+	principalType authorizationv1.RoleAssignmentProperties_PrincipalType,
+	labels map[string]string,
+) (*authorizationv1.RoleAssignment, error) {
 	ownerName := deterministicKubernetesName(v.Name, "akv")
 	if keyVault != nil {
 		ownerName = keyVault.Name
 	}
-	azureName := deterministicRoleAssignmentAzureName(v.Namespace, ownerName, principalID, roleDef)
+	azureName := deterministicRoleAssignmentAzureName(v.Namespace, ownerName, principalID, keyVaultSecretsOfficerRole)
 
 	owner := genruntime.ArbitraryOwnerReference{
 		Group: keyvaultv1.GroupVersion.Group,
@@ -138,13 +198,11 @@ func BuildOwnerRoleAssignmentResource(v *vaultv1alpha1.Vault, keyVault *keyvault
 		Name:  ownerName,
 	}
 
-	roleAssignment := &authorizationv1.RoleAssignment{
+	return &authorizationv1.RoleAssignment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleAssignmentName,
+			Name:      resourceName,
 			Namespace: v.Namespace,
-			Labels: map[string]string{
-				"vault.dis.altinn.cloud/name": v.Name,
-			},
+			Labels:    labels,
 		},
 		Spec: authorizationv1.RoleAssignment_Spec{
 			AzureName:     azureName,
@@ -152,16 +210,10 @@ func BuildOwnerRoleAssignmentResource(v *vaultv1alpha1.Vault, keyVault *keyvault
 			PrincipalId:   &principalID,
 			PrincipalType: &principalType,
 			RoleDefinitionReference: &genruntime.WellKnownResourceReference{
-				WellKnownName: roleDef,
+				WellKnownName: keyVaultSecretsOfficerRole,
 			},
 		},
-	}
-
-	return roleAssignment, nil
-}
-
-func BuildOwnerRoleAssignmentName(vaultName string) string {
-	return deterministicKubernetesName(vaultName, "owner-ra")
+	}, nil
 }
 
 func deterministicKubernetesName(base, suffix string) string {

--- a/services/dis-vault-operator/internal/vault/builders_test.go
+++ b/services/dis-vault-operator/internal/vault/builders_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	testVaultName    = "my-app-vault"
-	testNamespace    = "default"
-	testIdentityName = "my-app-identity"
+	testVaultName     = "my-app-vault"
+	testNamespace     = "default"
+	testIdentityName  = "my-app-identity"
+	testGroupObjectID = "11111111-1111-1111-1111-111111111111"
 )
 
 func TestBuildASOKeyVaultResource(t *testing.T) {
@@ -127,8 +128,8 @@ func TestBuildOwnerRoleAssignmentResource(t *testing.T) {
 		t.Fatalf("expected PrincipalType=ServicePrincipal")
 	}
 	if roleAssignment.Spec.RoleDefinitionReference == nil ||
-		roleAssignment.Spec.RoleDefinitionReference.WellKnownName != "Key Vault Secrets Officer" {
-		t.Fatalf("expected RoleDefinitionReference.WellKnownName=Key Vault Secrets Officer")
+		roleAssignment.Spec.RoleDefinitionReference.WellKnownName != keyVaultSecretsOfficerRole {
+		t.Fatalf("expected RoleDefinitionReference.WellKnownName=%s", keyVaultSecretsOfficerRole)
 	}
 	if _, err := uuid.Parse(roleAssignment.Spec.AzureName); err != nil {
 		t.Fatalf("expected AzureName to be a GUID, got %q: %v", roleAssignment.Spec.AzureName, err)
@@ -140,5 +141,86 @@ func TestBuildOwnerRoleAssignmentResource(t *testing.T) {
 	}
 	if roleAssignment.Spec.AzureName != roleAssignment2.Spec.AzureName {
 		t.Fatalf("expected deterministic AzureName across builds")
+	}
+}
+
+func TestBuildGroupRoleAssignmentResource(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	roleAssignment, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID)
+	if err != nil {
+		t.Fatalf("expected group role assignment builder to succeed, got error: %v", err)
+	}
+	if roleAssignment == nil {
+		t.Fatalf("expected group role assignment builder to return resource")
+	}
+
+	if roleAssignment.Spec.PrincipalType == nil ||
+		*roleAssignment.Spec.PrincipalType != authorizationv1.RoleAssignmentProperties_PrincipalType_Group {
+		t.Fatalf("expected PrincipalType=Group")
+	}
+	if roleAssignment.Spec.RoleDefinitionReference == nil ||
+		roleAssignment.Spec.RoleDefinitionReference.WellKnownName != keyVaultSecretsOfficerRole {
+		t.Fatalf("expected RoleDefinitionReference.WellKnownName=%s", keyVaultSecretsOfficerRole)
+	}
+	if _, err := uuid.Parse(roleAssignment.Spec.AzureName); err != nil {
+		t.Fatalf("expected AzureName to be a GUID, got %q: %v", roleAssignment.Spec.AzureName, err)
+	}
+	if roleAssignment.Name != BuildGroupRoleAssignmentName(testVaultName) {
+		t.Fatalf("expected deterministic group role assignment name")
+	}
+	if roleAssignment.Labels["vault.dis.altinn.cloud/name"] != testVaultName {
+		t.Fatalf("expected vault name label to be set")
+	}
+	if roleAssignment.Labels["vault.dis.altinn.cloud/assignment-kind"] != "group" {
+		t.Fatalf("expected group assignment label to be set")
+	}
+
+	roleAssignment2, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID)
+	if err != nil {
+		t.Fatalf("expected second group build to succeed, got error: %v", err)
+	}
+	if roleAssignment.Spec.AzureName != roleAssignment2.Spec.AzureName {
+		t.Fatalf("expected deterministic AzureName across builds")
+	}
+}
+
+func TestBuildGroupRoleAssignmentResourceIsDeterministicForDifferentGroups(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	first, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID)
+	if err != nil {
+		t.Fatalf("expected first build to succeed, got error: %v", err)
+	}
+	second, err := BuildGroupRoleAssignmentResource(v, nil, "22222222-2222-2222-2222-222222222222")
+	if err != nil {
+		t.Fatalf("expected second build to succeed, got error: %v", err)
+	}
+
+	if first.Spec.AzureName == second.Spec.AzureName {
+		t.Fatalf("expected different group object IDs to produce different Azure names")
+	}
+}
+
+func TestBuildGroupRoleAssignmentName(t *testing.T) {
+	t.Parallel()
+
+	nameA := BuildGroupRoleAssignmentName(testVaultName)
+	nameB := BuildGroupRoleAssignmentName(testVaultName)
+	nameC := BuildGroupRoleAssignmentName("another-vault")
+
+	if nameA != nameB {
+		t.Fatalf("expected deterministic name generation across calls")
+	}
+	if nameA == nameC {
+		t.Fatalf("expected different vault names to produce different names")
 	}
 }

--- a/services/dis-vault-operator/internal/vault/status.go
+++ b/services/dis-vault-operator/internal/vault/status.go
@@ -48,14 +48,20 @@ func NewCondition(
 
 func AggregateReadyCondition(
 	generation int64,
-	identityReady, vaultReady, roleAssignmentReady, networkPolicyReady, externalSecretsReady metav1.Condition,
+	identityReady,
+	vaultReady,
+	ownerRoleAssignmentReady,
+	networkPolicyReady,
+	externalSecretsReady metav1.Condition,
+	extraRequired ...metav1.Condition,
 ) metav1.Condition {
 	required := []metav1.Condition{
 		identityReady,
 		vaultReady,
-		roleAssignmentReady,
+		ownerRoleAssignmentReady,
 		networkPolicyReady,
 	}
+	required = append(required, extraRequired...)
 	if externalSecretsReady.Status != metav1.ConditionFalse || externalSecretsReady.Reason != "Disabled" {
 		required = append(required, externalSecretsReady)
 	}

--- a/services/dis-vault-operator/test/e2e/vault_e2e_test.go
+++ b/services/dis-vault-operator/test/e2e/vault_e2e_test.go
@@ -20,6 +20,8 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		sampleVaultName                     = "vault-sample"
 		expectedASOVaultName                = "vault-sample-akv"
 		expectedRoleAssignName              = "vault-sample-owner-ra"
+		expectedGroupRoleAssignName         = "vault-sample-group-ra"
+		sampleGroupObjectID                 = "11111111-1111-1111-1111-111111111111"
 		expectedVPNExitNodeSubnetID         = "/subscriptions/fake-subscription/resourceGroups/fake-network-rg/providers/Microsoft.Network/virtualNetworks/fake-vnet/subnets/fake-vpn-exit-subnet"
 		externalSecretsSamplePath           = "config/samples/vault_v1alpha1_external_secrets_vault.yaml"
 		externalSecretsVaultName            = "vault-es-sample"
@@ -153,6 +155,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForResourceNotFound("vaults.vault.dis.altinn.cloud", sampleVaultName)
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedRoleAssignName)
+		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedGroupRoleAssignName)
 		waitForResourceNotFound("vaults.vault.dis.altinn.cloud", externalSecretsVaultName)
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedExternalSecretsASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedExternalSecretsRoleAssign)
@@ -170,6 +173,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForResourceNotFound("vaults.vault.dis.altinn.cloud", sampleVaultName)
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedRoleAssignName)
+		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedGroupRoleAssignName)
 		waitForResourceNotFound("vaults.vault.dis.altinn.cloud", externalSecretsVaultName)
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedExternalSecretsASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedExternalSecretsRoleAssign)
@@ -207,16 +211,34 @@ var _ = Describe("Vault e2e", Ordered, func() {
 			return err
 		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
 
+		By("verifying group RoleAssignment was created with the fixed Key Vault Secrets Officer role")
+		Eventually(func() error {
+			checkCmd := utils.Kubectl("get", "roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "-n", sampleNamespace)
+			_, err := utils.Run(checkCmd)
+			return err
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+		waitForJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.spec.principalId}", sampleGroupObjectID)
+		waitForJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.spec.principalType}", "Group")
+		waitForJSONPath(
+			"roleassignments.authorization.azure.com",
+			expectedGroupRoleAssignName,
+			"{.spec.roleDefinitionReference.wellKnownName}",
+			"Key Vault Secrets Officer",
+		)
+
 		By("patching dependent ASO resources to Ready so parent status can be projected")
 		resourceID := "/subscriptions/fake-subscription/resourceGroups/fake-resource-group/providers/Microsoft.KeyVault/vaults/vault-sample"
 		vaultURI := "https://vault-sample.vault.azure.net"
-		roleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/role-123"
+		roleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/role-owner-123"
+		groupRoleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/role-group-123"
 		patchKeyVaultReadyStatus(expectedASOVaultName, resourceID, vaultURI)
 		patchRoleAssignmentReadyStatus(expectedRoleAssignName, roleAssignmentID)
+		patchRoleAssignmentReadyStatus(expectedGroupRoleAssignName, groupRoleAssignmentID)
 
 		By("verifying Vault status projects dependent readiness and identifiers")
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='VaultReady')].status}", "True")
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='RoleAssignmentReady')].status}", "True")
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='GroupRoleAssignmentReady')].status}", "True")
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='Ready')].status}", "True")
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.resourceId}", resourceID)
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.vaultUri}", vaultURI)
@@ -254,6 +276,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		By("capturing child resource UIDs before deletion")
 		originalVaultUID := mustGetJSONPath("vaults.keyvault.azure.com", expectedASOVaultName, "{.metadata.uid}")
 		originalRoleAssignUID := mustGetJSONPath("roleassignments.authorization.azure.com", expectedRoleAssignName, "{.metadata.uid}")
+		originalGroupRoleAssignUID := mustGetJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.metadata.uid}")
 
 		By("deleting ASO child resources")
 		cmd := utils.Kubectl("delete", "vaults.keyvault.azure.com", expectedASOVaultName, "-n", sampleNamespace)
@@ -264,6 +287,10 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to delete owner RoleAssignment")
 
+		cmd = utils.Kubectl("delete", "roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "-n", sampleNamespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to delete group RoleAssignment")
+
 		By("verifying deleted children are recreated by reconciliation")
 		Eventually(func() (string, error) {
 			return getJSONPath("vaults.keyvault.azure.com", expectedASOVaultName, "{.metadata.uid}")
@@ -272,6 +299,10 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		Eventually(func() (string, error) {
 			return getJSONPath("roleassignments.authorization.azure.com", expectedRoleAssignName, "{.metadata.uid}")
 		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).ShouldNot(Equal(originalRoleAssignUID))
+
+		Eventually(func() (string, error) {
+			return getJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.metadata.uid}")
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).ShouldNot(Equal(originalGroupRoleAssignUID))
 	})
 
 	It("deletes Vault sample and cascades deletion to ASO child resources", func() {
@@ -288,6 +319,9 @@ var _ = Describe("Vault e2e", Ordered, func() {
 
 		By("verifying owner RoleAssignment was deleted via ownerReference garbage collection")
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedRoleAssignName)
+
+		By("verifying group RoleAssignment was deleted via ownerReference garbage collection")
+		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedGroupRoleAssignName)
 	})
 
 	It("manages a SecretStore for the external secrets sample", func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**Given** a `Vault` with a ready `ApplicationIdentity` and `spec.groupObjectId` set  
**When** the controller reconciles the resource  
**Then** it creates one additional vault-scoped ASO `RoleAssignment` for that Entra group    
**And** the assignment grants the default role for owners of a vault

```mermaid
flowchart LR
    V["Vault CR<br/>groupObjectId (optional)"] --> C["dis-vault-operator"]
    C --> KV["ASO Key Vault"]
    C --> GRA["ASO RoleAssignment for group"]

```
## Related Issue(s)
- #{issue number}


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for group-based Azure Key Vault role assignments via a new groupObjectId field.

* **Improvements**
  * Enhanced status reporting with dedicated group role assignment readiness tracking.
  * Improved role assignment management and deterministic naming for group/owner assignments.

* **Tests**
  * Added unit and end-to-end tests covering group role assignment lifecycle and status projection.

* **Documentation**
  * Updated contributor guidance on code organization and Git prep rules.

* **Chores**
  * Updated Go builder image version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->