### PR TITLE
fix(dis-vault): replace role assignments on write-once changes

### DIFF
--- a/services/dis-vault-operator/internal/controller/suite_test.go
+++ b/services/dis-vault-operator/internal/controller/suite_test.go
@@ -81,6 +81,10 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
+	// Envtest installs CRDs only. It does not run ASO admission webhooks, so these
+	// controller tests must model write-once replacement behavior directly rather than
+	// relying on webhook rejections to catch invalid RoleAssignment updates.
+
 	if getFirstFoundEnvTestBinaryDir() != "" {
 		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
 	}

--- a/services/dis-vault-operator/internal/controller/vault_controller.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller.go
@@ -92,15 +92,12 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if ownerReplacementPending {
-			return ctrl.Result{Requeue: true}, nil
-		}
 
 		groupReplacementPending, err := r.reconcileGroupRoleAssignment(ctx, &vaultObj, desiredKeyVault)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if groupReplacementPending {
+		if ownerReplacementPending || groupReplacementPending {
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}

--- a/services/dis-vault-operator/internal/controller/vault_controller.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller.go
@@ -88,11 +88,20 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			return ctrl.Result{}, err
 		}
 
-		if err := r.reconcileOwnerRoleAssignment(ctx, &vaultObj, desiredKeyVault, identity.PrincipalID); err != nil {
+		ownerReplacementPending, err := r.reconcileOwnerRoleAssignment(ctx, &vaultObj, desiredKeyVault, identity.PrincipalID)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if err := r.reconcileGroupRoleAssignment(ctx, &vaultObj, desiredKeyVault); err != nil {
+		if ownerReplacementPending {
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		groupReplacementPending, err := r.reconcileGroupRoleAssignment(ctx, &vaultObj, desiredKeyVault)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if groupReplacementPending {
+			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 

--- a/services/dis-vault-operator/internal/controller/vault_controller_role.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_role.go
@@ -8,6 +8,7 @@ import (
 	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
 	authorizationv1 "github.com/Azure/azure-service-operator/v2/api/authorization/v1api20220401"
 	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,12 +28,13 @@ func (r *VaultReconciler) reconcileOwnerRoleAssignment(
 	vaultObj *vaultv1alpha1.Vault,
 	keyVault *keyvaultv1.Vault,
 	principalID string,
-) error {
+) (bool, error) {
 	desired, err := vaultpkg.BuildOwnerRoleAssignmentResource(vaultObj, keyVault, principalID)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return r.upsertRoleAssignment(ctx, vaultObj, desired)
+
+	return r.reconcileRoleAssignment(ctx, vaultObj, desired)
 }
 
 func (r *VaultReconciler) upsertRoleAssignment(
@@ -82,30 +84,28 @@ func (r *VaultReconciler) reconcileGroupRoleAssignment(
 	ctx context.Context,
 	vaultObj *vaultv1alpha1.Vault,
 	keyVault *keyvaultv1.Vault,
-) error {
+) (bool, error) {
 	groupObjectID := strings.TrimSpace(vaultObj.Spec.GroupObjectID)
 	desiredName := ""
 	if groupObjectID != "" {
 		desiredName = vaultpkg.BuildGroupRoleAssignmentName(vaultObj.Name)
 		desired, err := vaultpkg.BuildGroupRoleAssignmentResource(vaultObj, keyVault, groupObjectID)
 		if err != nil {
-			return err
+			return false, err
 		}
 
-		current, err := r.getRoleAssignment(ctx, desired.Name, desired.Namespace)
+		replacementPending, err := r.reconcileRoleAssignment(ctx, vaultObj, desired)
 		if err != nil {
-			return err
+			return false, err
 		}
-		if current == nil || metav1.IsControlledBy(current, vaultObj) {
-			if err := r.upsertRoleAssignment(ctx, vaultObj, desired); err != nil {
-				return err
-			}
+		if replacementPending {
+			return true, nil
 		}
 	}
 
 	currentAssignments, err := r.listManagedGroupRoleAssignments(ctx, vaultObj)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	for i := range currentAssignments {
@@ -114,11 +114,58 @@ func (r *VaultReconciler) reconcileGroupRoleAssignment(
 			continue
 		}
 		if err := client.IgnoreNotFound(r.Delete(ctx, &current)); err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	return nil
+	return false, nil
+}
+
+func (r *VaultReconciler) reconcileRoleAssignment(
+	ctx context.Context,
+	owner *vaultv1alpha1.Vault,
+	desired *authorizationv1.RoleAssignment,
+) (bool, error) {
+	current, err := r.getRoleAssignment(ctx, desired.Name, desired.Namespace)
+	if err != nil {
+		return false, err
+	}
+
+	if current != nil && metav1.IsControlledBy(current, owner) && roleAssignmentRequiresReplacement(current, desired) {
+		if err := client.IgnoreNotFound(r.Delete(ctx, current)); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	return false, r.upsertRoleAssignment(ctx, owner, desired)
+}
+
+func roleAssignmentRequiresReplacement(current, desired *authorizationv1.RoleAssignment) bool {
+	if current == nil || desired == nil {
+		return false
+	}
+
+	// ASO rejects updates to write-once RoleAssignment properties after creation,
+	// so changes to the Azure role assignment name or extension owner must be
+	// handled as delete-and-recreate instead of an in-place update.
+	if current.Spec.AzureName != desired.Spec.AzureName {
+		return true
+	}
+
+	return !arbitraryOwnerReferenceEqual(current.Spec.Owner, desired.Spec.Owner)
+}
+
+func arbitraryOwnerReferenceEqual(left, right *genruntime.ArbitraryOwnerReference) bool {
+	// If either pointer is nil, pointer equality covers both nil cases:
+	// nil == nil is equal, and nil != non-nil is not equal.
+	if left == nil || right == nil {
+		return left == right
+	}
+
+	// ArbitraryOwnerReference is a plain value object, so direct struct equality
+	// is sufficient once both pointers are known to be non-nil.
+	return *left == *right
 }
 
 func (r *VaultReconciler) listManagedGroupRoleAssignments(

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Vault controller", func() {
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 	})
 
-	It("updates owner RoleAssignment when Vault identityRef changes", func() {
+	It("replaces a ready owner RoleAssignment when Vault identityRef changes", func() {
 		const (
 			identityA = "identity-owner-a"
 			identityB = "identity-owner-b"
@@ -362,21 +362,46 @@ var _ = Describe("Vault controller", func() {
 		createIdentity(testCtx, identityB, true)
 		Expect(k8sClient.Create(testCtx, newVault(vaultName, identityA))).To(Succeed())
 
+		var keyVaultName string
+		var roleAssignmentName string
 		var roleAssignmentUID types.UID
 		var initialRoleAssignmentAzureName string
 		Eventually(func(g Gomega) {
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+			keyVaultName = keyVaults.Items[0].Name
+
 			var list authorizationv1.RoleAssignmentList
 			g.Expect(k8sClient.List(testCtx, &list, client.InNamespace(ns))).To(Succeed())
 			g.Expect(list.Items).To(HaveLen(1))
 
 			roleAssignment := list.Items[0]
+			roleAssignmentName = roleAssignment.Name
 			roleAssignmentUID = roleAssignment.UID
 			initialRoleAssignmentAzureName = roleAssignment.Spec.AzureName
 
+			g.Expect(roleAssignmentName).NotTo(BeEmpty())
 			g.Expect(roleAssignmentUID).NotTo(BeEmpty())
 			g.Expect(initialRoleAssignmentAzureName).NotTo(BeEmpty())
 			g.Expect(roleAssignment.Spec.PrincipalId).NotTo(BeNil())
 			g.Expect(*roleAssignment.Spec.PrincipalId).To(Equal(identityA + "-principal"))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName
+		vaultURI := "https://" + vaultName + ".vault.azure.net"
+		roleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/" + roleAssignmentName
+		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
+		setRoleAssignmentReadyStatus(testCtx, roleAssignmentName, roleAssignmentID)
+
+		Eventually(func(g Gomega) {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+			g.Expect(current.Status.OwnerRoleAssignmentID).To(Equal(roleAssignmentID))
+
+			roleCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionRoleAssignmentReady))
+			g.Expect(roleCondition).NotTo(BeNil())
+			g.Expect(roleCondition.Status).To(Equal(metav1.ConditionTrue))
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
 		Eventually(func(g Gomega) bool {
@@ -400,7 +425,7 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(roleAssignments.Items).To(HaveLen(1))
 			roleAssignment := roleAssignments.Items[0]
 
-			g.Expect(roleAssignment.UID).To(Equal(roleAssignmentUID))
+			g.Expect(roleAssignment.UID).NotTo(Equal(roleAssignmentUID))
 			g.Expect(roleAssignment.Spec.PrincipalId).NotTo(BeNil())
 			g.Expect(*roleAssignment.Spec.PrincipalId).To(Equal(expectedPrincipalID))
 			g.Expect(roleAssignment.Spec.AzureName).NotTo(Equal(initialRoleAssignmentAzureName))
@@ -643,7 +668,7 @@ var _ = Describe("Vault controller", func() {
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 	})
 
-	It("updates and removes the configured group role assignment", func() {
+	It("replaces and removes the configured group role assignment", func() {
 		const (
 			identityName = "identity-group-switch"
 			vaultName    = "my-app-vault-group-switch"
@@ -691,6 +716,42 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(groupCondition.Reason).To(Equal("Ready"))
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
+		findGroupAndOwnerAssignments := func(items []authorizationv1.RoleAssignment) (authorizationv1.RoleAssignment, authorizationv1.RoleAssignment) {
+			var groupAssignment authorizationv1.RoleAssignment
+			var ownerAssignment authorizationv1.RoleAssignment
+			for i := range items {
+				assignment := items[i]
+				if assignment.Labels[roleAssignmentLabelKind] == roleAssignmentKindGroup {
+					groupAssignment = assignment
+					continue
+				}
+				ownerAssignment = assignment
+			}
+
+			return groupAssignment, ownerAssignment
+		}
+
+		var initialGroupRoleAssignmentUID types.UID
+		var initialGroupRoleAssignmentAzureName string
+		var initialOwnerRoleAssignmentUID types.UID
+		Eventually(func(g Gomega) {
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(2))
+
+			groupAssignment, ownerAssignment := findGroupAndOwnerAssignments(roleAssignments.Items)
+			g.Expect(groupAssignment.Name).NotTo(BeEmpty())
+			g.Expect(ownerAssignment.Name).NotTo(BeEmpty())
+
+			initialGroupRoleAssignmentUID = groupAssignment.UID
+			initialGroupRoleAssignmentAzureName = groupAssignment.Spec.AzureName
+			initialOwnerRoleAssignmentUID = ownerAssignment.UID
+
+			g.Expect(initialGroupRoleAssignmentUID).NotTo(BeEmpty())
+			g.Expect(initialGroupRoleAssignmentAzureName).NotTo(BeEmpty())
+			g.Expect(initialOwnerRoleAssignmentUID).NotTo(BeEmpty())
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
 		Eventually(func(g Gomega) bool {
 			var current vaultv1alpha1.Vault
 			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
@@ -709,14 +770,27 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
 			g.Expect(roleAssignments.Items).To(HaveLen(2))
 
-			principalIDs := make([]string, 0, len(roleAssignments.Items))
-			for i := range roleAssignments.Items {
-				if roleAssignments.Items[i].Spec.PrincipalId != nil {
-					principalIDs = append(principalIDs, *roleAssignments.Items[i].Spec.PrincipalId)
-				}
-			}
-			g.Expect(principalIDs).NotTo(ContainElement(groupOneID))
-			g.Expect(principalIDs).To(ContainElement(groupTwoID))
+			groupAssignment, ownerAssignment := findGroupAndOwnerAssignments(roleAssignments.Items)
+			g.Expect(groupAssignment.UID).NotTo(Equal(initialGroupRoleAssignmentUID))
+			g.Expect(groupAssignment.Spec.PrincipalId).NotTo(BeNil())
+			g.Expect(*groupAssignment.Spec.PrincipalId).To(Equal(groupTwoID))
+			g.Expect(groupAssignment.Spec.AzureName).NotTo(Equal(initialGroupRoleAssignmentAzureName))
+			g.Expect(ownerAssignment.UID).To(Equal(initialOwnerRoleAssignmentUID))
+
+			var currentVault vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &currentVault)).To(Succeed())
+
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+
+			expectedRoleAssignment, err := vaultpkg.BuildGroupRoleAssignmentResource(
+				&currentVault,
+				&keyVaults.Items[0],
+				groupTwoID,
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(groupAssignment.Spec.AzureName).To(Equal(expectedRoleAssignment.Spec.AzureName))
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
 		Eventually(func(g Gomega) {

--- a/services/dis-vault-operator/test/e2e/e2e_suite_test.go
+++ b/services/dis-vault-operator/test/e2e/e2e_suite_test.go
@@ -72,6 +72,9 @@ var _ = BeforeSuite(func() {
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install ASO CRDs on Kind")
 
+	// This suite installs ASO CRDs only. Without ASO controllers and admission webhooks,
+	// it validates our resource wiring and status projection, not ASO write-once enforcement.
+
 	By("installing ApplicationIdentity CRD")
 	cmd = exec.Command("make", "install-dis-identity-crd-kind")
 	_, err = utils.Run(cmd)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role assignment reconciliation to properly handle configuration changes; role assignments are now replaced when Vault identity references or group configurations change, ensuring correct behavior with Azure Service Operator constraints and preventing state inconsistencies.

* **Tests**
  * Enhanced test coverage to validate role assignment replacement behavior during identity reference changes and group configuration updates, with improved assertions for resource state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->