### PR TITLE
fix(renovate): ignore go-openapi/testify/v2 pin in dis-vault-operator

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,18 @@
     },
     {
       "matchManagers": [
+        "gomod"
+      ],
+      "matchFileNames": [
+        "services/dis-vault-operator/go.mod"
+      ],
+      "matchPackageNames": [
+        "github.com/go-openapi/testify/v2"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
         "custom.regex"
       ],
       "matchDatasources": [


### PR DESCRIPTION
## Summary

Stops Renovate from repeatedly breaking `services/dis-vault-operator` by overriding an intentional `replace` directive.

The pin exists because `go-openapi/testify/v2 v2.4.2+` removed the `assert/yaml` package that `go-openapi/swag/loading@v0.25.4` transitively depends on. Renovate has bumped this pin twice already (#3521, #3562), failing tests both times.

## Test plan

- [x] PRs #3521 and #3562 can be closed
- [ ] Renovate no longer creates PRs updating `go-openapi/testify/v2` in `services/dis-vault-operator`