### PR TITLE
fix(dis-pgsql-operator): never revoke the connecting admin from managed roles

### DIFF
--- a/services/dis-pgsql-operator/config/kind/postgres.yaml
+++ b/services/dis-pgsql-operator/config/kind/postgres.yaml
@@ -1,3 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  namespace: default
+data:
+  10-dispg-admin.sql: |
+    CREATE ROLE dispg_admin LOGIN CREATEROLE CREATEDB;
+    ALTER ROLE dispg_admin SET createrole_self_grant = 'set, inherit';
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,6 +31,13 @@ spec:
               value: "trust"
           ports:
             - containerPort: 5432
+          volumeMounts:
+            - name: init
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: init
+          configMap:
+            name: postgres-init
 ---
 apiVersion: v1
 kind: Service

--- a/services/dis-pgsql-operator/internal/controller/database_controller_postgres.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_postgres.go
@@ -41,6 +41,13 @@ const (
 	labelValueTrue                  = "true"
 	databaseAccessProvisionLabelKey = "dis.altinn.cloud/access-provision"
 	userProvisionLabelKey           = "dis.altinn.cloud/user-provision"
+
+	// kindProvisionAdminUser is the non-superuser Postgres role the provisioning
+	// Job connects as when running against Kind (useAzFakes). It mirrors Azure's
+	// non-superuser Entra admin; see the useAzFakes branch in
+	// database_controller_user_job.go. The role is bootstrapped by
+	// config/kind/postgres.yaml.
+	kindProvisionAdminUser = "dispg_admin"
 )
 
 func (r *DatabaseReconciler) ensureFlexibleServersDatabase(

--- a/services/dis-pgsql-operator/internal/controller/database_controller_user_job.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_user_job.go
@@ -134,13 +134,21 @@ func ensureUserProvisionJobForReconciler(
 	job := buildUserProvisionJob(ns, jobName, image, labels, spec, parallelism, completions, ttlSeconds)
 
 	// If we're using AzFakes, we need to disable AAD authentication in the provisioner
-	// since we're running on Kind
+	// since we're running on Kind. We also connect as a dedicated NON-superuser admin
+	// instead of the bootstrap "postgres" superuser. Azure PostgreSQL's Entra admin is
+	// a non-superuser CREATEROLE role, which (unlike a superuser) is auto-granted
+	// membership in every role it creates. Connecting as a superuser hides that, so the
+	// Kind environment must mirror the non-superuser admin to exercise that code path.
 	if useAzFakes {
 		job.Spec.Template.Spec.Containers[0].Env = append(
 			job.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
 				Name:  dbUtil.DisableAADEnv,
 				Value: "1",
+			},
+			corev1.EnvVar{
+				Name:  dbUtil.DBAdminUserEnv,
+				Value: kindProvisionAdminUser,
 			},
 		)
 		job.Spec.Template.Spec.InitContainers = append(

--- a/services/dis-pgsql-operator/internal/database/access_payload.go
+++ b/services/dis-pgsql-operator/internal/database/access_payload.go
@@ -25,6 +25,7 @@ const (
 	DBSchemaEnv            = "DISPG_DB_SCHEMA"
 	DBHostEnv              = "DISPG_DB_HOST"
 	DBNameEnv              = "DISPG_DB_NAME"
+	DBAdminUserEnv         = "DISPG_DB_ADMIN_USER"
 	DisableAADEnv          = "DISPG_DISABLE_AAD"
 	RevokePublicConnectEnv = "DISPG_REVOKE_PUBLIC_CONNECT"
 	DBSearchPathScopeEnv   = "DISPG_DB_SEARCH_PATH_SCOPE"

--- a/services/dis-pgsql-operator/internal/database/user_provisioner.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner.go
@@ -79,7 +79,7 @@ func RunUserProvisioner(ctx context.Context) error {
 		return fmt.Errorf("parse pgx config: %w", err)
 	}
 	if disableAAD {
-		adminUser := strings.TrimSpace(os.Getenv("DISPG_DB_ADMIN_USER"))
+		adminUser := strings.TrimSpace(os.Getenv(DBAdminUserEnv))
 		if adminUser == "" {
 			adminUser = "postgres"
 		}
@@ -500,11 +500,17 @@ func createAADPrincipalSQL() string {
 }
 
 func roleMembersSQL() string {
+	// CURRENT_USER is excluded: PostgreSQL auto-grants the creating role membership
+	// WITH ADMIN OPTION on CREATE ROLE, so the connecting admin shows up as a member
+	// of every managed role it created. Reconciling that membership away fails with
+	// "dependent privileges exist" (2BP01) because the admin used it to grant the
+	// role onward, so it must never be treated as a revocable member.
 	return `SELECT member_role.rolname
 FROM pg_auth_members membership
 JOIN pg_roles role_role ON role_role.oid = membership.roleid
 JOIN pg_roles member_role ON member_role.oid = membership.member
-WHERE role_role.rolname = $1`
+WHERE role_role.rolname = $1
+  AND member_role.rolname <> CURRENT_USER`
 }
 
 func grantRoleSQL(role, member string) string {

--- a/services/dis-pgsql-operator/test/e2e/user_provision_test.go
+++ b/services/dis-pgsql-operator/test/e2e/user_provision_test.go
@@ -40,6 +40,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// provisionAdminUser is the non-superuser Postgres role the operator's
+// provisioning Job connects as in Kind (useAzFakes). It must match
+// kindProvisionAdminUser in internal/controller and the role bootstrapped by
+// config/kind/postgres.yaml. App databases are owned by this role so the
+// non-superuser admin can provision them, mirroring Azure's Entra admin.
+const provisionAdminUser = "dispg_admin"
+
 var _ = Describe("User provisioning", Ordered, func() {
 	const (
 		dbName                     = "e2e-user-provision"
@@ -135,8 +142,9 @@ var _ = Describe("User provisioning", Ordered, func() {
 
 		By("creating the real app database in local Postgres")
 		runPostgresQuery(fmt.Sprintf(
-			"CREATE DATABASE %s;",
+			"CREATE DATABASE %s OWNER %s;",
 			quoteIdentifier(expectedDatabaseName),
+			quoteIdentifier(provisionAdminUser),
 		))
 
 		By("marking ASO resources ready for the local Postgres stand-in")
@@ -218,8 +226,9 @@ var _ = Describe("User provisioning", Ordered, func() {
 
 		By("creating the real database in local Postgres")
 		runPostgresQuery(fmt.Sprintf(
-			"CREATE DATABASE %s;",
+			"CREATE DATABASE %s OWNER %s;",
 			quoteIdentifier(expectedDatabaseName),
+			quoteIdentifier(provisionAdminUser),
 		))
 
 		By("marking ASO resources ready for the local Postgres stand-in")
@@ -291,6 +300,101 @@ var _ = Describe("User provisioning", Ordered, func() {
 		runPostgresQuery(`DROP ROLE IF EXISTS "e2e-database-intruder"; CREATE ROLE "e2e-database-intruder" LOGIN;`)
 		_, err = runPostgresQueryAsUserInDatabase("e2e-database-intruder", expectedDatabaseName, "SELECT 1;")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("re-provisions without revoking the connecting admin (regression for SQLSTATE 2BP01)", func() {
+		const (
+			reproServerName      = "e2e-reprovision-server"
+			reproDatabaseName    = "e2e-reprovision"
+			reproOwnerA          = "e2e-reprovision-owner-a"
+			reproOwnerAPrincipal = "33333333-3333-3333-3333-333333333333"
+			reproOwnerB          = "e2e-reprovision-owner-b"
+			reproOwnerBPrincipal = "44444444-4444-4444-4444-444444444444"
+		)
+
+		manifestOwnerA := writeReprovisionManifest(
+			reproServerName, reproDatabaseName, namespace, adminIdentityRef, reproOwnerA, reproOwnerAPrincipal)
+		manifestOwnerB := writeReprovisionManifest(
+			reproServerName, reproDatabaseName, namespace, adminIdentityRef, reproOwnerB, reproOwnerBPrincipal)
+
+		defer func() {
+			deleteDatabaseAndProvisionJobs(reproDatabaseName, namespace)
+			deleteDatabaseServerAndProvisionJobs(reproServerName, namespace)
+			_ = os.Remove(manifestOwnerA)
+			_ = os.Remove(manifestOwnerB)
+			cleanupDatabasePostgresResources(reproDatabaseName, reproOwnerA, reproOwnerB)
+		}()
+
+		By("cleaning up stale re-provision resources from previous runs")
+		deleteDatabaseAndProvisionJobs(reproDatabaseName, namespace)
+		deleteDatabaseServerAndProvisionJobs(reproServerName, namespace)
+		cleanupDatabasePostgresResources(reproDatabaseName, reproOwnerA, reproOwnerB)
+
+		waitForAccessJobComplete := func(failure string) {
+			labelSelector := fmt.Sprintf(
+				"dis.altinn.cloud/database-name=%s,dis.altinn.cloud/user-provision=true", reproDatabaseName)
+			Eventually(func() error {
+				cmd := exec.Command(
+					"kubectl", "wait",
+					"--for=condition=complete",
+					"job",
+					"-l", labelSelector,
+					"-n", namespace,
+					"--timeout=20s",
+				)
+				_, err := utils.Run(cmd)
+				return err
+			}).WithTimeout(5*time.Minute).WithPolling(2*time.Second).
+				Should(Succeed(), failure)
+		}
+
+		By("provisioning the database with owner A")
+		cmd := exec.Command("kubectl", "apply", "-f", manifestOwnerA)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply re-provision manifest (owner A)")
+		patchApplicationIdentityStatus(adminIdentityRef, namespace, adminIdentity, adminPrincipal)
+
+		By("waiting for the ASO database child")
+		asoDatabaseName := waitForDatabaseASOResource(reproDatabaseName, namespace)
+
+		By("creating the app database owned by the provisioning admin")
+		runPostgresQuery(fmt.Sprintf(
+			"CREATE DATABASE %s OWNER %s;",
+			quoteIdentifier(reproDatabaseName),
+			quoteIdentifier(provisionAdminUser),
+		))
+
+		By("marking ASO resources ready for the local Postgres stand-in")
+		patchFlexibleServerReady(reproServerName, namespace, "postgres.default.svc")
+		patchFlexibleServersDatabaseReady(asoDatabaseName, namespace)
+
+		By("waiting for the first provisioning job to complete")
+		waitForAccessJobComplete("First access provisioning job did not complete")
+
+		By("re-provisioning with owner B so the reconcile must revoke the removed owner A member")
+		cmd = exec.Command("kubectl", "apply", "-f", manifestOwnerB)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply re-provision manifest (owner B)")
+
+		// The connecting admin is a non-superuser that PostgreSQL auto-grants into
+		// every managed role it created. Before the fix, the reconcile treated that
+		// membership as revocable; the revoke failed with "dependent privileges
+		// exist" (SQLSTATE 2BP01) and the second Job never completed. Owner B's role
+		// is only created once the second Job gets past schema/role setup, so its
+		// presence plus Job completion proves the admin was not revoked.
+		By("waiting until owner B is provisioned by the second job")
+		Eventually(func(g Gomega) string {
+			out, err := runPostgresQueryAsUser("postgres",
+				"SELECT 1 FROM pg_roles WHERE rolname = '"+reproOwnerB+"';")
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.TrimSpace(out)
+		}).WithTimeout(5*time.Minute).WithPolling(2*time.Second).
+			Should(Equal("1"),
+				"owner B role was not created: the second provisioning job likely failed before reaching it (regression for SQLSTATE 2BP01)")
+
+		By("waiting for the second provisioning job to complete")
+		waitForAccessJobComplete(
+			"Second access provisioning job did not complete: the reconcile likely tried to revoke the connecting admin (SQLSTATE 2BP01)")
 	})
 
 	It("applies storage settings to the FlexibleServer", func() {
@@ -872,6 +976,101 @@ func writeDatabaseTestManifest(
 
 	dir := os.TempDir()
 	path := filepath.Join(dir, fmt.Sprintf("database-%s.yaml", databaseResourceName))
+	err := os.WriteFile(path, []byte(content), 0o600)
+	Expect(err).NotTo(HaveOccurred(), "Failed to write temp manifest")
+	return path
+}
+
+func writeReprovisionManifest(
+	serverName,
+	databaseResourceName,
+	namespace,
+	adminIdentityRef,
+	ownerName,
+	ownerPrincipalID string,
+) string {
+	adminIdentity := &identityv1alpha1.ApplicationIdentity{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "application.dis.altinn.cloud/v1alpha1",
+			Kind:       "ApplicationIdentity",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminIdentityRef,
+			Namespace: namespace,
+		},
+		Spec: identityv1alpha1.ApplicationIdentitySpec{},
+	}
+
+	sharedDatabase := &storagev1alpha1.DatabaseServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "storage.dis.altinn.cloud/v1alpha1",
+			Kind:       "DatabaseServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverName,
+			Namespace: namespace,
+		},
+		Spec: storagev1alpha1.DatabaseServerSpec{
+			Mode:       storagev1alpha1.DatabaseServerModeShared,
+			Version:    17,
+			ServerType: "dev",
+			Network: &storagev1alpha1.DatabaseServerNetworkSpec{
+				DelegatedSubnetResourceID: "/subscriptions/fake-subscription/resourceGroups/rg-dis-admin-network/providers/Microsoft.Network/virtualNetworks/vnet-dis-admin-dbs/subnets/snet-postgres-shared",
+				PrivateDNSZoneResourceID:  "/subscriptions/fake-subscription/resourceGroups/rg-dis-admin-network/providers/Microsoft.Network/privateDnsZones/shared.private.postgres.database.azure.com",
+			},
+			Auth: storagev1alpha1.DatabaseServerAuth{
+				Admin: storagev1alpha1.AdminIdentitySpec{
+					Identity: storagev1alpha1.IdentitySource{
+						IdentityRef: &storagev1alpha1.ApplicationIdentityRef{Name: adminIdentityRef},
+					},
+				},
+			},
+		},
+	}
+
+	database := &storagev1alpha1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "storage.dis.altinn.cloud/v1alpha1",
+			Kind:       "Database",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      databaseResourceName,
+			Namespace: namespace,
+		},
+		Spec: storagev1alpha1.DatabaseSpec{
+			Name: databaseResourceName,
+			Server: storagev1alpha1.DatabaseServerReference{
+				Name: serverName,
+			},
+			Access: storagev1alpha1.DatabaseAccessSpec{
+				Principals: []storagev1alpha1.DatabaseAccessPrincipalSpec{
+					{
+						Role: storagev1alpha1.DatabaseAccessRoleOwner,
+						Group: &storagev1alpha1.DatabaseGroupPrincipalSpec{
+							Name:        ownerName,
+							PrincipalId: ownerPrincipalID,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resources := []interface{}{adminIdentity, sharedDatabase, database}
+	docs := make([]string, 0, len(resources))
+	for i := range resources {
+		content, err := yaml.Marshal(resources[i])
+		Expect(err).NotTo(HaveOccurred(), "Failed to marshal re-provision manifest resource")
+		docs = append(docs, string(content))
+	}
+
+	content := strings.Join(docs, "---\n")
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	dir := os.TempDir()
+	path := filepath.Join(dir, fmt.Sprintf("reprovision-%s-%s.yaml", databaseResourceName, ownerName))
 	err := os.WriteFile(path, []byte(content), 0o600)
 	Expect(err).NotTo(HaveOccurred(), "Failed to write temp manifest")
 	return path


### PR DESCRIPTION
## Problem

Production provisioning pod crashed:

```
ERROR setup user provisioner failed {"error": "revoke managed role disp ERROR: dependent privileges exist (SQLSTATE 2BP01)"}
```

The user provisioner connects to Postgres as a **non-superuser** admin (Azure's Entra admin). On PostgreSQL 16, a non-superuser `CREATEROLE` role is **auto-granted membership `WITH ADMIN OPTION`** in every role it creates. So the connecting admin silently becomes a member of every managed `reader`/`writer`/`owner` role it provisions.

The membership reconcile listed those members and treated the admin's own membership as revocable, issuing `REVOKE <role> FROM <admin>`. Because the admin had used that membership to grant the role onward (the role hierarchy + principals), the revoke failed with **`dependent privileges exist` (SQLSTATE 2BP01)** and the provisioning Job crashed.

A superuser receives **no** such self-grant — which is exactly why this never showed up locally or in e2e (both connected as the `postgres` superuser).

## Fix

Exclude `CURRENT_USER` from the managed-role member query (`roleMembersSQL`), so the connecting admin is never treated as a revocable member:

```sql
WHERE role_role.rolname = $1
  AND member_role.rolname <> CURRENT_USER
```

This is a one-line behavioral fix; the rest of the diff is the regression test.

## Why the test changes are larger than the fix

The bug is **invisible to a superuser connection**, so the existing e2e suite (which provisions as `postgres`) could not catch it. To reproduce it the way production hits it, the e2e Kind path now provisions as a **dedicated non-superuser admin**, mirroring Azure:

- `config/kind/postgres.yaml` bootstraps a `dispg_admin` role (`LOGIN CREATEROLE CREATEDB`, `createrole_self_grant = 'set, inherit'`).
- In `useAzFakes` mode the provisioning Job now connects as `dispg_admin` (via `DISPG_DB_ADMIN_USER`) instead of the `postgres` superuser. Trust auth means no password is needed.
- The e2e app databases are created `OWNER dispg_admin` so the non-superuser admin can provision them.
- A new e2e test re-provisions a database with a changed owner principal. The second Job only completes if the admin's auto-granted memberships are left intact — it **fails deterministically on the bug (2BP01 / `must be able to SET ROLE`) and passes on the fix**.

This also makes the Kind environment faithful to Azure for this whole class of superuser-masked bugs.

## Verification

Ran with the repo's `*-cache` targets:

- `make fmt-cache` — passed
- `make generate-cache` — passed
- `make manifests-cache` — passed (config/ changed)
- `make test-ci-cache` — passed
- `make lint-cache` — passed (0 issues)
- `go vet -tags=e2e ./test/e2e/...` — passed (e2e package compiles)

**Not run here:** `make test-e2e` (needs a Kind cluster, unavailable in this environment). Please run it before merge — it is the gate that exercises the new regression test. The fix + reproduction were proven against a real PostgreSQL 16 (deterministic fail-before / pass-after) during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a database provisioning issue where admin users could be incorrectly removed when re-provisioning shared databases.

* **Tests**
  * Added comprehensive regression tests for database user provisioning and role management scenarios to prevent future issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->