### PR TITLE
feat(dis-vault): use a configmap to share state with services/clis

### DIFF
--- a/services/dis-vault-operator/api/v1alpha1/vault_types.go
+++ b/services/dis-vault-operator/api/v1alpha1/vault_types.go
@@ -138,12 +138,15 @@ const (
 	ConditionGroupRoleAssignment  ConditionType = "GroupRoleAssignmentReady"
 	ConditionNetworkPolicyReady   ConditionType = "NetworkPolicyReady"
 	ConditionExternalSecretsReady ConditionType = "ExternalSecretsReady"
+	ConditionConfigMapReady       ConditionType = "ConfigMapReady"
 )
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="AzureName",type="string",JSONPath=".status.azureName"
+// +kubebuilder:printcolumn:name="VaultURI",type="string",JSONPath=".status.vaultUri"
 
 // Vault is the Schema for the vaults API.
 type Vault struct {

--- a/services/dis-vault-operator/config/crd/bases/vault.dis.altinn.cloud_vaults.yaml
+++ b/services/dis-vault-operator/config/crd/bases/vault.dis.altinn.cloud_vaults.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Ready')].reason
       name: Reason
       type: string
+    - jsonPath: .status.azureName
+      name: AzureName
+      type: string
+    - jsonPath: .status.vaultUri
+      name: VaultURI
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/services/dis-vault-operator/config/rbac/role.yaml
+++ b/services/dis-vault-operator/config/rbac/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - application.dis.altinn.cloud
   resources:
   - applicationidentities

--- a/services/dis-vault-operator/internal/controller/suite_test.go
+++ b/services/dis-vault-operator/internal/controller/suite_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -56,6 +57,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 	scheme := runtime.NewScheme()
 
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	Expect(vaultv1alpha1.AddToScheme(scheme)).To(Succeed())
 	Expect(identityv1alpha1.AddToScheme(scheme)).To(Succeed())
 	Expect(keyvaultv1.AddToScheme(scheme)).To(Succeed())

--- a/services/dis-vault-operator/internal/controller/vault_controller.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller.go
@@ -12,6 +12,7 @@ import (
 	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
 	authorizationv1 "github.com/Azure/azure-service-operator/v2/api/authorization/v1api20220401"
 	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,9 @@ type VaultReconciler struct {
 // External Secrets
 // +kubebuilder:rbac:groups=external-secrets.io,resources=secretstores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=external-secrets.io,resources=secretstores/status,verbs=get
+
+// Core
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("vault", req.NamespacedName)
@@ -118,6 +122,10 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	configMapResult, err := r.reconcileManagedConfigMap(ctx, &vaultObj, azureName, keyVault)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	if err := r.updateStatus(
 		ctx,
 		&vaultObj,
@@ -131,6 +139,7 @@ func (r *VaultReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		roleAssignmentReady,
 		groupRoleAssignmentCondition,
 		secretStore,
+		configMapResult,
 	); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -148,6 +157,7 @@ func (r *VaultReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&vaultv1alpha1.Vault{}).
 		Owns(&keyvaultv1.Vault{}).
 		Owns(&authorizationv1.RoleAssignment{}).
+		Owns(&corev1.ConfigMap{}).
 		Watches(&identityv1alpha1.ApplicationIdentity{}, handler.EnqueueRequestsFromMapFunc(r.mapApplicationIdentityToVaults)).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,

--- a/services/dis-vault-operator/internal/controller/vault_controller_configmap.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_configmap.go
@@ -1,0 +1,147 @@
+package controller
+
+import (
+	"context"
+
+	vaultv1alpha1 "github.com/Altinn/altinn-platform/services/dis-vault-operator/api/v1alpha1"
+	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
+	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type configMapReconcileResult struct {
+	Condition metav1.Condition
+}
+
+func (r *VaultReconciler) upsertManagedConfigMap(
+	ctx context.Context,
+	owner *vaultv1alpha1.Vault,
+	desired *corev1.ConfigMap,
+) error {
+	current := &corev1.ConfigMap{}
+	current.SetName(desired.GetName())
+	current.SetNamespace(desired.GetNamespace())
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, current, func() error {
+		current.Labels = mergeStringMaps(current.Labels, desired.Labels)
+		current.Data = desired.Data
+		current.BinaryData = nil
+		return ctrl.SetControllerReference(owner, current, r.Scheme)
+	})
+	return err
+}
+
+func (r *VaultReconciler) cleanupManagedConfigMaps(
+	ctx context.Context,
+	owner *vaultv1alpha1.Vault,
+	desiredKey types.NamespacedName,
+) error {
+	var configMaps corev1.ConfigMapList
+	if err := r.List(
+		ctx,
+		&configMaps,
+		client.InNamespace(owner.Namespace),
+		client.MatchingLabels{
+			vaultpkg.ManagedResourceOwnerLabel:     owner.Name,
+			vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
+		},
+	); err != nil {
+		return err
+	}
+
+	for i := range configMaps.Items {
+		current := &configMaps.Items[i]
+		if current.Name == desiredKey.Name || !metav1.IsControlledBy(current, owner) {
+			continue
+		}
+		if err := client.IgnoreNotFound(r.Delete(ctx, current)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *VaultReconciler) reconcileManagedConfigMap(
+	ctx context.Context,
+	vaultObj *vaultv1alpha1.Vault,
+	azureName string,
+	keyVault *keyvaultv1.Vault,
+) (configMapReconcileResult, error) {
+	name := vaultpkg.DeterministicConfigMapName(vaultObj.Spec.IdentityRef.Name)
+	key := types.NamespacedName{Name: name, Namespace: vaultObj.Namespace}
+
+	if err := r.cleanupManagedConfigMaps(ctx, vaultObj, key); err != nil {
+		return configMapReconcileResult{}, err
+	}
+
+	current := &corev1.ConfigMap{}
+	if err := r.Get(ctx, key, current); err != nil {
+		if apierrors.IsNotFound(err) {
+			current = nil
+		} else {
+			return configMapReconcileResult{}, err
+		}
+	}
+
+	if current != nil && !metav1.IsControlledBy(current, vaultObj) {
+		return configMapReconcileResult{
+			Condition: vaultpkg.NewCondition(
+				vaultv1alpha1.ConditionConfigMapReady,
+				vaultObj.Generation,
+				metav1.ConditionFalse,
+				"NameConflict",
+				"managed ConfigMap already exists and is not managed by this Vault",
+			),
+		}, nil
+	}
+
+	vaultURI := vaultURIFromStatus(keyVault)
+	if vaultURI == "" {
+		if current != nil {
+			return configMapReconcileResult{
+				Condition: vaultpkg.NewCondition(
+					vaultv1alpha1.ConditionConfigMapReady,
+					vaultObj.Generation,
+					metav1.ConditionTrue,
+					"Ready",
+					"managed ConfigMap is present",
+				),
+			}, nil
+		}
+
+		return configMapReconcileResult{
+			Condition: vaultpkg.NewCondition(
+				vaultv1alpha1.ConditionConfigMapReady,
+				vaultObj.Generation,
+				metav1.ConditionUnknown,
+				"VaultNotReady",
+				"waiting for Vault URI before reconciling ConfigMap",
+			),
+		}, nil
+	}
+
+	desired, err := vaultpkg.BuildManagedConfigMap(vaultObj, azureName, vaultURI)
+	if err != nil {
+		return configMapReconcileResult{}, err
+	}
+	if err := r.upsertManagedConfigMap(ctx, vaultObj, desired); err != nil {
+		return configMapReconcileResult{}, err
+	}
+
+	return configMapReconcileResult{
+		Condition: vaultpkg.NewCondition(
+			vaultv1alpha1.ConditionConfigMapReady,
+			vaultObj.Generation,
+			metav1.ConditionTrue,
+			"Ready",
+			"managed ConfigMap reconciled",
+		),
+	}, nil
+}

--- a/services/dis-vault-operator/internal/controller/vault_controller_status.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_status.go
@@ -24,6 +24,7 @@ func (r *VaultReconciler) updateStatus(
 	roleAssignmentReady vaultpkg.ASOReadyCondition,
 	groupRoleAssignmentCondition metav1.Condition,
 	secretStore secretStoreReconcileResult,
+	configMapResult configMapReconcileResult,
 ) error {
 	updated := false
 
@@ -46,6 +47,7 @@ func (r *VaultReconciler) updateStatus(
 	groupRoleAssignmentCondition = applyCondition(groupRoleAssignmentCondition)
 	networkCondition := applyCondition(buildNetworkPolicyCondition(vaultObj.Generation, desiredKeyVault, r.Config))
 	secretStoreCondition := applyCondition(secretStore.Condition)
+	configMapCondition := applyCondition(configMapResult.Condition)
 	applyCondition(vaultpkg.AggregateReadyCondition(
 		vaultObj.Generation,
 		identityCondition,
@@ -54,6 +56,7 @@ func (r *VaultReconciler) updateStatus(
 		networkCondition,
 		secretStoreCondition,
 		groupRoleAssignmentCondition,
+		configMapCondition,
 	))
 
 	updated = setIfChanged(&vaultObj.Status.AzureName, azureName) || updated

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -16,6 +16,7 @@ import (
 	keyvaultv1 "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701"
 	asoconditions "github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	esov1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,16 @@ var _ = Describe("Vault controller", func() {
 		deleteAll := func(obj client.Object) {
 			Expect(k8sClient.DeleteAllOf(ctx, obj, client.InNamespace(namespace))).To(Succeed())
 		}
+		deleteManagedConfigMaps := func() {
+			Expect(k8sClient.DeleteAllOf(
+				ctx,
+				&corev1.ConfigMap{},
+				client.InNamespace(namespace),
+				client.MatchingLabels{
+					vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
+				},
+			)).To(Succeed())
+		}
 		waitUntilEmpty := func(list client.ObjectList) {
 			Eventually(func(g Gomega) int {
 				g.Expect(k8sClient.List(ctx, list, client.InNamespace(namespace))).To(Succeed())
@@ -70,6 +81,20 @@ var _ = Describe("Vault controller", func() {
 				}
 			}).WithTimeout(10 * time.Second).WithPolling(200 * time.Millisecond).Should(Equal(0))
 		}
+		waitUntilManagedConfigMapsEmpty := func() {
+			Eventually(func(g Gomega) int {
+				var list corev1.ConfigMapList
+				g.Expect(k8sClient.List(
+					ctx,
+					&list,
+					client.InNamespace(namespace),
+					client.MatchingLabels{
+						vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
+					},
+				)).To(Succeed())
+				return len(list.Items)
+			}).WithTimeout(10 * time.Second).WithPolling(200 * time.Millisecond).Should(Equal(0))
+		}
 
 		// Delete owners first to avoid controller re-creating dependents during cleanup.
 		deleteAll(&vaultv1alpha1.Vault{})
@@ -79,11 +104,13 @@ var _ = Describe("Vault controller", func() {
 		deleteAll(&keyvaultv1.Vault{})
 		deleteAll(&esov1.SecretStore{})
 		deleteAll(&identityv1alpha1.ApplicationIdentity{})
+		deleteManagedConfigMaps()
 
 		waitUntilEmpty(&authorizationv1.RoleAssignmentList{})
 		waitUntilEmpty(&keyvaultv1.VaultList{})
 		waitUntilEmpty(&esov1.SecretStoreList{})
 		waitUntilEmpty(&identityv1alpha1.ApplicationIdentityList{})
+		waitUntilManagedConfigMapsEmpty()
 	}
 
 	newVault := func(name, identityRef string) *vaultv1alpha1.Vault {
@@ -971,6 +998,69 @@ var _ = Describe("Vault controller", func() {
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 	})
 
+	It("manages a ConfigMap lifecycle when the Vault URI becomes available", func() {
+		const (
+			identityName = "my-app-identity-configmap"
+			vaultName    = "my-app-vault-configmap"
+		)
+
+		createIdentity(testCtx, identityName, true)
+		vaultObj := newVault(vaultName, identityName)
+		Expect(k8sClient.Create(testCtx, vaultObj)).To(Succeed())
+
+		expectedConfigMapName := vaultpkg.DeterministicConfigMapName(identityName)
+		Consistently(func() bool {
+			var configMap corev1.ConfigMap
+			err := k8sClient.Get(testCtx, types.NamespacedName{Name: expectedConfigMapName, Namespace: ns}, &configMap)
+			return apierrors.IsNotFound(err)
+		}, 2*time.Second, 300*time.Millisecond).Should(BeTrue())
+
+		var keyVaultName string
+		var roleAssignmentName string
+		Eventually(func(g Gomega) {
+			var keyVaults keyvaultv1.VaultList
+			g.Expect(k8sClient.List(testCtx, &keyVaults, client.InNamespace(ns))).To(Succeed())
+			g.Expect(keyVaults.Items).To(HaveLen(1))
+			keyVaultName = keyVaults.Items[0].Name
+
+			var roleAssignments authorizationv1.RoleAssignmentList
+			g.Expect(k8sClient.List(testCtx, &roleAssignments, client.InNamespace(ns))).To(Succeed())
+			g.Expect(roleAssignments.Items).To(HaveLen(1))
+			roleAssignmentName = roleAssignments.Items[0].Name
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		resourceID := "/subscriptions/sub-123/resourceGroups/rg-dis-dev/providers/Microsoft.KeyVault/vaults/" + vaultName
+		vaultURI := "https://" + vaultName + ".vault.azure.net"
+		roleAssignmentID := resourceID + "/providers/Microsoft.Authorization/roleAssignments/role-123"
+		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
+		setRoleAssignmentReadyStatus(testCtx, roleAssignmentName, roleAssignmentID)
+
+		expectedAKVName := vaultpkg.DeterministicAzureVaultName(ns, vaultName, "dev")
+		Eventually(func(g Gomega) {
+			var configMap corev1.ConfigMap
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: expectedConfigMapName, Namespace: ns}, &configMap)).To(Succeed())
+			g.Expect(configMap.Labels).To(HaveKeyWithValue(vaultpkg.ManagedResourceOwnerLabel, vaultName))
+			g.Expect(configMap.Labels).To(HaveKeyWithValue(vaultpkg.ManagedResourceComponentLabel, vaultpkg.ManagedConfigMapComponentValue))
+			g.Expect(configMap.Data).To(HaveKeyWithValue(vaultpkg.ConfigMapKeyAKVName, expectedAKVName))
+			g.Expect(configMap.Data).To(HaveKeyWithValue(vaultpkg.ConfigMapKeyAKVURI, vaultURI))
+			g.Expect(metav1.IsControlledBy(&configMap, vaultObj)).To(BeTrue())
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+
+			configMapCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionConfigMapReady))
+			g.Expect(configMapCondition).NotTo(BeNil())
+			g.Expect(configMapCondition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(configMapCondition.Reason).To(Equal("Ready"))
+
+			ready := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionReady))
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+	})
+
 	It("manages a SecretStore lifecycle when external secrets integration is enabled", func() {
 		const (
 			identityName = "my-app-identity-secretstore"
@@ -1153,6 +1243,126 @@ func TestReconcileManagedSecretStoreReturnsCRDNotInstalledWhenSecretStoreCRDIsMi
 	}
 }
 
+func TestReconcileManagedConfigMapDeletesStaleOwnedConfigMaps(t *testing.T) {
+	t.Parallel()
+
+	scheme := newControllerUnitTestScheme(t)
+	vaultObj := &vaultv1alpha1.Vault{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: vaultv1alpha1.GroupVersion.String(),
+			Kind:       "Vault",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "vault-sample",
+			Namespace:  "default",
+			Generation: 9,
+			UID:        types.UID("vault-uid"),
+		},
+		Spec: vaultv1alpha1.VaultSpec{
+			IdentityRef: vaultv1alpha1.ApplicationIdentityRef{Name: "new-app"},
+		},
+	}
+
+	stale := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vaultpkg.DeterministicConfigMapName("old-app"),
+			Namespace: vaultObj.Namespace,
+			Labels: map[string]string{
+				vaultpkg.ManagedResourceOwnerLabel:     vaultObj.Name,
+				vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(vaultObj, vaultv1alpha1.GroupVersion.WithKind("Vault")),
+			},
+		},
+		Data: map[string]string{
+			vaultpkg.ConfigMapKeyAKVName: "stale-akv",
+			vaultpkg.ConfigMapKeyAKVURI:  "https://stale.vault.azure.net",
+		},
+	}
+
+	reconciler := &VaultReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build(),
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.reconcileManagedConfigMap(context.Background(), vaultObj, "new-akv", nil)
+	if err != nil {
+		t.Fatalf("expected stale cleanup reconcile to succeed, got error: %v", err)
+	}
+	if result.Condition.Type != string(vaultv1alpha1.ConditionConfigMapReady) {
+		t.Fatalf("expected ConfigMapReady condition, got %q", result.Condition.Type)
+	}
+	if result.Condition.Status != metav1.ConditionUnknown || result.Condition.Reason != "VaultNotReady" {
+		t.Fatalf("expected ConfigMapReady=Unknown/VaultNotReady, got %s/%s", result.Condition.Status, result.Condition.Reason)
+	}
+
+	var current corev1.ConfigMap
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: stale.Name, Namespace: stale.Namespace}, &current)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stale managed ConfigMap to be deleted, got err=%v obj=%#v", err, current)
+	}
+}
+
+func TestReconcileManagedConfigMapReturnsNameConflictForNonOwnedConfigMap(t *testing.T) {
+	t.Parallel()
+
+	scheme := newControllerUnitTestScheme(t)
+	vaultObj := &vaultv1alpha1.Vault{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "vault-sample",
+			Namespace:  "default",
+			Generation: 11,
+		},
+		Spec: vaultv1alpha1.VaultSpec{
+			IdentityRef: vaultv1alpha1.ApplicationIdentityRef{Name: "app-sample"},
+		},
+	}
+
+	conflict := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vaultpkg.DeterministicConfigMapName(vaultObj.Spec.IdentityRef.Name),
+			Namespace: vaultObj.Namespace,
+		},
+		Data: map[string]string{
+			vaultpkg.ConfigMapKeyAKVName: "existing-akv",
+			vaultpkg.ConfigMapKeyAKVURI:  "https://existing.vault.azure.net",
+		},
+	}
+
+	keyVault := &keyvaultv1.Vault{
+		Status: keyvaultv1.Vault_STATUS{
+			Properties: &keyvaultv1.VaultProperties_STATUS{
+				VaultUri: ptrTo("https://new.vault.azure.net"),
+			},
+		},
+	}
+
+	reconciler := &VaultReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(conflict).Build(),
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.reconcileManagedConfigMap(context.Background(), vaultObj, "new-akv", keyVault)
+	if err != nil {
+		t.Fatalf("expected name conflict to surface as condition, got error: %v", err)
+	}
+	if result.Condition.Type != string(vaultv1alpha1.ConditionConfigMapReady) {
+		t.Fatalf("expected ConfigMapReady condition, got %q", result.Condition.Type)
+	}
+	if result.Condition.Status != metav1.ConditionFalse || result.Condition.Reason != "NameConflict" {
+		t.Fatalf("expected ConfigMapReady=False/NameConflict, got %s/%s", result.Condition.Status, result.Condition.Reason)
+	}
+
+	var current corev1.ConfigMap
+	if err := reconciler.Get(context.Background(), types.NamespacedName{Name: conflict.Name, Namespace: conflict.Namespace}, &current); err != nil {
+		t.Fatalf("expected conflicting ConfigMap to remain, got error: %v", err)
+	}
+	if current.Data[vaultpkg.ConfigMapKeyAKVURI] != "https://existing.vault.azure.net" {
+		t.Fatalf("expected conflicting ConfigMap data to remain unchanged, got %#v", current.Data)
+	}
+}
+
 func TestBuildNetworkPolicyCondition(t *testing.T) {
 	t.Parallel()
 
@@ -1201,6 +1411,9 @@ func newControllerUnitTestScheme(t *testing.T) *runtime.Scheme {
 	if err := vaultv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add Vault scheme: %v", err)
 	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
 	if err := esov1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add SecretStore scheme: %v", err)
 	}
@@ -1208,4 +1421,8 @@ func newControllerUnitTestScheme(t *testing.T) *runtime.Scheme {
 		t.Fatalf("add Key Vault scheme: %v", err)
 	}
 	return scheme
+}
+
+func ptrTo[T any](value T) *T {
+	return &value
 }

--- a/services/dis-vault-operator/internal/vault/builders.go
+++ b/services/dis-vault-operator/internal/vault/builders.go
@@ -20,7 +20,6 @@ import (
 const defaultManagedResourceBaseName = "vault"
 
 const (
-	roleAssignmentLabelName    = "vault.dis.altinn.cloud/name"
 	roleAssignmentLabelKind    = "vault.dis.altinn.cloud/assignment-kind"
 	roleAssignmentKindGroup    = "group"
 	keyVaultSecretsOfficerRole = "Key Vault Secrets Officer"
@@ -104,7 +103,7 @@ func BuildASOKeyVaultResource(v *vaultv1alpha1.Vault, cfg config.OperatorConfig,
 			Name:      keyVaultK8sName,
 			Namespace: v.Namespace,
 			Labels: map[string]string{
-				roleAssignmentLabelName: v.Name,
+				ManagedResourceOwnerLabel: v.Name,
 			},
 		},
 		Spec: keyvaultv1.Vault_Spec{
@@ -137,7 +136,7 @@ func BuildOwnerRoleAssignmentResource(v *vaultv1alpha1.Vault, keyVault *keyvault
 		principalID,
 		authorizationv1.RoleAssignmentProperties_PrincipalType_ServicePrincipal,
 		map[string]string{
-			roleAssignmentLabelName: v.Name,
+			ManagedResourceOwnerLabel: v.Name,
 		},
 	)
 }
@@ -168,8 +167,8 @@ func BuildGroupRoleAssignmentResource(
 		groupObjectID,
 		authorizationv1.RoleAssignmentProperties_PrincipalType_Group,
 		map[string]string{
-			roleAssignmentLabelName: v.Name,
-			roleAssignmentLabelKind: roleAssignmentKindGroup,
+			ManagedResourceOwnerLabel: v.Name,
+			roleAssignmentLabelKind:   roleAssignmentKindGroup,
 		},
 	)
 }

--- a/services/dis-vault-operator/internal/vault/configmap.go
+++ b/services/dis-vault-operator/internal/vault/configmap.go
@@ -1,0 +1,69 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+
+	vaultv1alpha1 "github.com/Altinn/altinn-platform/services/dis-vault-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	configMapSuffix     = "dis-vault"
+	configMapMaxLen     = 63
+	ConfigMapKeyAKVName = "AkvName"
+	ConfigMapKeyAKVURI  = "AkvUri"
+)
+
+func DeterministicConfigMapName(appName string) string {
+	appName = sanitizeKubernetesName(appName)
+	if appName == "" {
+		appName = defaultManagedResourceBaseName
+	}
+
+	name := appName + "-" + configMapSuffix
+	if len(name) <= configMapMaxLen {
+		return name
+	}
+
+	hash := stableHexHash(name)[:8]
+	maxBase := max(configMapMaxLen-len(configMapSuffix)-len(hash)-2, 1)
+	appName = strings.Trim(appName[:min(len(appName), maxBase)], "-")
+	if appName == "" {
+		appName = "v"
+	}
+
+	return appName + "-" + configMapSuffix + "-" + hash
+}
+
+func BuildManagedConfigMap(v *vaultv1alpha1.Vault, azureName, vaultURI string) (*corev1.ConfigMap, error) {
+	if v == nil {
+		return nil, fmt.Errorf("vault must not be nil")
+	}
+	if strings.TrimSpace(v.Spec.IdentityRef.Name) == "" {
+		return nil, fmt.Errorf("identityRef.name must not be empty")
+	}
+	if strings.TrimSpace(azureName) == "" {
+		return nil, fmt.Errorf("azureName must not be empty")
+	}
+	vaultURI = strings.TrimSpace(vaultURI)
+	if vaultURI == "" {
+		return nil, fmt.Errorf("vaultURI must not be empty")
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeterministicConfigMapName(v.Spec.IdentityRef.Name),
+			Namespace: v.Namespace,
+			Labels: map[string]string{
+				ManagedResourceOwnerLabel:     v.Name,
+				ManagedResourceComponentLabel: ManagedConfigMapComponentValue,
+			},
+		},
+		Data: map[string]string{
+			ConfigMapKeyAKVName: azureName,
+			ConfigMapKeyAKVURI:  vaultURI,
+		},
+	}, nil
+}

--- a/services/dis-vault-operator/internal/vault/configmap_test.go
+++ b/services/dis-vault-operator/internal/vault/configmap_test.go
@@ -1,0 +1,67 @@
+package vault
+
+import (
+	"strings"
+	"testing"
+
+	vaultv1alpha1 "github.com/Altinn/altinn-platform/services/dis-vault-operator/api/v1alpha1"
+)
+
+func TestDeterministicConfigMapName(t *testing.T) {
+	t.Parallel()
+
+	got := DeterministicConfigMapName("my-app")
+	if got != "my-app-dis-vault" {
+		t.Fatalf("expected preferred ConfigMap name, got %q", got)
+	}
+}
+
+func TestDeterministicConfigMapNameTruncatesLongNames(t *testing.T) {
+	t.Parallel()
+
+	base := strings.Repeat("very-long-application-name-", 4)
+	got := DeterministicConfigMapName(base)
+	got2 := DeterministicConfigMapName(base)
+
+	if got != got2 {
+		t.Fatalf("expected deterministic output ConfigMap name, got %q and %q", got, got2)
+	}
+	if len(got) > 63 {
+		t.Fatalf("expected DNS-1123 compliant name length, got %d for %q", len(got), got)
+	}
+	if !strings.Contains(got, "-dis-vault-") {
+		t.Fatalf("expected hashed dis-vault suffix fallback, got %q", got)
+	}
+}
+
+func TestBuildManagedConfigMap(t *testing.T) {
+	t.Parallel()
+
+	vaultObj := &vaultv1alpha1.Vault{}
+	vaultObj.Name = "my-app-vault"
+	vaultObj.Namespace = "default"
+	vaultObj.Spec.IdentityRef.Name = "my-app"
+
+	configMap, err := BuildManagedConfigMap(vaultObj, "my-akv-name", "https://my-akv.vault.azure.net")
+	if err != nil {
+		t.Fatalf("expected ConfigMap builder to succeed, got error: %v", err)
+	}
+	if configMap.Name != "my-app-dis-vault" {
+		t.Fatalf("expected deterministic ConfigMap name, got %q", configMap.Name)
+	}
+	if configMap.Namespace != vaultObj.Namespace {
+		t.Fatalf("expected namespace %q, got %q", vaultObj.Namespace, configMap.Namespace)
+	}
+	if got := configMap.Labels[ManagedResourceOwnerLabel]; got != vaultObj.Name {
+		t.Fatalf("expected managed owner label %q, got %q", vaultObj.Name, got)
+	}
+	if got := configMap.Labels[ManagedResourceComponentLabel]; got != ManagedConfigMapComponentValue {
+		t.Fatalf("expected ConfigMap component label %q, got %q", ManagedConfigMapComponentValue, got)
+	}
+	if got := configMap.Data[ConfigMapKeyAKVName]; got != "my-akv-name" {
+		t.Fatalf("expected AkvName data key to be set, got %q", got)
+	}
+	if got := configMap.Data[ConfigMapKeyAKVURI]; got != "https://my-akv.vault.azure.net" {
+		t.Fatalf("expected AkvUri data key to be set, got %q", got)
+	}
+}

--- a/services/dis-vault-operator/internal/vault/labels.go
+++ b/services/dis-vault-operator/internal/vault/labels.go
@@ -1,0 +1,7 @@
+package vault
+
+const (
+	ManagedResourceOwnerLabel      = "vault.dis.altinn.cloud/name"
+	ManagedResourceComponentLabel  = "vault.dis.altinn.cloud/component"
+	ManagedConfigMapComponentValue = "configmap"
+)

--- a/services/dis-vault-operator/internal/vault/secretstore.go
+++ b/services/dis-vault-operator/internal/vault/secretstore.go
@@ -64,7 +64,7 @@ func BuildManagedSecretStore(v *vaultv1alpha1.Vault, tenantID, vaultURI string) 
 			Name:      name,
 			Namespace: v.Namespace,
 			Labels: map[string]string{
-				"vault.dis.altinn.cloud/name": v.Name,
+				ManagedResourceOwnerLabel: v.Name,
 			},
 		},
 		Spec: externalsecretsv1.SecretStoreSpec{

--- a/services/dis-vault-operator/test/e2e/vault_e2e_test.go
+++ b/services/dis-vault-operator/test/e2e/vault_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	vaultpkg "github.com/Altinn/altinn-platform/services/dis-vault-operator/internal/vault"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -23,6 +24,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		expectedGroupRoleAssignName         = "vault-sample-group-ra"
 		sampleGroupObjectID                 = "11111111-1111-1111-1111-111111111111"
 		expectedVPNExitNodeSubnetID         = "/subscriptions/fake-subscription/resourceGroups/fake-network-rg/providers/Microsoft.Network/virtualNetworks/fake-vnet/subnets/fake-vpn-exit-subnet"
+		expectedConfigMapName               = "app-identity-sample-dis-vault"
 		externalSecretsSamplePath           = "config/samples/vault_v1alpha1_external_secrets_vault.yaml"
 		externalSecretsVaultName            = "vault-es-sample"
 		expectedExternalSecretsASOVaultName = "vault-es-sample-akv"
@@ -90,13 +92,13 @@ var _ = Describe("Vault e2e", Ordered, func() {
 	waitForResourceNotFound := func(resource, name string) {
 		Eventually(func() (bool, error) {
 			return resourceExists(resource, name)
-		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(BeFalse(), "expected %s/%s to be deleted", resource, name)
+		}).WithTimeout(2*time.Minute).WithPolling(2*time.Second).Should(BeFalse(), "expected %s/%s to be deleted", resource, name)
 	}
 
 	ensureResourceNotCreatedYet := func(resource, name string) {
 		Consistently(func() (bool, error) {
 			return resourceExists(resource, name)
-		}).WithTimeout(15 * time.Second).WithPolling(2 * time.Second).Should(BeFalse(), "expected %s/%s to remain absent", resource, name)
+		}).WithTimeout(15*time.Second).WithPolling(2*time.Second).Should(BeFalse(), "expected %s/%s to remain absent", resource, name)
 	}
 
 	applyManifest := func(path string) {
@@ -160,6 +162,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedExternalSecretsASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedExternalSecretsRoleAssign)
 		waitForResourceNotFound("secretstores.external-secrets.io", expectedSecretStoreName)
+		waitForResourceNotFound("configmaps", expectedConfigMapName)
 	})
 
 	AfterAll(func() {
@@ -178,6 +181,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedExternalSecretsASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedExternalSecretsRoleAssign)
 		waitForResourceNotFound("secretstores.external-secrets.io", expectedSecretStoreName)
+		waitForResourceNotFound("configmaps", expectedConfigMapName)
 	})
 
 	It("applies Vault sample from config and creates ASO resources", func() {
@@ -217,6 +221,9 @@ var _ = Describe("Vault e2e", Ordered, func() {
 			_, err := utils.Run(checkCmd)
 			return err
 		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+
+		By("verifying the ConfigMap is not created before the Vault URI is known")
+		ensureResourceNotCreatedYet("configmaps", expectedConfigMapName)
 		waitForJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.spec.principalId}", sampleGroupObjectID)
 		waitForJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.spec.principalType}", "Group")
 		waitForJSONPath(
@@ -243,6 +250,9 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.resourceId}", resourceID)
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.vaultUri}", vaultURI)
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.ownerRoleAssignmentId}", roleAssignmentID)
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='ConfigMapReady')].status}", "True")
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvName}", vaultpkg.DeterministicAzureVaultName(sampleNamespace, sampleVaultName, "dev"))
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvUri}", vaultURI)
 		waitForJSONPathContains(
 			"vaults.keyvault.azure.com",
 			expectedASOVaultName,
@@ -322,6 +332,9 @@ var _ = Describe("Vault e2e", Ordered, func() {
 
 		By("verifying group RoleAssignment was deleted via ownerReference garbage collection")
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedGroupRoleAssignName)
+
+		By("verifying the ConfigMap was deleted via ownerReference garbage collection")
+		waitForResourceNotFound("configmaps", expectedConfigMapName)
 	})
 
 	It("manages a SecretStore for the external secrets sample", func() {
@@ -342,6 +355,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 
 		By("verifying the SecretStore is not created before the Vault URI is known")
 		ensureResourceNotCreatedYet("secretstores.external-secrets.io", expectedSecretStoreName)
+		ensureResourceNotCreatedYet("configmaps", expectedConfigMapName)
 
 		By("patching dependent ASO resources to Ready")
 		resourceID := "/subscriptions/fake-subscription/resourceGroups/fake-resource-group/providers/Microsoft.KeyVault/vaults/vault-es-sample"
@@ -355,9 +369,12 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.serviceAccountRef.name}", "app-identity-sample")
 		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.vaultUrl}", vaultURI)
 		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.tenantId}", "00000000-0000-0000-0000-000000000000")
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvName}", vaultpkg.DeterministicAzureVaultName(sampleNamespace, externalSecretsVaultName, "dev"))
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvUri}", vaultURI)
 
 		By("verifying Vault status reports External Secrets readiness")
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", externalSecretsVaultName, "{.status.conditions[?(@.type=='ExternalSecretsReady')].status}", "True")
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", externalSecretsVaultName, "{.status.conditions[?(@.type=='ConfigMapReady')].status}", "True")
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", externalSecretsVaultName, "{.status.externalSecretStoreName}", expectedSecretStoreName)
 		waitForJSONPath("vaults.vault.dis.altinn.cloud", externalSecretsVaultName, "{.status.conditions[?(@.type=='Ready')].status}", "True")
 
@@ -384,5 +401,6 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForResourceNotFound("vaults.vault.dis.altinn.cloud", externalSecretsVaultName)
 		waitForResourceNotFound("vaults.keyvault.azure.com", expectedExternalSecretsASOVaultName)
 		waitForResourceNotFound("roleassignments.authorization.azure.com", expectedExternalSecretsRoleAssign)
+		waitForResourceNotFound("configmaps", expectedConfigMapName)
 	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Vault operator now automatically creates and manages ConfigMaps containing Azure Key Vault connection details (vault name and URI)
- Enhanced Vault resource display in list views with new Azure Name and Vault URI columns
- Added ConfigMap readiness status tracking to Vault status conditions for improved resource visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->