### PR TITLE
fix(azure-devops-agent): add CVE-2026-44431 and CVE-2026-44432 to trivyignore

### DIFF
--- a/infrastructure/images/azure-devops-agent/.trivyignore
+++ b/infrastructure/images/azure-devops-agent/.trivyignore
@@ -1,0 +1,5 @@
+# urllib3 vulnerabilities - will be resolved when Azure CLI updates its urllib3 dependency
+# https://avd.aquasec.com/nvd/cve-2026-44431
+CVE-2026-44431
+# https://avd.aquasec.com/nvd/cve-2026-44432
+CVE-2026-44432


### PR DESCRIPTION
## Summary

- urllib3 2.6.3 (installed by Azure CLI) has two HIGH severity CVEs fixed in 2.7.0
- Added `CVE-2026-44431` (information disclosure via cross-origin redirects) and `CVE-2026-44432` (DoS via excessive HTTP response decompression) to `.trivyignore`
- Will be resolved when Azure CLI updates its urllib3 dependency upstream

## Test plan

- [ ] Verify `Scan/Release azure devops agent Image` workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability ignore list for temporary security considerations related to dependency management. These items are expected to be resolved once dependencies are updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->