### PR TITLE
fix(gh-runner): add CVE-2026-46680 to trivyignore

### DIFF
--- a/infrastructure/images/gh-runner/.trivyignore
+++ b/infrastructure/images/gh-runner/.trivyignore
@@ -124,3 +124,6 @@ CVE-2026-39836
 
 # stdlib: DoS via pathological inputs in consumePhrase
 CVE-2026-42499
+
+# containerd: user ID handling bypass allows runAsNonRoot evasion
+CVE-2026-46680


### PR DESCRIPTION
## Summary

- Adds `CVE-2026-46680` (containerd `runAsNonRoot` bypass) to `.trivyignore` to unblock the gh-runner image build
- This CVE is in the base image (`ghcr.io/actions/actions-runner:2.334.0`) and fixed in containerd v2.2.4+
- Proper fix is bumping the base image; this suppresses the noise in the meantime, consistent with all other CVEs already in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration for continuous integration infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->