### PR TITLE
fix(dis-pgsql-operator): skip PgBouncer params on Burstable tier

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -920,8 +920,6 @@ var _ = Describe("DatabaseServer controller", func() {
 		expectedConfigurations := map[string]string{
 			extensionsConfigResourceName(db.Name):                              "hstore,pg_cron",
 			serverParameterConfigResourceName(db.Name, paramAutovacuumNaptime): "15",
-			serverParameterConfigResourceName(db.Name, "pgbouncer.enabled"):    "true",
-			serverParameterConfigResourceName(db.Name, "pgbouncer.pool_mode"):  "transaction",
 		}
 
 		for resourceName, expectedValue := range expectedConfigurations {
@@ -1494,8 +1492,10 @@ var _ = Describe("DatabaseServer controller", func() {
 				Namespace: ns,
 			},
 			Spec: storagev1alpha1.DatabaseServerSpec{
-				Version:    17,
-				ServerType: serverTypeDev,
+				Version: 17,
+				// PgBouncer parameters are only emitted on tiers that support it,
+				// so use a prod (General Purpose) server to exercise them here.
+				ServerType: serverTypeProd,
 				Auth: directAuth(
 					adminManagedIdentity,
 					adminManagedIdentityID,
@@ -1513,7 +1513,7 @@ var _ = Describe("DatabaseServer controller", func() {
 		}
 		Expect(k8sClient.Create(ctx, db)).To(Succeed())
 
-		maxConnections, err := dbUtil.ResolveMaxConnections(dbUtil.GetProfile(serverTypeDev))
+		maxConnections, err := dbUtil.ResolveMaxConnections(dbUtil.GetProfile(serverTypeProd))
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedValues := map[string]string{

--- a/services/dis-pgsql-operator/internal/database/db.go
+++ b/services/dis-pgsql-operator/internal/database/db.go
@@ -43,6 +43,12 @@ func GetProfile(serverType string) Profile {
 	return devProfile
 }
 
+// SupportsPgBouncer reports whether the profile's compute tier can run the
+// built-in PgBouncer. Azure rejects PgBouncer on the Burstable tier.
+func (p Profile) SupportsPgBouncer() bool {
+	return p.SkuTier != dbforpostgresqlv1.SkuTier_Burstable
+}
+
 func ResolveBackupRetentionDays(serverType string, requested *int) int {
 	if requested != nil {
 		return *requested

--- a/services/dis-pgsql-operator/internal/database/server_parameters.go
+++ b/services/dis-pgsql-operator/internal/database/server_parameters.go
@@ -53,10 +53,15 @@ func ResolveServerParameters(
 	}
 
 	resolved := map[string]string{
-		ServerParameterPgBouncerEnabled:     defaultPgBouncerEnabled,
-		ServerParameterPgBouncerMaxPrepared: defaultPgBouncerMaxPrepared,
-		ServerParameterPgBouncerPoolMode:    defaultPgBouncerPoolMode,
-		ServerParameterMaxConnections:       strconv.Itoa(maxConnections),
+		ServerParameterMaxConnections: strconv.Itoa(maxConnections),
+	}
+
+	// PgBouncer is only available on tiers that support it (Azure rejects it on
+	// the Burstable tier), so only seed its parameters when the profile allows it.
+	if profile.SupportsPgBouncer() {
+		resolved[ServerParameterPgBouncerEnabled] = defaultPgBouncerEnabled
+		resolved[ServerParameterPgBouncerMaxPrepared] = defaultPgBouncerMaxPrepared
+		resolved[ServerParameterPgBouncerPoolMode] = defaultPgBouncerPoolMode
 	}
 
 	for i := range requested {

--- a/services/dis-pgsql-operator/internal/database/server_parameters_test.go
+++ b/services/dis-pgsql-operator/internal/database/server_parameters_test.go
@@ -56,10 +56,31 @@ func TestResolveServerParameters(t *testing.T) {
 		return out
 	}
 
-	t.Run("includes non-overridable defaults for dev profile", func(t *testing.T) {
+	t.Run("omits pgbouncer parameters for dev profile on Burstable tier", func(t *testing.T) {
 		got, err := ResolveServerParameters("dev", nil)
 		if err != nil {
 			t.Fatalf("ResolveServerParameters(dev, nil) returned error: %v", err)
+		}
+
+		values := toMap(got)
+		for _, name := range []string{
+			ServerParameterPgBouncerEnabled,
+			ServerParameterPgBouncerMaxPrepared,
+			ServerParameterPgBouncerPoolMode,
+		} {
+			if _, ok := values[name]; ok {
+				t.Fatalf("expected %q to be omitted on Burstable tier, got %q", name, values[name])
+			}
+		}
+		if values[ServerParameterMaxConnections] != "50" {
+			t.Fatalf("max_connections = %q, want %q", values[ServerParameterMaxConnections], "50")
+		}
+	})
+
+	t.Run("includes pgbouncer defaults and max_connections for prod profile", func(t *testing.T) {
+		got, err := ResolveServerParameters("prod", nil)
+		if err != nil {
+			t.Fatalf("ResolveServerParameters(prod, nil) returned error: %v", err)
 		}
 
 		values := toMap(got)
@@ -72,18 +93,6 @@ func TestResolveServerParameters(t *testing.T) {
 		if values[ServerParameterPgBouncerPoolMode] != "transaction" {
 			t.Fatalf("pgbouncer.pool_mode = %q, want %q", values[ServerParameterPgBouncerPoolMode], "transaction")
 		}
-		if values[ServerParameterMaxConnections] != "50" {
-			t.Fatalf("max_connections = %q, want %q", values[ServerParameterMaxConnections], "50")
-		}
-	})
-
-	t.Run("includes profile-specific max_connections for prod profile", func(t *testing.T) {
-		got, err := ResolveServerParameters("prod", nil)
-		if err != nil {
-			t.Fatalf("ResolveServerParameters(prod, nil) returned error: %v", err)
-		}
-
-		values := toMap(got)
 		if values[ServerParameterMaxConnections] != "1718" {
 			t.Fatalf("max_connections = %q, want %q", values[ServerParameterMaxConnections], "1718")
 		}

--- a/services/dis-pgsql-operator/test/e2e/user_provision_test.go
+++ b/services/dis-pgsql-operator/test/e2e/user_provision_test.go
@@ -496,12 +496,12 @@ var _ = Describe("User provisioning", Ordered, func() {
 		)
 
 		By("verifying fixed and explicit server parameter configurations are created")
+		// The dev server runs on the Burstable tier, which does not support the
+		// built-in PgBouncer, so only max_connections and the user-defined
+		// parameter are expected (no pgbouncer.* parameters).
 		expected := map[string]string{
-			"pgbouncer.enabled":                 "true",
-			"pgbouncer.max_prepared_statements": "5000",
-			"pgbouncer.pool_mode":               "transaction",
-			"max_connections":                   "50",
-			explicitCustomServerParam:           explicitCustomServerValue,
+			"max_connections":         "50",
+			explicitCustomServerParam: explicitCustomServerValue,
 		}
 
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
## Summary
- The dev profile uses the Burstable tier (`Standard_B1ms`), which does **not** support Azure's built-in PgBouncer. The operator was unconditionally emitting `pgbouncer.*` server parameters, so the PostgreSQL RP rejected them and the `DatabaseServer` reported `ServerParametersReady=False` / `ApplyFailed`.
- Add `Profile.SupportsPgBouncer()` (false on the Burstable tier) and only seed `pgbouncer.enabled`, `pgbouncer.max_prepared_statements`, and `pgbouncer.pool_mode` when the profile supports PgBouncer. `max_connections` is still always set.
- Update unit, controller, and e2e expectations: dev/Burstable yields only `max_connections` (plus any user-defined params); prod (General Purpose) retains the pgbouncer defaults.

## Test plan
- [x] `make run-checks-ci-cache` (fmt, generate, manifests, test-ci, lint) — passes; lint 0 issues
- [x] `make test` (envtest/ginkgo controller specs) — passes locally
- [x] `make test-e2e` (Kind) — passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PgBouncer configuration is now correctly limited to supported server tiers only; Burstable tier servers no longer receive PgBouncer parameters.

* **Tests**
  * Updated test expectations to reflect tier-specific PgBouncer availability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->