### PR TITLE
fix(dis-vault): create configmap before vault uri is ready

### DIFF
--- a/services/dis-vault-operator/internal/controller/vault_controller_configmap.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_configmap.go
@@ -107,28 +107,8 @@ func (r *VaultReconciler) reconcileManagedConfigMap(
 	}
 
 	vaultURI := vaultURIFromStatus(keyVault)
-	if vaultURI == "" {
-		if current != nil {
-			return configMapReconcileResult{
-				Condition: vaultpkg.NewCondition(
-					vaultv1alpha1.ConditionConfigMapReady,
-					vaultObj.Generation,
-					metav1.ConditionTrue,
-					"Ready",
-					"managed ConfigMap is present",
-				),
-			}, nil
-		}
-
-		return configMapReconcileResult{
-			Condition: vaultpkg.NewCondition(
-				vaultv1alpha1.ConditionConfigMapReady,
-				vaultObj.Generation,
-				metav1.ConditionUnknown,
-				"VaultNotReady",
-				"waiting for Vault URI before reconciling ConfigMap",
-			),
-		}, nil
+	if vaultURI == "" && current != nil {
+		vaultURI = current.Data[vaultpkg.ConfigMapKeyAKVURI]
 	}
 
 	desired, err := vaultpkg.BuildManagedConfigMap(vaultObj, azureName, vaultURI)
@@ -137,6 +117,18 @@ func (r *VaultReconciler) reconcileManagedConfigMap(
 	}
 	if err := r.upsertManagedConfigMap(ctx, vaultObj, desired); err != nil {
 		return configMapReconcileResult{}, err
+	}
+
+	if desired.Data[vaultpkg.ConfigMapKeyAKVURI] == "" {
+		return configMapReconcileResult{
+			Condition: vaultpkg.NewCondition(
+				vaultv1alpha1.ConditionConfigMapReady,
+				vaultObj.Generation,
+				metav1.ConditionTrue,
+				"PendingVaultURI",
+				"managed ConfigMap reconciled; AkvUri will be updated when Vault URI becomes available",
+			),
+		}, nil
 	}
 
 	return configMapReconcileResult{

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -1609,7 +1609,11 @@ func TestReconcileManagedConfigMapDeletesStaleOwnedConfigMaps(t *testing.T) {
 	if current.Data[vaultpkg.ConfigMapKeyAKVName] != "new-akv" {
 		t.Fatalf("expected replacement ConfigMap to contain the Azure Key Vault name, got %#v", current.Data)
 	}
-	if current.Data[vaultpkg.ConfigMapKeyAKVURI] != "" {
+	gotURI, ok := current.Data[vaultpkg.ConfigMapKeyAKVURI]
+	if !ok {
+		t.Fatalf("expected replacement ConfigMap to contain the AkvUri key, got %#v", current.Data)
+	}
+	if gotURI != "" {
 		t.Fatalf("expected replacement ConfigMap to leave AkvUri empty until the Vault URI is known, got %#v", current.Data)
 	}
 }

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const readyReason = "Ready"
+
 type noMatchSecretStoreClient struct {
 	client.Client
 }
@@ -165,7 +167,7 @@ var _ = Describe("Vault controller", func() {
 			meta.SetStatusCondition(&appIdentity.Status.Conditions, metav1.Condition{
 				Type:   string(identityv1alpha1.ConditionReady),
 				Status: metav1.ConditionTrue,
-				Reason: "Ready",
+				Reason: readyReason,
 			})
 			Expect(k8sClient.Status().Update(ctx, appIdentity)).To(Succeed())
 		}
@@ -197,7 +199,7 @@ var _ = Describe("Vault controller", func() {
 				Severity:           asoconditions.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				ObservedGeneration: keyVault.Generation,
-				Reason:             "Ready",
+				Reason:             readyReason,
 				Message:            "Provisioned",
 			}}
 
@@ -223,7 +225,7 @@ var _ = Describe("Vault controller", func() {
 				Severity:           asoconditions.ConditionSeverityNone,
 				LastTransitionTime: metav1.Now(),
 				ObservedGeneration: roleAssignment.Generation,
-				Reason:             "Ready",
+				Reason:             readyReason,
 				Message:            "Assigned",
 			}}
 
@@ -304,7 +306,7 @@ var _ = Describe("Vault controller", func() {
 			meta.SetStatusCondition(&identity.Status.Conditions, metav1.Condition{
 				Type:   string(identityv1alpha1.ConditionReady),
 				Status: metav1.ConditionTrue,
-				Reason: "Ready",
+				Reason: readyReason,
 			})
 			if err := k8sClient.Status().Update(testCtx, &identity); err != nil {
 				if apierrors.IsConflict(err) {
@@ -912,7 +914,7 @@ var _ = Describe("Vault controller", func() {
 			groupCondition := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionGroupRoleAssignment))
 			g.Expect(groupCondition).NotTo(BeNil())
 			g.Expect(groupCondition.Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(groupCondition.Reason).To(Equal("Ready"))
+			g.Expect(groupCondition.Reason).To(Equal(readyReason))
 
 			ready := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionReady))
 			g.Expect(ready).NotTo(BeNil())
@@ -965,7 +967,7 @@ var _ = Describe("Vault controller", func() {
 			groupCondition := meta.FindStatusCondition(vaultObj.Status.Conditions, string(vaultv1alpha1.ConditionGroupRoleAssignment))
 			g.Expect(groupCondition).NotTo(BeNil())
 			g.Expect(groupCondition.Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(groupCondition.Reason).To(Equal("Ready"))
+			g.Expect(groupCondition.Reason).To(Equal(readyReason))
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
 		findGroupAndOwnerAssignments := func(items []authorizationv1.RoleAssignment) (authorizationv1.RoleAssignment, authorizationv1.RoleAssignment) {
@@ -1292,7 +1294,7 @@ var _ = Describe("Vault controller", func() {
 			configMapCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionConfigMapReady))
 			g.Expect(configMapCondition).NotTo(BeNil())
 			g.Expect(configMapCondition.Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(configMapCondition.Reason).To(Equal("Ready"))
+			g.Expect(configMapCondition.Reason).To(Equal(readyReason))
 
 			ready := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionReady))
 			g.Expect(ready).NotTo(BeNil())
@@ -1362,7 +1364,7 @@ var _ = Describe("Vault controller", func() {
 			external := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionExternalSecretsReady))
 			g.Expect(external).NotTo(BeNil())
 			g.Expect(external.Status).To(Equal(metav1.ConditionTrue))
-			g.Expect(external.Reason).To(Equal("Ready"))
+			g.Expect(external.Reason).To(Equal(readyReason))
 			g.Expect(current.Status.ExternalSecretStoreName).To(Equal(expectedStoreName))
 
 			ready := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionReady))
@@ -1721,7 +1723,7 @@ func TestReconcileManagedConfigMapPreservesExistingVaultURIWhenStatusIsUnavailab
 	if result.Condition.Type != string(vaultv1alpha1.ConditionConfigMapReady) {
 		t.Fatalf("expected ConfigMapReady condition, got %q", result.Condition.Type)
 	}
-	if result.Condition.Status != metav1.ConditionTrue || result.Condition.Reason != "Ready" {
+	if result.Condition.Status != metav1.ConditionTrue || result.Condition.Reason != readyReason {
 		t.Fatalf("expected ConfigMapReady=True/Ready, got %s/%s", result.Condition.Status, result.Condition.Reason)
 	}
 
@@ -1763,7 +1765,7 @@ func TestBuildNetworkPolicyCondition(t *testing.T) {
 	}
 
 	ready := buildNetworkPolicyCondition(3, desired, cfg)
-	if ready.Status != metav1.ConditionTrue || ready.Reason != "Ready" {
+	if ready.Status != metav1.ConditionTrue || ready.Reason != readyReason {
 		t.Fatalf("expected network policy condition to be ready, got %s/%s", ready.Status, ready.Reason)
 	}
 

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -1223,7 +1223,7 @@ var _ = Describe("Vault controller", func() {
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 	})
 
-	It("manages a ConfigMap lifecycle when the Vault URI becomes available", func() {
+	It("creates a ConfigMap before the Vault URI is available and updates it later", func() {
 		const (
 			identityName = "my-app-identity-configmap"
 			vaultName    = "my-app-vault-configmap"
@@ -1234,11 +1234,26 @@ var _ = Describe("Vault controller", func() {
 		Expect(k8sClient.Create(testCtx, vaultObj)).To(Succeed())
 
 		expectedConfigMapName := vaultpkg.DeterministicConfigMapName(identityName)
-		Consistently(func() bool {
+		expectedAKVName := vaultpkg.DeterministicAzureVaultName(ns, vaultName, "dev")
+		Eventually(func(g Gomega) {
 			var configMap corev1.ConfigMap
-			err := k8sClient.Get(testCtx, types.NamespacedName{Name: expectedConfigMapName, Namespace: ns}, &configMap)
-			return apierrors.IsNotFound(err)
-		}, 2*time.Second, 300*time.Millisecond).Should(BeTrue())
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: expectedConfigMapName, Namespace: ns}, &configMap)).To(Succeed())
+			g.Expect(configMap.Labels).To(HaveKeyWithValue(vaultpkg.ManagedResourceOwnerLabel, vaultName))
+			g.Expect(configMap.Labels).To(HaveKeyWithValue(vaultpkg.ManagedResourceComponentLabel, vaultpkg.ManagedConfigMapComponentValue))
+			g.Expect(configMap.Data).To(HaveKeyWithValue(vaultpkg.ConfigMapKeyAKVName, expectedAKVName))
+			g.Expect(configMap.Data).To(HaveKeyWithValue(vaultpkg.ConfigMapKeyAKVURI, ""))
+			g.Expect(metav1.IsControlledBy(&configMap, vaultObj)).To(BeTrue())
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			var current vaultv1alpha1.Vault
+			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vaultName, Namespace: ns}, &current)).To(Succeed())
+
+			configMapCondition := meta.FindStatusCondition(current.Status.Conditions, string(vaultv1alpha1.ConditionConfigMapReady))
+			g.Expect(configMapCondition).NotTo(BeNil())
+			g.Expect(configMapCondition.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(configMapCondition.Reason).To(Equal("PendingVaultURI"))
+		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
 		var keyVaultName string
 		var roleAssignmentName string
@@ -1260,7 +1275,6 @@ var _ = Describe("Vault controller", func() {
 		setKeyVaultReadyStatus(testCtx, keyVaultName, resourceID, vaultURI)
 		setRoleAssignmentReadyStatus(testCtx, roleAssignmentName, roleAssignmentID)
 
-		expectedAKVName := vaultpkg.DeterministicAzureVaultName(ns, vaultName, "dev")
 		Eventually(func(g Gomega) {
 			var configMap corev1.ConfigMap
 			g.Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: expectedConfigMapName, Namespace: ns}, &configMap)).To(Succeed())
@@ -1576,14 +1590,25 @@ func TestReconcileManagedConfigMapDeletesStaleOwnedConfigMaps(t *testing.T) {
 	if result.Condition.Type != string(vaultv1alpha1.ConditionConfigMapReady) {
 		t.Fatalf("expected ConfigMapReady condition, got %q", result.Condition.Type)
 	}
-	if result.Condition.Status != metav1.ConditionUnknown || result.Condition.Reason != "VaultNotReady" {
-		t.Fatalf("expected ConfigMapReady=Unknown/VaultNotReady, got %s/%s", result.Condition.Status, result.Condition.Reason)
+	if result.Condition.Status != metav1.ConditionTrue || result.Condition.Reason != "PendingVaultURI" {
+		t.Fatalf("expected ConfigMapReady=True/PendingVaultURI, got %s/%s", result.Condition.Status, result.Condition.Reason)
 	}
 
 	var current corev1.ConfigMap
 	err = reconciler.Get(context.Background(), types.NamespacedName{Name: stale.Name, Namespace: stale.Namespace}, &current)
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected stale managed ConfigMap to be deleted, got err=%v obj=%#v", err, current)
+	}
+
+	expectedName := vaultpkg.DeterministicConfigMapName("new-app")
+	if err := reconciler.Get(context.Background(), types.NamespacedName{Name: expectedName, Namespace: vaultObj.Namespace}, &current); err != nil {
+		t.Fatalf("expected reconciler to create the replacement ConfigMap, got error: %v", err)
+	}
+	if current.Data[vaultpkg.ConfigMapKeyAKVName] != "new-akv" {
+		t.Fatalf("expected replacement ConfigMap to contain the Azure Key Vault name, got %#v", current.Data)
+	}
+	if current.Data[vaultpkg.ConfigMapKeyAKVURI] != "" {
+		t.Fatalf("expected replacement ConfigMap to leave AkvUri empty until the Vault URI is known, got %#v", current.Data)
 	}
 }
 
@@ -1643,6 +1668,72 @@ func TestReconcileManagedConfigMapReturnsNameConflictForNonOwnedConfigMap(t *tes
 	}
 	if current.Data[vaultpkg.ConfigMapKeyAKVURI] != "https://existing.vault.azure.net" {
 		t.Fatalf("expected conflicting ConfigMap data to remain unchanged, got %#v", current.Data)
+	}
+}
+
+func TestReconcileManagedConfigMapPreservesExistingVaultURIWhenStatusIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	scheme := newControllerUnitTestScheme(t)
+	vaultObj := &vaultv1alpha1.Vault{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: vaultv1alpha1.GroupVersion.String(),
+			Kind:       "Vault",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "vault-sample",
+			Namespace:  "default",
+			Generation: 12,
+			UID:        types.UID("vault-uid"),
+		},
+		Spec: vaultv1alpha1.VaultSpec{
+			IdentityRef: &vaultv1alpha1.ApplicationIdentityRef{Name: "app-sample"},
+		},
+	}
+
+	current := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vaultpkg.DeterministicConfigMapName("app-sample"),
+			Namespace: vaultObj.Namespace,
+			Labels: map[string]string{
+				vaultpkg.ManagedResourceOwnerLabel:     vaultObj.Name,
+				vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(vaultObj, vaultv1alpha1.GroupVersion.WithKind("Vault")),
+			},
+		},
+		Data: map[string]string{
+			vaultpkg.ConfigMapKeyAKVName: "old-akv",
+			vaultpkg.ConfigMapKeyAKVURI:  "https://existing.vault.azure.net",
+		},
+	}
+
+	reconciler := &VaultReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(current).Build(),
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.reconcileManagedConfigMap(context.Background(), vaultObj, "new-akv", nil)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed when Vault status is temporarily unavailable, got error: %v", err)
+	}
+	if result.Condition.Type != string(vaultv1alpha1.ConditionConfigMapReady) {
+		t.Fatalf("expected ConfigMapReady condition, got %q", result.Condition.Type)
+	}
+	if result.Condition.Status != metav1.ConditionTrue || result.Condition.Reason != "Ready" {
+		t.Fatalf("expected ConfigMapReady=True/Ready, got %s/%s", result.Condition.Status, result.Condition.Reason)
+	}
+
+	var updated corev1.ConfigMap
+	if err := reconciler.Get(context.Background(), types.NamespacedName{Name: current.Name, Namespace: current.Namespace}, &updated); err != nil {
+		t.Fatalf("expected owned ConfigMap to remain managed, got error: %v", err)
+	}
+	if updated.Data[vaultpkg.ConfigMapKeyAKVName] != "new-akv" {
+		t.Fatalf("expected AkvName to be refreshed during reconcile, got %#v", updated.Data)
+	}
+	if updated.Data[vaultpkg.ConfigMapKeyAKVURI] != "https://existing.vault.azure.net" {
+		t.Fatalf("expected existing AkvUri to be preserved until a newer Vault URI is known, got %#v", updated.Data)
 	}
 }
 

--- a/services/dis-vault-operator/internal/vault/configmap.go
+++ b/services/dis-vault-operator/internal/vault/configmap.go
@@ -49,9 +49,6 @@ func BuildManagedConfigMap(v *vaultv1alpha1.Vault, azureName, vaultURI string) (
 		return nil, fmt.Errorf("azureName must not be empty")
 	}
 	vaultURI = strings.TrimSpace(vaultURI)
-	if vaultURI == "" {
-		return nil, fmt.Errorf("vaultURI must not be empty")
-	}
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/services/dis-vault-operator/internal/vault/configmap_test.go
+++ b/services/dis-vault-operator/internal/vault/configmap_test.go
@@ -82,3 +82,20 @@ func TestBuildManagedConfigMapWithServiceAccountRef(t *testing.T) {
 		t.Fatalf("expected service-account based ConfigMap name, got %q", configMap.Name)
 	}
 }
+
+func TestBuildManagedConfigMapAllowsEmptyVaultURI(t *testing.T) {
+	t.Parallel()
+
+	vaultObj := &vaultv1alpha1.Vault{}
+	vaultObj.Name = testVaultName
+	vaultObj.Namespace = testNamespace
+	vaultObj.Spec.IdentityRef = &vaultv1alpha1.ApplicationIdentityRef{Name: "my-app"}
+
+	configMap, err := BuildManagedConfigMap(vaultObj, "my-akv-name", "")
+	if err != nil {
+		t.Fatalf("expected ConfigMap builder to allow an empty Vault URI, got error: %v", err)
+	}
+	if got := configMap.Data[ConfigMapKeyAKVURI]; got != "" {
+		t.Fatalf("expected AkvUri data key to be empty until ASO reports the Vault URI, got %q", got)
+	}
+}

--- a/services/dis-vault-operator/internal/vault/configmap_test.go
+++ b/services/dis-vault-operator/internal/vault/configmap_test.go
@@ -95,7 +95,11 @@ func TestBuildManagedConfigMapAllowsEmptyVaultURI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected ConfigMap builder to allow an empty Vault URI, got error: %v", err)
 	}
-	if got := configMap.Data[ConfigMapKeyAKVURI]; got != "" {
+	got, ok := configMap.Data[ConfigMapKeyAKVURI]
+	if !ok {
+		t.Fatalf("expected AkvUri data key to be present")
+	}
+	if got != "" {
 		t.Fatalf("expected AkvUri data key to be empty until ASO reports the Vault URI, got %q", got)
 	}
 }

--- a/services/dis-vault-operator/test/e2e/vault_e2e_test.go
+++ b/services/dis-vault-operator/test/e2e/vault_e2e_test.go
@@ -222,8 +222,11 @@ var _ = Describe("Vault e2e", Ordered, func() {
 			return err
 		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
 
-		By("verifying the ConfigMap is not created before the Vault URI is known")
-		ensureResourceNotCreatedYet("configmaps", expectedConfigMapName)
+		By("verifying the ConfigMap is created before the Vault URI is known")
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvName}", vaultpkg.DeterministicAzureVaultName(sampleNamespace, sampleVaultName, "dev"))
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvUri}", "")
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='ConfigMapReady')].status}", "True")
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", sampleVaultName, "{.status.conditions[?(@.type=='ConfigMapReady')].reason}", "PendingVaultURI")
 		waitForJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.spec.principalId}", sampleGroupObjectID)
 		waitForJSONPath("roleassignments.authorization.azure.com", expectedGroupRoleAssignName, "{.spec.principalType}", "Group")
 		waitForJSONPath(
@@ -353,9 +356,12 @@ var _ = Describe("Vault e2e", Ordered, func() {
 			return err
 		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
 
-		By("verifying the SecretStore is not created before the Vault URI is known")
+		By("verifying the SecretStore waits for the Vault URI while the ConfigMap is created immediately")
 		ensureResourceNotCreatedYet("secretstores.external-secrets.io", expectedSecretStoreName)
-		ensureResourceNotCreatedYet("configmaps", expectedConfigMapName)
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvName}", vaultpkg.DeterministicAzureVaultName(sampleNamespace, externalSecretsVaultName, "dev"))
+		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvUri}", "")
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", externalSecretsVaultName, "{.status.conditions[?(@.type=='ConfigMapReady')].status}", "True")
+		waitForJSONPath("vaults.vault.dis.altinn.cloud", externalSecretsVaultName, "{.status.conditions[?(@.type=='ConfigMapReady')].reason}", "PendingVaultURI")
 
 		By("patching dependent ASO resources to Ready")
 		resourceID := "/subscriptions/fake-subscription/resourceGroups/fake-resource-group/providers/Microsoft.KeyVault/vaults/vault-es-sample"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * ConfigMaps are now created immediately in the resource lifecycle, rather than waiting for Vault URI availability.
  * The Vault URI field is populated once the Vault status becomes ready.
  * Operator status now reports "PendingVaultURI" condition to indicate ConfigMap readiness while Vault URI resolution is in progress.
  * ConfigMap configuration is preserved during temporary Vault status unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->