### PR TITLE
Use grafana/k6:1.7.1-with-browser instead of the master version

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -83,7 +83,7 @@
                }
             }
          ],
-         "image": "grafana/k6:master-with-browser",
+         "image": "grafana/k6:1.7.1-with-browser",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -196,7 +196,7 @@ func generate(td *TestDefinition, c *TestContext, r K8sManifestGenerator, cf Con
 	}
 	imageName := "ghcr.io/altinn/altinn-platform/k6-image:latest"
 	if *c.TestTypeDefinition.Type == "browser" {
-		imageName = "grafana/k6:master-with-browser"
+		imageName = "grafana/k6:1.7.1-with-browser"
 	}
 
 	mergedEnvsMarshalled, err := yaml.Marshal(mergedEnvs)


### PR DESCRIPTION
The current image seems to be broken.
I saw there was a push recently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana k6 image to use a pinned version for browser tests, improving stability and ensuring consistent test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->