### PR TITLE
Make runner CPU and memory configurable

### DIFF
--- a/infrastructure/gh-runners/altinn-broker.tf
+++ b/infrastructure/gh-runners/altinn-broker.tf
@@ -9,6 +9,8 @@ module "gh_runners_altinn_broker" {
   altinn_app_install_id         = var.altinn_app_install_id
   altinn_app_key                = var.altinn_app_key
   host_ip                       = var.host_ip
+  runner_cpu                    = "4.0"
+  runner_memory                 = "8Gi"
   tags = merge(local.tags, {
     finops_product = "altinn-broker"
     product        = "altinn-broker"

--- a/infrastructure/gh-runners/altinn-correspondence.tf
+++ b/infrastructure/gh-runners/altinn-correspondence.tf
@@ -9,6 +9,8 @@ module "gh_runners_altinn_correspondence" {
   altinn_app_install_id         = var.altinn_app_install_id
   altinn_app_key                = var.altinn_app_key
   host_ip                       = var.host_ip
+  runner_cpu                    = "4.0"
+  runner_memory                 = "8Gi"
   tags = merge(local.tags, {
     finops_product = "altinn-correspondence"
     product        = "altinn-correspondence"

--- a/infrastructure/modules/gh-runners/main.tf
+++ b/infrastructure/modules/gh-runners/main.tf
@@ -39,8 +39,8 @@ module "container_apps_gh_runners" {
   resource_prefix          = var.private_runners_prefix
   infrastructure_subnet_id = azurerm_subnet.gh_runners.id
   resource_group_name      = var.resource_group_name
-  runner_cpu               = "2.0"
-  runner_memory            = "4Gi"
+  runner_cpu               = var.runner_cpu
+  runner_memory            = var.runner_memory
   # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
   runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.6.2"
   additional_tags = merge(

--- a/infrastructure/modules/gh-runners/variables.tf
+++ b/infrastructure/modules/gh-runners/variables.tf
@@ -46,3 +46,15 @@ variable "tags" {
   description = "Tags to apply to all resources"
   default     = {}
 }
+
+variable "runner_cpu" {
+  type        = string
+  description = "CPU allocated to a runner"
+  default     = "2.0"
+}
+
+variable "runner_memory" {
+  type        = string
+  description = "Memory allocated to a runner"
+  default     = "4Gi"
+}


### PR DESCRIPTION
Add variables to the gh-runners module to allow CPU and memory allocation to be customized per runner instance, with defaults matching the previous hardcoded values.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
