### PR TITLE
fix(gh-runner): add CVE-2026-39823, CVE-2026-39825, CVE-2026-39826 to trivyignore

### DIFF
--- a/infrastructure/images/gh-runner/.trivyignore
+++ b/infrastructure/images/gh-runner/.trivyignore
@@ -127,3 +127,12 @@ CVE-2026-42499
 
 # containerd: user ID handling bypass allows runAsNonRoot evasion
 CVE-2026-46680
+
+# stdlib: URL handling vulnerability (CVE-2026-27142 follow-up)
+CVE-2026-39823
+
+# stdlib: ReverseProxy forwards queries with unintended parameters
+CVE-2026-39825
+
+# stdlib: html/template script tag injection by trusted template author
+CVE-2026-39826


### PR DESCRIPTION
## Summary

- Three new Go stdlib HIGH CVEs present in Go binaries embedded in the gh-runner base image (docker, containerd, buildx etc.)
- All fixed in Go 1.25.10 / 1.26.3 — will be resolved when upstream tools rebuild with the fixed Go version
- Added to `.trivyignore` to unblock the scan in the meantime

| CVE | Description |
|---|---|
| `CVE-2026-39823` | stdlib: URL handling vulnerability (CVE-2026-27142 follow-up) |
| `CVE-2026-39825` | stdlib: ReverseProxy forwards queries with unintended parameters |
| `CVE-2026-39826` | stdlib: html/template script tag injection by trusted template author |

## Test plan

- [ ] Verify `Scan/Release gh-runner base Image` workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)