### PR TITLE
fix(dis-pgsql-operator): create Entra principals on postgres maintenance db

### DIFF
--- a/services/dis-pgsql-operator/internal/database/user_provisioner.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner.go
@@ -15,6 +15,11 @@ import (
 
 const (
 	userProvisionScope = "https://ossrdbms-aad.database.windows.net/.default"
+
+	// maintenanceDatabase holds the cluster-global pgaadauth_* helper functions on
+	// Azure Flexible Server; they do not exist in freshly created databases, so
+	// principal creation must run here even though the resulting role is global.
+	maintenanceDatabase = "postgres"
 )
 
 // RunUserProvisioner connects to the database using workload identity and
@@ -105,7 +110,19 @@ func RunUserProvisioner(ctx context.Context) error {
 		}
 	}()
 
-	if err := ensureAccess(ctx, conn, accessOptions{
+	maintenanceCfg := cfg.Copy()
+	maintenanceCfg.Database = maintenanceDatabase
+	principalConn, err := pgx.ConnectConfig(ctx, maintenanceCfg)
+	if err != nil {
+		return fmt.Errorf("connect maintenance database %q: %w", maintenanceDatabase, err)
+	}
+	defer func() {
+		if err := principalConn.Close(ctx); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "close maintenance connection: %v\n", err)
+		}
+	}()
+
+	if err := ensureAccess(ctx, conn, principalConn, accessOptions{
 		DatabaseName:             dbName,
 		SchemaName:               schemaName,
 		Principals:               accessPrincipals,
@@ -134,7 +151,7 @@ type accessOptions struct {
 	DatabaseScopedSearchPath bool
 }
 
-func ensureAccess(ctx context.Context, conn pgxConn, opts accessOptions) error {
+func ensureAccess(ctx context.Context, conn pgxConn, principalConn pgxConn, opts accessOptions) error {
 	if opts.RevokePublicConnect {
 		if _, err := conn.Exec(ctx, revokePublicConnectSQL(opts.DatabaseName)); err != nil {
 			return fmt.Errorf("revoke public connect: %w", err)
@@ -166,7 +183,7 @@ func ensureAccess(ctx context.Context, conn pgxConn, opts accessOptions) error {
 		if err := validateAccessPrincipal(principal, opts.UseAAD); err != nil {
 			return err
 		}
-		if err := ensurePrincipal(ctx, conn, principal.Name, principal.PrincipalID, string(principal.PrincipalType), opts.UseAAD); err != nil {
+		if err := ensurePrincipal(ctx, principalConn, principal.Name, principal.PrincipalID, string(principal.PrincipalType), opts.UseAAD); err != nil {
 			return err
 		}
 		roleName, err := accessRoles.roleFor(principal.Role)

--- a/services/dis-pgsql-operator/internal/database/user_provisioner.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner.go
@@ -110,17 +110,21 @@ func RunUserProvisioner(ctx context.Context) error {
 		}
 	}()
 
-	maintenanceCfg := cfg.Copy()
-	maintenanceCfg.Database = maintenanceDatabase
-	principalConn, err := pgx.ConnectConfig(ctx, maintenanceCfg)
-	if err != nil {
-		return fmt.Errorf("connect maintenance database %q: %w", maintenanceDatabase, err)
-	}
-	defer func() {
-		if err := principalConn.Close(ctx); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "close maintenance connection: %v\n", err)
+	principalConn := conn
+	if !disableAAD && !strings.EqualFold(dbName, maintenanceDatabase) {
+		maintenanceCfg := cfg.Copy()
+		maintenanceCfg.Database = maintenanceDatabase
+		maintenanceConn, connErr := pgx.ConnectConfig(ctx, maintenanceCfg)
+		if connErr != nil {
+			return fmt.Errorf("connect maintenance database %q: %w", maintenanceDatabase, connErr)
 		}
-	}()
+		defer func() {
+			if err := maintenanceConn.Close(ctx); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "close maintenance connection: %v\n", err)
+			}
+		}()
+		principalConn = maintenanceConn
+	}
 
 	if err := ensureAccess(ctx, conn, principalConn, accessOptions{
 		DatabaseName:             dbName,

--- a/services/dis-pgsql-operator/internal/database/user_provisioner_test.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner_test.go
@@ -218,8 +218,9 @@ func TestEnsurePrincipalSkipsCreateWhenExists(t *testing.T) {
 
 func TestEnsureAccessCreatesManagedRolesAndPrincipalMemberships(t *testing.T) {
 	conn := &recordingConn{}
+	principalConn := &recordingConn{}
 
-	if err := ensureAccess(context.Background(), conn, accessOptions{
+	if err := ensureAccess(context.Background(), conn, principalConn, accessOptions{
 		DatabaseName: appDBName,
 		SchemaName:   appDBName,
 		Principals: []AccessPrincipal{
@@ -254,8 +255,9 @@ func TestEnsureAccessCreatesManagedRolesAndPrincipalMemberships(t *testing.T) {
 	requireExec(t, conn, createNoLoginRoleSQL(roles.Reader))
 	requireExec(t, conn, createNoLoginRoleSQL(roles.Writer))
 	requireExec(t, conn, createNoLoginRoleSQL(roles.Owner))
-	requireExec(t, conn, createAADPrincipalSQL(), "app-user", "app-principal-id", "service")
-	requireExec(t, conn, createAADPrincipalSQL(), "owner-group", "owner-principal-id", "group")
+	requireExec(t, principalConn, createAADPrincipalSQL(), "app-user", "app-principal-id", "service")
+	requireExec(t, principalConn, createAADPrincipalSQL(), "owner-group", "owner-principal-id", "group")
+	requireNoExec(t, conn, createAADPrincipalSQL())
 	requireExec(t, conn, grantConnectSQL(appDBName, roles.Reader))
 	requireExec(t, conn, alterSchemaOwnerSQL(appDBName, roles.Owner))
 	requireExec(t, conn, grantSchemaUsageSQL(appDBName, roles.Reader))
@@ -281,7 +283,7 @@ func TestEnsureAccessRevokesRemovedManagedRoleMembers(t *testing.T) {
 		},
 	}
 
-	if err := ensureAccess(context.Background(), conn, accessOptions{
+	if err := ensureAccess(context.Background(), conn, &recordingConn{}, accessOptions{
 		DatabaseName: appDBName,
 		SchemaName:   appDBName,
 		Principals: []AccessPrincipal{
@@ -398,6 +400,16 @@ func requireExec(t *testing.T, conn *recordingConn, sql string, args ...any) {
 	}
 
 	t.Fatalf("missing exec %q with args %#v; got %#v", sql, args, conn.execs)
+}
+
+func requireNoExec(t *testing.T, conn *recordingConn, sql string) {
+	t.Helper()
+
+	for _, exec := range conn.execs {
+		if exec.sql == sql {
+			t.Fatalf("unexpected exec %q on connection; got %#v", sql, conn.execs)
+		}
+	}
 }
 
 func equalArgs(got, want []any) bool {


### PR DESCRIPTION
## Summary
The user-provisioning job connected only to the **application** database and ran `pgaadauth_create_principal_with_oid(...)` there. On Azure PostgreSQL Flexible Server those `pgaadauth_*` helper functions only exist in the **`postgres`** maintenance database (a freshly created DB is cloned from `template1`, which doesn't carry them), so the call failed with:

```
ERROR: function pgaadauth_create_principal_with_oid(unknown, unknown, unknown, boolean, boolean) does not exist (SQLSTATE 42883)
```

leaving the `Database` stuck at `AccessReady=False`.

This change opens a second connection to the `postgres` maintenance database and runs **principal creation** there (the resulting role is cluster-global), while keeping all per-database work — managed roles, schema, grants, default privileges, `search_path`, revoke-public-connect — on the application-database connection.

This matches Azure's documented requirement (run `pgaadauth_create_principal*` against `postgres`) and the CloudNativePG pattern of managing global roles over the maintenance connection and per-database objects over the target connection.

## Changes
- `RunUserProvisioner`: derive a maintenance (`postgres`) connection via `cfg.Copy()` and pass it to `ensureAccess`.
- `ensureAccess`: takes a `principalConn`; `ensurePrincipal` (the `pgaadauth_create_principal_with_oid` call) runs over it. Everything else stays on the app-db connection.
- Tests: AAD principal creation is asserted on `principalConn`, with a `requireNoExec` guard that it does **not** run on the app-db connection.

## Test plan
- [x] `make run-checks-ci-cache` (fmt, generate, manifests, test-ci, lint) — all passed, no manifest drift, 0 lint issues.
- [ ] Redeploy operator to at23/at22 and confirm the `Database` reaches `AccessReady=True` / `Ready=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL user provisioning for Azure AD principals by using the appropriate maintenance database connection, ensuring proper authentication setup with Azure Flexible Server.

* **Tests**
  * Enhanced test coverage for user provisioning logic to validate correct connection usage during Azure AD principal creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-platform/pull/3610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->