### PR TITLE
ci(dis-pgsql-operator): run e2e suite on PRs via Kind on ubuntu-latest

### DIFF
--- a/.github/workflows/dis-pgsql-lint-test.yml
+++ b/.github/workflows/dis-pgsql-lint-test.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -78,6 +82,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/dis-pgsql-lint-test.yml
+++ b/.github/workflows/dis-pgsql-lint-test.yml
@@ -14,6 +14,10 @@ on:
       - services/dis-pgsql-operator/**
       - .github/workflows/dis-pgsql-lint-test.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -59,3 +63,27 @@ jobs:
         run: |
           go mod tidy
           make test
+
+  e2e:
+    name: Run e2e tests on Kind
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: services/dis-pgsql-operator
+    env:
+      CONTAINER_TOOL: docker
+      CERT_MANAGER_INSTALL_SKIP: "true"
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "services/dis-pgsql-operator/go.mod"
+          cache-dependency-path: "services/dis-pgsql-operator/go.sum"
+
+      - name: Run e2e suite on Kind
+        run: make test-e2e-kind-ci


### PR DESCRIPTION
## What
Adds an `e2e` job to `.github/workflows/dis-pgsql-lint-test.yml` that runs the dis-pgsql-operator e2e suite (`make test-e2e-kind-ci`) on pull requests touching `services/dis-pgsql-operator/**`. The suite previously only ran locally.

## Why `ubuntu-latest` (not `self-hosted`)
The `self-hosted` runners are Azure Container App Jobs (`ghcr.io/altinn/altinn-platform/gh-runner`) with no container runtime and no privileged/DinD support, so they can't create a Kind cluster. GitHub-hosted `ubuntu-latest` ships docker, kubectl and kind preinstalled, so the job reuses the existing Makefile targets with no extra tooling.

## Details
- `CONTAINER_TOOL: docker` so the image built by `make docker-build` lands in the same daemon `kind load docker-image` reads from (the Makefile default is podman for local dev).
- `CERT_MANAGER_INSTALL_SKIP: "true"` (suite needs no webhooks); `timeout-minutes: 45` sits above the suite's 30m `E2E_TEST_TIMEOUT`.
- Gated on the unit `test` job so we don't burn GitHub-hosted minutes when unit tests fail.
- Added a workflow `concurrency` group to cancel superseded PR runs.

## Verification
This PR edits the workflow in its own trigger path, so the new `e2e` job runs on this PR — its CI result is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow with concurrency management to efficiently cancel duplicate runs when processing pull requests
  * Added comprehensive end-to-end testing to the continuous integration pipeline with extended timeout for thorough validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->