### PR TITLE
fix(renovate): ignore pgxmock/v5 in dis-pgsql-operator

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,18 @@
     },
     {
       "matchManagers": [
+        "gomod"
+      ],
+      "matchFileNames": [
+        "services/dis-pgsql-operator/go.mod"
+      ],
+      "matchPackageNames": [
+        "github.com/pashagolub/pgxmock/v5"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
         "custom.regex"
       ],
       "matchDatasources": [


### PR DESCRIPTION
## Summary

Stops Renovate from repeatedly re-adding `pgxmock/v5` to `services/dis-pgsql-operator`.

`pgxmock/v5` is never imported in any source file — only `pgxmock/v4` is used. It was removed in #3557 but Renovate re-added it in PR #3578. Close #3578.

Same pattern as the `go-openapi/testify/v2` ignore rule added in #3573.