### PR TITLE
feat(syncroot): add dis-pgsql sample database to at23

### DIFF
--- a/syncroot/at23/applicationidentity.yaml
+++ b/syncroot/at23/applicationidentity.yaml
@@ -1,0 +1,6 @@
+apiVersion: application.dis.altinn.cloud/v1alpha1
+kind: ApplicationIdentity
+metadata:
+  name: dis-sample-db-admin
+  namespace: product-dis
+spec: {}

--- a/syncroot/at23/database.yaml
+++ b/syncroot/at23/database.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: Database
+metadata:
+  name: dis-sample-appdb
+  namespace: product-dis
+spec:
+  name: appdb
+  server:
+    name: dis-sample-db
+  access:
+    principals:
+      - role: Owner
+        identityRef:
+          name: dis-sample-app
+  deletionPolicy: Retain

--- a/syncroot/at23/databaseserver.yaml
+++ b/syncroot/at23/databaseserver.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: DatabaseServer
+metadata:
+  name: dis-sample-db
+  namespace: product-dis
+spec:
+  version: 17
+  serverType: dev
+  auth:
+    admin:
+      identity:
+        identityRef:
+          name: dis-sample-db-admin

--- a/syncroot/at23/kustomization.yaml
+++ b/syncroot/at23/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - applicationidentity.yaml
+  - databaseserver.yaml
+  - database.yaml
 patches:
   - target:
       kind: Vault


### PR DESCRIPTION
## Summary
- Add a dedicated `DatabaseServer` (`dis-sample-db`, PostgreSQL 17, `serverType: dev`) in the `product-dis` namespace on at23
- Add a `Database` (`dis-sample-appdb`, PG name `appdb`) granting the existing `dis-sample-app` identity the `Owner` role
- Add a dedicated `dis-sample-db-admin` `ApplicationIdentity` used as the server admin identity for provisioning

This is the first step toward testing `dis-pgsql` end to end. A connection client and the operator-published connection ConfigMap (mirroring dis-vault) will follow in separate PRs.

## Test plan
- [ ] Triggering the at23 env workflow reconciles `syncroot/at23` via Flux
- [ ] `dis-sample-db-admin` ApplicationIdentity reaches Ready (managed identity + federated credential + ServiceAccount)
- [ ] `DatabaseServer dis-sample-db` provisions the Azure PostgreSQL Flexible Server
- [ ] `Database dis-sample-appdb` reaches Ready; `status.host` and `status.port` are populated
- [ ] A client pod under the `dis-sample-app` workload identity (user `product-dis-dis-sample-app`) can connect and run a query

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database infrastructure configuration files for a sample environment.
  * Configured database server (version 17) in development mode with admin identity and access controls.
  * Set up database resource management with retention policies and owner role assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->