### PR TITLE
fix(dis-vault): avoid role assignment guid collisions

### DIFF
--- a/services/dis-vault-operator/internal/vault/builders.go
+++ b/services/dis-vault-operator/internal/vault/builders.go
@@ -185,14 +185,13 @@ func buildRoleAssignmentResource(
 	principalType authorizationv1.RoleAssignmentProperties_PrincipalType,
 	labels map[string]string,
 ) (*authorizationv1.RoleAssignment, error) {
-	kubernetesOwnerName := deterministicKubernetesName(v.Name, "akv")
-	azureOwnerName := kubernetesOwnerName
-	if keyVault != nil {
-		kubernetesOwnerName = keyVault.Name
-		azureOwnerName = strings.TrimSpace(keyVault.Spec.AzureName)
-		if azureOwnerName == "" {
-			return nil, fmt.Errorf("keyVault.Spec.AzureName must not be empty")
-		}
+	if keyVault == nil {
+		return nil, fmt.Errorf("keyVault must not be nil")
+	}
+	kubernetesOwnerName := keyVault.Name
+	azureOwnerName := strings.TrimSpace(keyVault.Spec.AzureName)
+	if azureOwnerName == "" {
+		return nil, fmt.Errorf("keyVault.Spec.AzureName must not be empty")
 	}
 	azureName := deterministicRoleAssignmentAzureName(v.Namespace, azureOwnerName, principalID, keyVaultSecretsOfficerRole)
 

--- a/services/dis-vault-operator/internal/vault/builders.go
+++ b/services/dis-vault-operator/internal/vault/builders.go
@@ -185,16 +185,21 @@ func buildRoleAssignmentResource(
 	principalType authorizationv1.RoleAssignmentProperties_PrincipalType,
 	labels map[string]string,
 ) (*authorizationv1.RoleAssignment, error) {
-	ownerName := deterministicKubernetesName(v.Name, "akv")
+	kubernetesOwnerName := deterministicKubernetesName(v.Name, "akv")
+	azureOwnerName := kubernetesOwnerName
 	if keyVault != nil {
-		ownerName = keyVault.Name
+		kubernetesOwnerName = keyVault.Name
+		azureOwnerName = strings.TrimSpace(keyVault.Spec.AzureName)
+		if azureOwnerName == "" {
+			return nil, fmt.Errorf("keyVault.Spec.AzureName must not be empty")
+		}
 	}
-	azureName := deterministicRoleAssignmentAzureName(v.Namespace, ownerName, principalID, keyVaultSecretsOfficerRole)
+	azureName := deterministicRoleAssignmentAzureName(v.Namespace, azureOwnerName, principalID, keyVaultSecretsOfficerRole)
 
 	owner := genruntime.ArbitraryOwnerReference{
 		Group: keyvaultv1.GroupVersion.Group,
 		Kind:  "Vault",
-		Name:  ownerName,
+		Name:  kubernetesOwnerName,
 	}
 
 	return &authorizationv1.RoleAssignment{

--- a/services/dis-vault-operator/internal/vault/builders_test.go
+++ b/services/dis-vault-operator/internal/vault/builders_test.go
@@ -114,8 +114,9 @@ func TestBuildOwnerRoleAssignmentResource(t *testing.T) {
 	v := &vaultv1alpha1.Vault{}
 	v.Name = testVaultName
 	v.Namespace = testNamespace
+	keyVault := testKeyVaultWithAzureName("sample-vault-a-11111111")
 
-	roleAssignment, err := BuildOwnerRoleAssignmentResource(v, nil, "principal-123")
+	roleAssignment, err := BuildOwnerRoleAssignmentResource(v, keyVault, "principal-123")
 	if err != nil {
 		t.Fatalf("expected role assignment builder to succeed, got error: %v", err)
 	}
@@ -135,12 +136,24 @@ func TestBuildOwnerRoleAssignmentResource(t *testing.T) {
 		t.Fatalf("expected AzureName to be a GUID, got %q: %v", roleAssignment.Spec.AzureName, err)
 	}
 
-	roleAssignment2, err := BuildOwnerRoleAssignmentResource(v, nil, "principal-123")
+	roleAssignment2, err := BuildOwnerRoleAssignmentResource(v, keyVault, "principal-123")
 	if err != nil {
 		t.Fatalf("expected second build to succeed, got error: %v", err)
 	}
 	if roleAssignment.Spec.AzureName != roleAssignment2.Spec.AzureName {
 		t.Fatalf("expected deterministic AzureName across builds")
+	}
+}
+
+func TestBuildOwnerRoleAssignmentResourceRejectsNilKeyVault(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	if _, err := BuildOwnerRoleAssignmentResource(v, nil, "principal-123"); err == nil {
+		t.Fatalf("expected error when Key Vault is nil")
 	}
 }
 
@@ -151,8 +164,8 @@ func TestBuildOwnerRoleAssignmentResourceUsesAzureKeyVaultNameForAzureNameSeed(t
 	v.Name = testVaultName
 	v.Namespace = testNamespace
 
-	firstKeyVault := testKeyVaultWithAzureName("product-infopor-f13d1aeb")
-	secondKeyVault := testKeyVaultWithAzureName("product-infopor-3b8f3a59")
+	firstKeyVault := testKeyVaultWithAzureName("sample-vault-a-11111111")
+	secondKeyVault := testKeyVaultWithAzureName("sample-vault-b-22222222")
 
 	first, err := BuildOwnerRoleAssignmentResource(v, firstKeyVault, "principal-123")
 	if err != nil {
@@ -190,8 +203,9 @@ func TestBuildGroupRoleAssignmentResource(t *testing.T) {
 	v := &vaultv1alpha1.Vault{}
 	v.Name = testVaultName
 	v.Namespace = testNamespace
+	keyVault := testKeyVaultWithAzureName("sample-vault-a-11111111")
 
-	roleAssignment, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID)
+	roleAssignment, err := BuildGroupRoleAssignmentResource(v, keyVault, testGroupObjectID)
 	if err != nil {
 		t.Fatalf("expected group role assignment builder to succeed, got error: %v", err)
 	}
@@ -220,12 +234,24 @@ func TestBuildGroupRoleAssignmentResource(t *testing.T) {
 		t.Fatalf("expected group assignment label to be set")
 	}
 
-	roleAssignment2, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID)
+	roleAssignment2, err := BuildGroupRoleAssignmentResource(v, keyVault, testGroupObjectID)
 	if err != nil {
 		t.Fatalf("expected second group build to succeed, got error: %v", err)
 	}
 	if roleAssignment.Spec.AzureName != roleAssignment2.Spec.AzureName {
 		t.Fatalf("expected deterministic AzureName across builds")
+	}
+}
+
+func TestBuildGroupRoleAssignmentResourceRejectsNilKeyVault(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	if _, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID); err == nil {
+		t.Fatalf("expected error when Key Vault is nil")
 	}
 }
 
@@ -236,8 +262,8 @@ func TestBuildGroupRoleAssignmentResourceUsesAzureKeyVaultNameForAzureNameSeed(t
 	v.Name = testVaultName
 	v.Namespace = testNamespace
 
-	firstKeyVault := testKeyVaultWithAzureName("product-infopor-f13d1aeb")
-	secondKeyVault := testKeyVaultWithAzureName("product-infopor-3b8f3a59")
+	firstKeyVault := testKeyVaultWithAzureName("sample-vault-a-11111111")
+	secondKeyVault := testKeyVaultWithAzureName("sample-vault-b-22222222")
 
 	first, err := BuildGroupRoleAssignmentResource(v, firstKeyVault, testGroupObjectID)
 	if err != nil {
@@ -275,12 +301,13 @@ func TestBuildGroupRoleAssignmentResourceIsDeterministicForDifferentGroups(t *te
 	v := &vaultv1alpha1.Vault{}
 	v.Name = testVaultName
 	v.Namespace = testNamespace
+	keyVault := testKeyVaultWithAzureName("sample-vault-a-11111111")
 
-	first, err := BuildGroupRoleAssignmentResource(v, nil, testGroupObjectID)
+	first, err := BuildGroupRoleAssignmentResource(v, keyVault, testGroupObjectID)
 	if err != nil {
 		t.Fatalf("expected first build to succeed, got error: %v", err)
 	}
-	second, err := BuildGroupRoleAssignmentResource(v, nil, "22222222-2222-2222-2222-222222222222")
+	second, err := BuildGroupRoleAssignmentResource(v, keyVault, "22222222-2222-2222-2222-222222222222")
 	if err != nil {
 		t.Fatalf("expected second build to succeed, got error: %v", err)
 	}

--- a/services/dis-vault-operator/internal/vault/builders_test.go
+++ b/services/dis-vault-operator/internal/vault/builders_test.go
@@ -144,6 +144,46 @@ func TestBuildOwnerRoleAssignmentResource(t *testing.T) {
 	}
 }
 
+func TestBuildOwnerRoleAssignmentResourceUsesAzureKeyVaultNameForAzureNameSeed(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	firstKeyVault := testKeyVaultWithAzureName("product-infopor-f13d1aeb")
+	secondKeyVault := testKeyVaultWithAzureName("product-infopor-3b8f3a59")
+
+	first, err := BuildOwnerRoleAssignmentResource(v, firstKeyVault, "principal-123")
+	if err != nil {
+		t.Fatalf("expected first role assignment build to succeed, got error: %v", err)
+	}
+	second, err := BuildOwnerRoleAssignmentResource(v, secondKeyVault, "principal-123")
+	if err != nil {
+		t.Fatalf("expected second role assignment build to succeed, got error: %v", err)
+	}
+
+	if first.Spec.AzureName == second.Spec.AzureName {
+		t.Fatalf("expected different Azure Key Vault names to produce different role assignment Azure names")
+	}
+	if first.Spec.Owner == nil || first.Spec.Owner.Name != firstKeyVault.Name {
+		t.Fatalf("expected owner reference to use Kubernetes Key Vault name %q, got %#v", firstKeyVault.Name, first.Spec.Owner)
+	}
+}
+
+func TestBuildOwnerRoleAssignmentResourceRejectsKeyVaultWithoutAzureName(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	keyVault := testKeyVaultWithAzureName(" ")
+	if _, err := BuildOwnerRoleAssignmentResource(v, keyVault, "principal-123"); err == nil {
+		t.Fatalf("expected error when Key Vault AzureName is empty")
+	}
+}
+
 func TestBuildGroupRoleAssignmentResource(t *testing.T) {
 	t.Parallel()
 
@@ -189,6 +229,46 @@ func TestBuildGroupRoleAssignmentResource(t *testing.T) {
 	}
 }
 
+func TestBuildGroupRoleAssignmentResourceUsesAzureKeyVaultNameForAzureNameSeed(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	firstKeyVault := testKeyVaultWithAzureName("product-infopor-f13d1aeb")
+	secondKeyVault := testKeyVaultWithAzureName("product-infopor-3b8f3a59")
+
+	first, err := BuildGroupRoleAssignmentResource(v, firstKeyVault, testGroupObjectID)
+	if err != nil {
+		t.Fatalf("expected first group role assignment build to succeed, got error: %v", err)
+	}
+	second, err := BuildGroupRoleAssignmentResource(v, secondKeyVault, testGroupObjectID)
+	if err != nil {
+		t.Fatalf("expected second group role assignment build to succeed, got error: %v", err)
+	}
+
+	if first.Spec.AzureName == second.Spec.AzureName {
+		t.Fatalf("expected different Azure Key Vault names to produce different group role assignment Azure names")
+	}
+	if first.Spec.Owner == nil || first.Spec.Owner.Name != firstKeyVault.Name {
+		t.Fatalf("expected owner reference to use Kubernetes Key Vault name %q, got %#v", firstKeyVault.Name, first.Spec.Owner)
+	}
+}
+
+func TestBuildGroupRoleAssignmentResourceRejectsKeyVaultWithoutAzureName(t *testing.T) {
+	t.Parallel()
+
+	v := &vaultv1alpha1.Vault{}
+	v.Name = testVaultName
+	v.Namespace = testNamespace
+
+	keyVault := testKeyVaultWithAzureName(" ")
+	if _, err := BuildGroupRoleAssignmentResource(v, keyVault, testGroupObjectID); err == nil {
+		t.Fatalf("expected error when Key Vault AzureName is empty")
+	}
+}
+
 func TestBuildGroupRoleAssignmentResourceIsDeterministicForDifferentGroups(t *testing.T) {
 	t.Parallel()
 
@@ -223,4 +303,12 @@ func TestBuildGroupRoleAssignmentName(t *testing.T) {
 	if nameA == nameC {
 		t.Fatalf("expected different vault names to produce different names")
 	}
+}
+
+func testKeyVaultWithAzureName(azureName string) *keyvaultv1.Vault {
+	keyVault := &keyvaultv1.Vault{}
+	keyVault.Name = deterministicKubernetesName(testVaultName, "akv")
+	keyVault.Namespace = testNamespace
+	keyVault.Spec.AzureName = azureName
+	return keyVault
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Supports recreation of existent role assignments
- Forces a unique ID based on the kv's azure name
## Related Issue(s)
- Fixes https://github.com/Altinn/altinn-platform/issues/3364

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed role assignment resource naming to use proper Azure Key Vault identifiers for deterministic name generation.

* **Tests**
  * Added comprehensive unit tests for role assignment builders to validate correct Azure identification seeding, proper ownership references, and error handling for empty identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->