### PR TITLE
fix: Update kubectl and helm versions, ignore golang CVEs

### DIFF
--- a/infrastructure/images/terraform-azure-devops-agent/.trivyignore
+++ b/infrastructure/images/terraform-azure-devops-agent/.trivyignore
@@ -1,3 +1,23 @@
 # Should be fixed in upstream image, this image is used for build agents in private repos so we accept the risk until it is fixed
 # https://avd.aquasec.com/nvd/2025/cve-2025-68973/
 CVE-2025-68973
+
+# golang library vulnerabilities in kubectl/helm binaries - will be resolved when upstream tools rebuild with fixed dependencies
+# https://avd.aquasec.com/nvd/cve-2025-61726
+CVE-2025-61726
+# https://avd.aquasec.com/nvd/cve-2025-61728
+CVE-2025-61728
+# https://avd.aquasec.com/nvd/cve-2025-68121
+CVE-2025-68121
+# https://avd.aquasec.com/nvd/cve-2026-25679
+CVE-2026-25679
+# https://avd.aquasec.com/nvd/cve-2026-32280
+CVE-2026-32280
+# https://avd.aquasec.com/nvd/cve-2026-32281
+CVE-2026-32281
+# https://avd.aquasec.com/nvd/cve-2026-32283
+CVE-2026-32283
+# https://avd.aquasec.com/nvd/cve-2026-33186
+CVE-2026-33186
+# https://avd.aquasec.com/nvd/cve-2026-35469
+CVE-2026-35469

--- a/infrastructure/images/terraform-azure-devops-agent/scripts/install.sh
+++ b/infrastructure/images/terraform-azure-devops-agent/scripts/install.sh
@@ -3,9 +3,9 @@ set -e
 
 # Versions
 # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
-KUBECTL_VERSION="v1.35.0" #Get the latest version with: curl -L -s https://dl.k8s.io/release/stable.txt
+KUBECTL_VERSION="v1.36.0" #Get the latest version with: curl -L -s https://dl.k8s.io/release/stable.txt
 # renovate: datasource=github-releases depName=helm packageName=helm/helm versioning=semver
-HELM_VERSION="v3.19.4" #Find the latest version at https://github.com/helm/helm/releases
+HELM_VERSION="v3.20.2" #Find the latest version at https://github.com/helm/helm/releases
 
 ###################################
 ### Install kubectl


### PR DESCRIPTION
Update kubectl to v1.36.0 and helm to v3.20.2. Ignore golang library vulnerabilities in kubectl/helm binaries that will be resolved when upstream tools rebuild with fixed dependencies.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
