### PR TITLE
feat(syncroot): add dis-pgsql sample database to at22

### DIFF
--- a/syncroot/at22/applicationidentity.yaml
+++ b/syncroot/at22/applicationidentity.yaml
@@ -1,0 +1,6 @@
+apiVersion: application.dis.altinn.cloud/v1alpha1
+kind: ApplicationIdentity
+metadata:
+  name: dis-sample-db-admin
+  namespace: product-dis
+spec: {}

--- a/syncroot/at22/database.yaml
+++ b/syncroot/at22/database.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: Database
+metadata:
+  name: dis-sample-appdb
+  namespace: product-dis
+spec:
+  name: appdb
+  server:
+    name: dis-sample-db
+  access:
+    principals:
+      - role: Owner
+        identityRef:
+          name: dis-sample-app
+  deletionPolicy: Retain

--- a/syncroot/at22/databaseserver.yaml
+++ b/syncroot/at22/databaseserver.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: DatabaseServer
+metadata:
+  name: dis-sample-db
+  namespace: product-dis
+spec:
+  version: 17
+  serverType: dev
+  auth:
+    admin:
+      identity:
+        identityRef:
+          name: dis-sample-db-admin

--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - applicationidentity.yaml
+  - databaseserver.yaml
+  - database.yaml
 patches:
   - target:
       kind: Vault


### PR DESCRIPTION
## Summary
Mirrors the at23 dis-pgsql sample-database setup (#3608) for the **at22** environment, deployed via syncroot GitOps so Flux reconciles it in the at22 cluster.

Adds to `syncroot/at22/`:
- `applicationidentity.yaml` — dedicated `dis-sample-db-admin` ApplicationIdentity used as the server's Entra admin.
- `databaseserver.yaml` — `dis-sample-db` DatabaseServer (PG 17, `serverType: dev` → Burstable/HA off, Dedicated mode self-allocates its subnet).
- `database.yaml` — `dis-sample-appdb` (PG db `appdb`) with `dis-sample-app` as Owner principal, `deletionPolicy: Retain`.
- `kustomization.yaml` — references the three new resources; the existing Vault patch (groupObjectId + `env: at22` tag) is preserved.

Deferred to follow-up PRs (same as at23): the client connection test, and an operator-published ConfigMap of connection variables (mirroring dis-vault).

## Test plan
- [x] `kustomize build syncroot/at22` renders all resources cleanly with the Vault patch intact.
- [ ] Trigger the at22 syncroot workflow and confirm Flux reconciles DatabaseServer + Database.
- [ ] Verify `Database.status` exposes host/port once the Azure PostgreSQL Flexible Server is provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)