### PR TITLE
chore: rename tag from 'name' to 'tokenGenerator' and set name to a fixed value to workaround dynamic urls

### DIFF
--- a/libs/k6/src/maskinporten/maskinporten.js
+++ b/libs/k6/src/maskinporten/maskinporten.js
@@ -63,13 +63,17 @@ class MaskinportenAccessTokenGenerator {
       assertion: grant,
     };
 
-    const headers = {
+    const params = {
+      tags: {
+        tokenGenerator: 'Maskinporten Token Generator',
+        name: config.tokenUrl,
+      },
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
     };
 
-    const res = http.post(config.tokenUrl, body, headers);
+    const res = http.post(config.tokenUrl, body, params);
 
     if (res.status != 200) {
       throw new Error(`Failed to generate Maskinporten token: ${res.body}`);

--- a/libs/k6/src/token_generator/token_generator.js
+++ b/libs/k6/src/token_generator/token_generator.js
@@ -44,7 +44,10 @@ class PersonalTokenGenerator {
       headers: {
         Authorization: `Basic ${this.#encodedCredentials}`,
       },
-      tags: { name: 'Personal Token Generator' },
+      tags: {
+        tokenGenerator: 'Personal Token Generator',
+        name: config.getPersonalTokenUrl,
+      },
     };
 
     this.tokenGeneratorOptions = new PersonalTokenGeneratorOptions(
@@ -199,7 +202,10 @@ class EnterpriseTokenGenerator {
       headers: {
         Authorization: `Basic ${this.#encodedCredentials}`,
       },
-      tags: { name: 'Enterprise Token Generator' },
+      tags: {
+        tokenGenerator: 'Enterprise Token Generator',
+        name: config.getEnterpriseTokenUrl,
+      },
     };
 
     this.tokenGeneratorOptions = new EnterpriseTokenGeneratorOptions(
@@ -336,7 +342,10 @@ class PlatformTokenGenerator {
       headers: {
         Authorization: `Basic ${this.#encodedCredentials}`,
       },
-      tags: { name: 'Platform Token Generator' },
+      tags: {
+        tokenGenerator: 'Platform Token Generator',
+        name: config.getPlatformAccessTokenUrl,
+      },
     };
 
     this.tokenGeneratorOptions = new PlatformTokenGeneratorOptions(


### PR DESCRIPTION
'name' is a system tag automatically added by k6 so we should avoid overriding it but it's required when working with dynamic URLs: https://grafana.com/docs/k6/latest/using-k6/http-requests/#url-grouping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Token generation requests now send structured request parameters that include the content type and consistent tags identifying generator type and endpoint name. This adjusts how request metadata is conveyed without changing token retrieval behavior, error handling, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->