### PR TITLE
Revert "deps: update helm release k8s-monitoring to v4 (#3411)"

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_grafana_k8s_monitoring.tf
@@ -9,7 +9,7 @@ resource "helm_release" "grafana_k8s_monitoring" {
   create_namespace = false
   repository       = "https://grafana.github.io/helm-charts"
   chart            = "k8s-monitoring"
-  version          = "4.0.4"
+  version          = "3.8.7"
 
   values = [
     "${templatefile(

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/grafana_k8s_monitoring.tf
@@ -9,7 +9,7 @@ resource "helm_release" "grafana_k8s_monitoring" {
   create_namespace = false
   repository       = "https://grafana.github.io/helm-charts"
   chart            = "k8s-monitoring"
-  version          = "4.0.4"
+  version          = "3.8.7"
 
   values = [
     "${templatefile(


### PR DESCRIPTION
This reverts commit 39eb076e6ed5756e134d142023fc7df22671fc05.

It's a bug upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana Kubernetes monitoring Helm chart version across infrastructure configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->