### PR TITLE
fix(k6-action): add Go stdlib CVEs to trivyignore

### DIFF
--- a/infrastructure/images/k6-action/.trivyignore
+++ b/infrastructure/images/k6-action/.trivyignore
@@ -54,12 +54,42 @@ CVE-2026-29181
 
 # Go stdlib CVEs fixed in 1.26.3/1.25.10 - kubectl (v1.36.1 uses Go 1.26.2), jb (v0.6.0 uses Go 1.23.0),
 # and k6 (k6-image not yet rebuilt with Go 1.26.3) still embed vulnerable versions.
+# https://avd.aquasec.com/nvd/cve-2025-22871
+CVE-2025-22871
+# https://avd.aquasec.com/nvd/cve-2025-47906
+CVE-2025-47906
+# https://avd.aquasec.com/nvd/cve-2025-47912
+CVE-2025-47912
+# https://avd.aquasec.com/nvd/cve-2025-58185
+CVE-2025-58185
+# https://avd.aquasec.com/nvd/cve-2025-58186
+CVE-2025-58186
+# https://avd.aquasec.com/nvd/cve-2025-58187
+CVE-2025-58187
+# https://avd.aquasec.com/nvd/cve-2025-58188
+CVE-2025-58188
+# https://avd.aquasec.com/nvd/cve-2025-58189
+CVE-2025-58189
+# https://avd.aquasec.com/nvd/cve-2025-61723
+CVE-2025-61723
+# https://avd.aquasec.com/nvd/cve-2025-61724
+CVE-2025-61724
+# https://avd.aquasec.com/nvd/cve-2025-61725
+CVE-2025-61725
+# https://avd.aquasec.com/nvd/cve-2025-61727
+CVE-2025-61727
 # https://avd.aquasec.com/nvd/cve-2026-33811
 CVE-2026-33811
 # https://avd.aquasec.com/nvd/cve-2026-33814
 CVE-2026-33814
 # https://avd.aquasec.com/nvd/cve-2026-39820
 CVE-2026-39820
+# https://avd.aquasec.com/nvd/cve-2026-39823
+CVE-2026-39823
+# https://avd.aquasec.com/nvd/cve-2026-39825
+CVE-2026-39825
+# https://avd.aquasec.com/nvd/cve-2026-39826
+CVE-2026-39826
 # https://avd.aquasec.com/nvd/cve-2026-39836
 CVE-2026-39836
 # https://avd.aquasec.com/nvd/cve-2026-42499


### PR DESCRIPTION
## Summary

15 HIGH Go stdlib CVEs found in binaries embedded in the k6-action image that haven't been rebuilt with Go 1.25.10 / 1.26.3 yet:

- **kubectl v1.36.1** (Go 1.26.2): `CVE-2026-39823`, `CVE-2026-39825`, `CVE-2026-39826`
- **jb v0.6.0** (Go 1.23.0): 12 CVEs from `CVE-2025-22871` through `CVE-2025-61727` plus the 3 above
- **k6**: same 3 stdlib CVEs

All will be resolved when upstream tools rebuild with the fixed Go version.

## Test plan

- [ ] Verify `Scan/Release k6-action Image` workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)