### PR TITLE
do not cleanup testruns after run

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=prod-get-deployments --tag namespace=platform --tag deploy_env=prod --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=tt02-get-deployments --tag namespace=platform --tag deploy_env=tt02 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=yt01-get-deployments --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-pre-determined --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v13/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v13/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments-smoke --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at23/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at23/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at23-get-deployments-smoke --tag namespace=platform --tag deploy_env=at23 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments-smoke --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=yt01-get-deployments --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=yt01-get-daemonsets --tag namespace=platform --tag deploy_env=yt01 --tag test_name=get-daemonsets --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw -e runFullTestSet=true -e tokenGeneratorUserName=olanordmenn -e orgNoRecipient=1234 -e resourceId=abcd",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -17,7 +17,6 @@
    },
    "spec": {
       "arguments": "--tag testid=at22-get-deployments --tag namespace=platform --tag deploy_env=at22 --tag test_name=get-deployments --tag test_scope=k8s-wrapper --out experimental-prometheus-rw",
-      "cleanup": "post",
       "parallelism": 1,
       "runner": {
          "env": [

--- a/infrastructure/images/k6-action/.trivyignore
+++ b/infrastructure/images/k6-action/.trivyignore
@@ -48,3 +48,6 @@ CVE-2026-32283
 
 # https://avd.aquasec.com/nvd/cve-2026-33810
 CVE-2026-33810
+
+# https://avd.aquasec.com/nvd/cve-2026-29181
+CVE-2026-29181

--- a/infrastructure/images/k6-action/jsonnet/main.jsonnet
+++ b/infrastructure/images/k6-action/jsonnet/main.jsonnet
@@ -119,7 +119,7 @@ local testrun = {
     },
 
     spec: {
-      cleanup: 'post',
+      // cleanup: 'post', // Seems to be a bit too aggressive sometimes. Some metrics don't have time to be fully flushed out.
       arguments: std.stripChars(
         std.format('--tag testid=%s --tag namespace=%s --tag deploy_env=%s --tag test_name=%s --tag test_scope=%s --out experimental-prometheus-rw %s',
                    [testid, namespace, deploy_env, test_name, test_scope, extra_cli_args]), ' '


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unintended automatic cleanup setting from k6 TestRun manifests and fixed minor manifest formatting issues.
  
* **Chores**
  * Added and standardized k6 tagging and output flags for better test identification and metrics export across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->