### PR TITLE
Disable kube-state-metrics

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_stack_values.tftpl
@@ -44,3 +44,5 @@ prometheus:
           resources:
             requests:
               storage: 64Gi
+kubeStateMetrics: # Not really used atm. If re-enabled, we need to drop high cardinality metrics.
+  enabled: false


### PR DESCRIPTION
Not actively being used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes monitoring stack configuration for the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->