### PR TITLE
fix: Add IP whitelisting for Key Vaults in GH runners deploy

### DIFF
--- a/.github/workflows/altinn-org-gh-runners-deploy.yml
+++ b/.github/workflows/altinn-org-gh-runners-deploy.yml
@@ -129,6 +129,30 @@ jobs:
         id: host_ip
         run: echo "ip=$(curl -sf https://api.ipify.org)" >> $GITHUB_OUTPUT
 
+      - name: Login to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Whitelist Runner IP in Key Vaults
+        continue-on-error: true
+        uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        with:
+          inlineScript: |
+            RUNNER_IP="${{ steps.host_ip.outputs.ip }}"
+            if ! [[ "$RUNNER_IP" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+              echo "Invalid IPv4 address: $RUNNER_IP"
+              exit 1
+            fi
+            echo "Whitelisting IP: $RUNNER_IP"
+            KVS=$(az keyvault list --resource-group altinn-org-gh-runners --query "[].name" -o tsv)
+            for kv in $KVS; do
+              echo "Adding IP to $kv..."
+              az keyvault network-rule add --name "$kv" --ip-address "$RUNNER_IP"
+            done
+
       - name: Terraform Apply
         uses: Altinn/altinn-platform/actions/terraform/apply@dd7b1578787e084472d1e5b5c6ed8a241afd6cdd # main
         env:
@@ -144,14 +168,6 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
-
-      - name: Login to Azure
-        if: always()
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        with:
-          client-id: ${{ env.ARM_CLIENT_ID }}
-          tenant-id: ${{ env.ARM_TENANT_ID }}
-          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: Remove Runner IP from Key Vault Whitelist
         if: always()

--- a/.github/workflows/altinn-org-gh-runners-deploy.yml
+++ b/.github/workflows/altinn-org-gh-runners-deploy.yml
@@ -96,9 +96,10 @@ jobs:
         if: always()
         continue-on-error: true
         uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        env:
+          RUNNER_IP: ${{ steps.host_ip.outputs.ip }}
         with:
           inlineScript: |
-            RUNNER_IP="${{ steps.host_ip.outputs.ip }}"
             if ! [[ "$RUNNER_IP" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
               echo "Invalid IPv4 address: $RUNNER_IP"
               exit 1
@@ -137,11 +138,11 @@ jobs:
           subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: Whitelist Runner IP in Key Vaults
-        continue-on-error: true
         uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        env:
+          RUNNER_IP: ${{ steps.host_ip.outputs.ip }}
         with:
           inlineScript: |
-            RUNNER_IP="${{ steps.host_ip.outputs.ip }}"
             if ! [[ "$RUNNER_IP" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
               echo "Invalid IPv4 address: $RUNNER_IP"
               exit 1
@@ -172,9 +173,10 @@ jobs:
       - name: Remove Runner IP from Key Vault Whitelist
         if: always()
         uses: azure/CLI@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        env:
+          RUNNER_IP: ${{ steps.host_ip.outputs.ip }}
         with:
           inlineScript: |
-            RUNNER_IP="${{ steps.host_ip.outputs.ip }}"
             if ! [[ "$RUNNER_IP" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
               echo "Invalid IPv4 address: $RUNNER_IP"
               exit 1

--- a/infrastructure/modules/gh-runners/main.tf
+++ b/infrastructure/modules/gh-runners/main.tf
@@ -11,6 +11,14 @@ resource "azurerm_subnet" "gh_runners" {
   virtual_network_name = azurerm_virtual_network.gh_runners.name
   address_prefixes     = [var.private_runners_address_space]
   service_endpoints    = ["Microsoft.KeyVault"]
+
+  delegation {
+    name = "Microsoft.App.environments"
+    service_delegation {
+      name    = "Microsoft.App/environments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
 }
 
 module "container_apps_gh_runners" {


### PR DESCRIPTION
- Login to Azure before Terraform apply to enable IP whitelisting
- Add runner IP to all Key Vault network rules before deployment
- Include IPv4 validation and error handling
- Add subnet delegation for Container Apps environments

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow security by reordering Azure authentication steps in the CI/CD pipeline.
  * Enhanced subnet infrastructure configuration to support additional cloud platform capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->