### PR TITLE
fix(k6-action): build jb from source to eliminate Go 1.23 CVEs

### DIFF
--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -38,9 +38,9 @@ RUN curl -L "https://github.com/google/jsonnet/archive/refs/tags/v${JSONNET_VERS
     chmod +x jsonnet && mv jsonnet /usr/local/bin &&\
     chmod +x jsonnetfmt && mv jsonnetfmt /usr/local/bin
 
-# Install jb
-RUN curl -OL "https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/v${JB_VERSION}/jb-linux-amd64" &&\
-    chmod +x jb-linux-amd64 && mv jb-linux-amd64 /usr/local/bin/jb
+# Install jb (built from source so it uses the builder's Go version rather than the pre-built binary's Go 1.23)
+RUN go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v${JB_VERSION} && \
+    mv /go/bin/jb /usr/local/bin/jb
 
 WORKDIR /jsonnet/vendor
 


### PR DESCRIPTION
## Summary

- The pre-built `jb` binary from GitHub releases embeds Go 1.23.0, which has 12 HIGH severity stdlib CVEs
- Switch from downloading the pre-built binary to `go install`, building it with the builder stage's Go 1.26.3
- This eliminates all 12 CVEs from `jb` without needing to ignore them

## What's still ignored

- **kubectl v1.36.1** (Go 1.26.2): 3 CVEs — pre-built binary, needs upstream kubectl release with Go 1.26.3
- **k6** from `k6-image:v1.7.0` (Go 1.26.1): 3 CVEs — needs k6-image rebuild with updated builder

## Test plan

- [ ] Verify `Scan/Release k6-action Image` workflow passes after merge (may need to close/reopen PR #3600 to re-evaluate trivyignore entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal Docker image build process to optimize dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->