### PR TITLE
fix(dis-vault-operator): omit tenant id from managed SecretStore

### DIFF
--- a/services/dis-vault-operator/Dockerfile
+++ b/services/dis-vault-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/services/dis-vault-operator/go.mod
+++ b/services/dis-vault-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/Altinn/altinn-platform/services/dis-vault-operator
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/Altinn/altinn-platform/services/dis-identity-operator v0.0.0-20260319083500-bd4f5f84c472
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	k8s.io/api v0.35.1
 	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
@@ -103,7 +104,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.35.1 // indirect
 	k8s.io/apiserver v0.35.0 // indirect
 	k8s.io/component-base v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/services/dis-vault-operator/internal/controller/vault_controller_secret_store.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_secret_store.go
@@ -134,7 +134,7 @@ func (r *VaultReconciler) reconcileManagedSecretStore(
 		}, nil
 	}
 
-	desired, err := vaultpkg.BuildManagedSecretStore(vaultObj, r.Config.TenantID, vaultURI)
+	desired, err := vaultpkg.BuildManagedSecretStore(vaultObj, vaultURI)
 	if err != nil {
 		return secretStoreReconcileResult{}, err
 	}

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -1350,8 +1350,7 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(*store.Spec.Provider.AzureKV.AuthType).To(Equal(esov1.AzureWorkloadIdentity))
 			g.Expect(store.Spec.Provider.AzureKV.VaultURL).NotTo(BeNil())
 			g.Expect(*store.Spec.Provider.AzureKV.VaultURL).To(Equal(vaultURI))
-			g.Expect(store.Spec.Provider.AzureKV.TenantID).NotTo(BeNil())
-			g.Expect(*store.Spec.Provider.AzureKV.TenantID).To(Equal("00000000-0000-0000-0000-000000000000"))
+			g.Expect(store.Spec.Provider.AzureKV.TenantID).To(BeNil())
 			g.Expect(store.Spec.Provider.AzureKV.ServiceAccountRef).NotTo(BeNil())
 			g.Expect(store.Spec.Provider.AzureKV.ServiceAccountRef.Name).To(Equal(identityName))
 			g.Expect(metav1.IsControlledBy(&store, vaultObj)).To(BeTrue())
@@ -1474,7 +1473,7 @@ var _ = Describe("Vault controller", func() {
 		createIdentity(testCtx, identityName, true)
 
 		conflictOwner := newVault("other-vault", identityName)
-		conflictStore, err := vaultpkg.BuildManagedSecretStore(conflictOwner, "00000000-0000-0000-0000-000000000000", "https://other-vault.vault.azure.net")
+		conflictStore, err := vaultpkg.BuildManagedSecretStore(conflictOwner, "https://other-vault.vault.azure.net")
 		Expect(err).NotTo(HaveOccurred())
 		conflictStore.Name = vaultpkg.DeterministicSecretStoreName(vaultName)
 		conflictStore.Namespace = ns

--- a/services/dis-vault-operator/internal/vault/secretstore.go
+++ b/services/dis-vault-operator/internal/vault/secretstore.go
@@ -44,7 +44,7 @@ func DeterministicSecretStoreName(base string) string {
 	return base + "-" + secretStoreShortSuffix + "-" + hash
 }
 
-func BuildManagedSecretStore(v *vaultv1alpha1.Vault, tenantID, vaultURI string) (*externalsecretsv1.SecretStore, error) {
+func BuildManagedSecretStore(v *vaultv1alpha1.Vault, vaultURI string) (*externalsecretsv1.SecretStore, error) {
 	if v == nil {
 		return nil, fmt.Errorf("vault must not be nil")
 	}
@@ -80,10 +80,6 @@ func BuildManagedSecretStore(v *vaultv1alpha1.Vault, tenantID, vaultURI string) 
 			},
 		},
 	}
-	if tenantID := strings.TrimSpace(tenantID); tenantID != "" {
-		store.Spec.Provider.AzureKV.TenantID = &tenantID
-	}
-
 	return store, nil
 }
 

--- a/services/dis-vault-operator/internal/vault/secretstore_test.go
+++ b/services/dis-vault-operator/internal/vault/secretstore_test.go
@@ -43,7 +43,7 @@ func TestBuildManagedSecretStore(t *testing.T) {
 	vaultObj.Namespace = "default"
 	vaultObj.Spec.IdentityRef = &vaultv1alpha1.ApplicationIdentityRef{Name: "my-app-identity"}
 
-	store, err := BuildManagedSecretStore(vaultObj, "00000000-0000-0000-0000-000000000000", "https://my-app-vault.vault.azure.net")
+	store, err := BuildManagedSecretStore(vaultObj, "https://my-app-vault.vault.azure.net")
 	if err != nil {
 		t.Fatalf("expected SecretStore builder to succeed, got error: %v", err)
 	}
@@ -68,8 +68,8 @@ func TestBuildManagedSecretStore(t *testing.T) {
 	if store.Spec.Provider.AzureKV.VaultURL == nil || *store.Spec.Provider.AzureKV.VaultURL != "https://my-app-vault.vault.azure.net" {
 		t.Fatalf("expected vault URL to be set, got %#v", store.Spec.Provider.AzureKV.VaultURL)
 	}
-	if store.Spec.Provider.AzureKV.TenantID == nil || *store.Spec.Provider.AzureKV.TenantID != "00000000-0000-0000-0000-000000000000" {
-		t.Fatalf("expected tenant ID to be set, got %#v", store.Spec.Provider.AzureKV.TenantID)
+	if store.Spec.Provider.AzureKV.TenantID != nil {
+		t.Fatalf("expected tenant ID to be omitted, got %#v", store.Spec.Provider.AzureKV.TenantID)
 	}
 }
 
@@ -81,7 +81,7 @@ func TestBuildManagedSecretStoreWithServiceAccountRef(t *testing.T) {
 	vaultObj.Namespace = "default"
 	vaultObj.Spec.ServiceAccountRef = &vaultv1alpha1.ServiceAccountRef{Name: "my-app-service-account"}
 
-	store, err := BuildManagedSecretStore(vaultObj, "00000000-0000-0000-0000-000000000000", "https://my-app-vault.vault.azure.net")
+	store, err := BuildManagedSecretStore(vaultObj, "https://my-app-vault.vault.azure.net")
 	if err != nil {
 		t.Fatalf("expected SecretStore builder to succeed, got error: %v", err)
 	}

--- a/services/dis-vault-operator/test/e2e/vault_e2e_test.go
+++ b/services/dis-vault-operator/test/e2e/vault_e2e_test.go
@@ -374,7 +374,7 @@ var _ = Describe("Vault e2e", Ordered, func() {
 		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.authType}", "WorkloadIdentity")
 		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.serviceAccountRef.name}", "app-identity-sample")
 		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.vaultUrl}", vaultURI)
-		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.tenantId}", "00000000-0000-0000-0000-000000000000")
+		waitForJSONPath("secretstores.external-secrets.io", expectedSecretStoreName, "{.spec.provider.azurekv.tenantId}", "")
 		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvName}", vaultpkg.DeterministicAzureVaultName(sampleNamespace, externalSecretsVaultName, "dev"))
 		waitForJSONPath("configmaps", expectedConfigMapName, "{.data.AkvUri}", vaultURI)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Managed SecretStore creation no longer sets an explicit Azure Key Vault tenant ID; the tenant ID field is now omitted, and tests/e2e expectations were updated accordingly.

* **Chores**
  * Build tooling updated: Go toolchain version and the Go builder image were bumped in the operator’s build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->