### PR TITLE
fix: Replace Terraform action with init and apply steps

### DIFF
--- a/.github/workflows/altinn-org-gh-runners-deploy.yml
+++ b/.github/workflows/altinn-org-gh-runners-deploy.yml
@@ -154,14 +154,8 @@ jobs:
               az keyvault network-rule add --name "$kv" --ip-address "$RUNNER_IP"
             done
 
-      - name: Terraform Apply
-        uses: Altinn/altinn-platform/actions/terraform/apply@dd7b1578787e084472d1e5b5c6ed8a241afd6cdd # main
-        env:
-          TF_VAR_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
-          TF_VAR_altinn_app_id: ${{ vars.GH_RUNNERS_APP_ID }}
-          TF_VAR_altinn_app_install_id: ${{ vars.GH_RUNNERS_APP_INSTALL_ID }}
-          TF_VAR_altinn_app_key: ${{ secrets.GH_RUNNERS_APP_KEY }}
-          TF_VAR_host_ip: ${{ steps.host_ip.outputs.ip }}
+      - name: Terraform Init
+        uses: Altinn/altinn-platform/actions/terraform/init@dd7b1578787e084472d1e5b5c6ed8a241afd6cdd # main
         with:
           working_directory: ${{ env.TF_PROJECT }}
           oidc_type: environment
@@ -169,6 +163,20 @@ jobs:
           arm_client_id: ${{ env.ARM_CLIENT_ID }}
           arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
           tf_state_name: ${{ env.TF_STATE_NAME }}
+
+      - name: Terraform Apply
+        working-directory: ${{ env.TF_PROJECT }}
+        run: terraform apply -input=false -auto-approve
+        env:
+          ARM_CLIENT_ID: ${{ env.ARM_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ env.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ env.ARM_TENANT_ID }}
+          ARM_USE_OIDC: "true"
+          TF_VAR_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          TF_VAR_altinn_app_id: ${{ vars.GH_RUNNERS_APP_ID }}
+          TF_VAR_altinn_app_install_id: ${{ vars.GH_RUNNERS_APP_INSTALL_ID }}
+          TF_VAR_altinn_app_key: ${{ secrets.GH_RUNNERS_APP_KEY }}
+          TF_VAR_host_ip: ${{ steps.host_ip.outputs.ip }}
 
       - name: Remove Runner IP from Key Vault Whitelist
         if: always()


### PR DESCRIPTION
Separate the terraform init and apply into distinct workflow steps. The apply step now runs terraform directly with explicit environment variables for ARM authentication.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions deployment workflow with enhanced Terraform initialization and application process.
  * Restructured deployment steps for better reliability and clearer infrastructure configuration management.
  * Refined CI/CD pipeline infrastructure with optimized deployment execution and explicit environment variable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->