### PR TITLE
feat(dis-syncroot): dispatch-driven workflow with at23 support

### DIFF
--- a/.github/workflows/dis-syncroot-release.yml
+++ b/.github/workflows/dis-syncroot-release.yml
@@ -1,28 +1,33 @@
 name: Publish DIS Syncroot Artifact
+run-name: Publish DIS syncroot to ${{ inputs.environment }}
 
 env:
   SYNCROOT_ARTIFACT_NAME: dis/syncroot
-  SYNCROOT_ENVIRONMENT: at22
 
 on:
-  workflow_dispatch: {}
-  push:
-    branches:
-      - main
-    paths:
-      - .github/workflows/dis-syncroot-release.yml
-      - syncroot/**
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: choice
+        required: true
+        options:
+          - at22
+          - at23
 
 permissions:
   contents: read
   id-token: write
+
+concurrency:
+  group: dis-syncroot-${{ inputs.environment }}
+  cancel-in-progress: false
 
 jobs:
   publish-syncroot:
     name: Publish syncroot artifact
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: at22
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,11 +37,11 @@ jobs:
         with:
           workdir: ./syncroot
 
-      - name: Build and push at22 syncroot artifact
+      - name: Build and push syncroot artifact
         uses: Altinn/altinn-platform/actions/flux/build-push-image@069dc838aa1c9ea8d76ecc289d7c91620f8bbff2 # main
         with:
           image_name: ${{ env.SYNCROOT_ARTIFACT_NAME }}
-          tag: ${{ env.SYNCROOT_ENVIRONMENT }}
+          tag: ${{ inputs.environment }}
           workdir: ./syncroot
           azure_subscription_id: ${{ secrets.DIS_SYNCROOT_AZURE_SUBSCRIPTION_ID }}
           azure_app_id: ${{ secrets.DIS_SYNCROOT_AZURE_CLIENT_ID }}

--- a/infrastructure/syncroots/terraform.tfvars.json
+++ b/infrastructure/syncroots/terraform.tfvars.json
@@ -26,9 +26,7 @@
     },
     "dis": {
       "repo_name": "altinn-platform",
-      "environments": [
-        "at22"
-      ],
+      "environments": [],
       "branches": [
         "main"
       ]


### PR DESCRIPTION
## Summary

- Convert `dis-syncroot-release.yml` from auto-publish-on-merge to manual `workflow_dispatch` with an `environment` choice input (at22, at23).
- Drop the job-level `environment:` binding so OIDC auth uses the existing branch federation on `main`. Adding a new env in the future is one line in the workflow `choice` list — no Terraform change required.
- Add a per-env `concurrency` group so dispatches to different envs don't queue each other.
- Add `run-name` so the Actions UI shows the target env at a glance.
- Clear the now-unused `dis.environments` entry in `infrastructure/syncroots/terraform.tfvars.json`. Applying this will remove the orphaned `at22` federated credential.

### Why dispatch-driven

Auto-publish on merge couples "code is merged" with "code is deployed to at22" — which doesn't scale once at23 (and eventually tt02/prod) come online. With dispatch you pick the target env per release, which env gets the new revision is explicit, and the rollout can be staggered. New envs are added by appending to the `choice` list and creating a `syncroot/<env>/` kustomization — no workflow duplication, no matrix needed.

## Test plan

- [ ] Apply Terraform on `infrastructure/syncroots` — confirm the at22 federated credential on the DIS syncroot UAMI is removed and no other change.
- [ ] Verify `dis-core-at23-aks`'s Flux config points at `altinncr.azurecr.io/dis/syncroot:at23` (config lives outside this repo).
- [ ] Dispatch the workflow with `environment: at22` from `main` — confirm the existing tag is updated.
- [ ] Dispatch with `environment: at23` — confirm the new tag is published and at23 Flux reconciles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the DIS syncroot release process to use manual triggering with environment selection capability, replacing automatic push-based publication and enabling deployment to multiple target environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->