### PR TITLE
chore(dis-vault-operator): scope goconst out of tests + align golangci-lint with CI

### DIFF
--- a/services/dis-vault-operator/.golangci.yml
+++ b/services/dis-vault-operator/.golangci.yml
@@ -37,6 +37,9 @@ linters:
           - lll
         path: internal/*
       - linters:
+          - goconst
+        path: _test\.go$
+      - linters:
           - staticcheck
         path: api/v1alpha1/groupversion_info.go
         text: SA1019

--- a/services/dis-vault-operator/Makefile
+++ b/services/dis-vault-operator/Makefile
@@ -352,7 +352,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.3
+GOLANGCI_LINT_VERSION ?= v2.12.2
 GOVULNCHECK_VERSION ?= latest
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/services/dis-vault-operator/internal/controller/suite_test.go
+++ b/services/dis-vault-operator/internal/controller/suite_test.go
@@ -66,9 +66,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	crds := []*apiextensionsv1.CustomResourceDefinition{
-		mustLoadCRD(filepath.Join("..", "..", "config", "crd", "bases"), "vault.dis.altinn.cloud", vaultKind),
+		mustLoadCRD(filepath.Join("..", "..", "config", "crd", "bases"), "vault.dis.altinn.cloud", "Vault"),
 		mustLoadCRD(disIdentityCRDPath(), "application.dis.altinn.cloud", "ApplicationIdentity"),
-		mustLoadCRD(asoCRDPath(), "keyvault.azure.com", vaultKind),
+		mustLoadCRD(asoCRDPath(), "keyvault.azure.com", "Vault"),
 		mustLoadCRD(asoCRDPath(), "authorization.azure.com", "RoleAssignment"),
 		mustLoadCRD(externalSecretsCRDPath(), "external-secrets.io", "SecretStore"),
 	}

--- a/services/dis-vault-operator/internal/controller/testconst_test.go
+++ b/services/dis-vault-operator/internal/controller/testconst_test.go
@@ -7,10 +7,6 @@ const (
 	testLocation         = "westeurope"
 	testEnvironment      = "dev"
 	testAKSSubnetID      = "/subscriptions/sub-123/resourceGroups/rg-net/providers/Microsoft.Network/virtualNetworks/vnet/subnets/aks-1"
-	labelTeam            = "team"
-	teamPlatform         = "platform"
-	vaultKind            = "Vault"
-	ns                   = "default"
 	testVaultName        = "vault-sample"
 	testExistingVaultURI = "https://existing.vault.azure.net"
 )

--- a/services/dis-vault-operator/internal/controller/vault_controller_test.go
+++ b/services/dis-vault-operator/internal/controller/vault_controller_test.go
@@ -48,6 +48,8 @@ var _ = Describe("Vault controller", func() {
 		cancel  context.CancelFunc
 	)
 
+	const ns = "default"
+
 	cleanupNamespacedTestResources := func(ctx context.Context, namespace string) {
 		deleteAll := func(obj client.Object) {
 			Expect(k8sClient.DeleteAllOf(ctx, obj, client.InNamespace(namespace))).To(Succeed())
@@ -440,8 +442,8 @@ var _ = Describe("Vault controller", func() {
 		v := newVault("my-app-vault-propagation", "my-app-identity-propagation")
 		v.Spec.SKU = vaultv1alpha1.VaultSKUStandard
 		v.Spec.Tags = map[string]string{
-			labelTeam: "apps",
-			"remove":  "old-value",
+			"team":   "apps",
+			"remove": "old-value",
 		}
 		v.Spec.SoftDeleteRetentionDays = 7
 		v.Spec.PurgeProtectionEnabled = &initialPurgeProtection
@@ -465,8 +467,8 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(keyVault.Spec.Properties.EnablePurgeProtection).NotTo(BeNil())
 			g.Expect(*keyVault.Spec.Properties.EnablePurgeProtection).To(BeFalse())
 			g.Expect(keyVault.Spec.Tags).To(Equal(map[string]string{
-				labelTeam: "apps",
-				"remove":  "old-value",
+				"team":   "apps",
+				"remove": "old-value",
 			}))
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
@@ -477,8 +479,8 @@ var _ = Describe("Vault controller", func() {
 			updatedPurgeProtection := true
 			current.Spec.SKU = vaultv1alpha1.VaultSKUPremium
 			current.Spec.Tags = map[string]string{
-				labelTeam: teamPlatform,
-				"env":     "prod",
+				"team": "platform",
+				"env":  "prod",
 			}
 			current.Spec.SoftDeleteRetentionDays = 30
 			current.Spec.PurgeProtectionEnabled = &updatedPurgeProtection
@@ -508,8 +510,8 @@ var _ = Describe("Vault controller", func() {
 			g.Expect(keyVault.Spec.Properties.EnablePurgeProtection).NotTo(BeNil())
 			g.Expect(*keyVault.Spec.Properties.EnablePurgeProtection).To(BeTrue())
 			g.Expect(keyVault.Spec.Tags).To(Equal(map[string]string{
-				labelTeam: teamPlatform,
-				"env":     "prod",
+				"team": "platform",
+				"env":  "prod",
 			}))
 			g.Expect(keyVault.Spec.Tags).NotTo(HaveKey("remove"))
 		}).WithTimeout(20 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
@@ -1100,7 +1102,7 @@ var _ = Describe("Vault controller", func() {
 		vaultObj := newVault(vaultName, identityName)
 		vaultObj.Spec.SKU = vaultv1alpha1.VaultSKUPremium
 		vaultObj.Spec.Tags = map[string]string{
-			labelTeam: teamPlatform,
+			"team": "platform",
 		}
 		vaultObj.Spec.SoftDeleteRetentionDays = 14
 		vaultObj.Spec.PurgeProtectionEnabled = &purgeProtectionEnabled
@@ -1130,7 +1132,7 @@ var _ = Describe("Vault controller", func() {
 				if ref.APIVersion != vaultv1alpha1.GroupVersion.String() {
 					continue
 				}
-				if ref.Kind != vaultKind || ref.Name != owner.Name || ref.UID != owner.UID {
+				if ref.Kind != "Vault" || ref.Name != owner.Name || ref.UID != owner.UID {
 					continue
 				}
 				if ref.Controller != nil && *ref.Controller {
@@ -1515,7 +1517,7 @@ func TestReconcileManagedSecretStoreReturnsCRDNotInstalledWhenSecretStoreCRDIsMi
 	vaultObj := &vaultv1alpha1.Vault{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       testVaultName,
-			Namespace:  ns,
+			Namespace:  "default",
 			Generation: 7,
 		},
 		Spec: vaultv1alpha1.VaultSpec{
@@ -1546,11 +1548,11 @@ func TestReconcileManagedConfigMapDeletesStaleOwnedConfigMaps(t *testing.T) {
 	vaultObj := &vaultv1alpha1.Vault{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: vaultv1alpha1.GroupVersion.String(),
-			Kind:       vaultKind,
+			Kind:       "Vault",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       testVaultName,
-			Namespace:  ns,
+			Namespace:  "default",
 			Generation: 9,
 			UID:        types.UID("vault-uid"),
 		},
@@ -1568,7 +1570,7 @@ func TestReconcileManagedConfigMapDeletesStaleOwnedConfigMaps(t *testing.T) {
 				vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(vaultObj, vaultv1alpha1.GroupVersion.WithKind(vaultKind)),
+				*metav1.NewControllerRef(vaultObj, vaultv1alpha1.GroupVersion.WithKind("Vault")),
 			},
 		},
 		Data: map[string]string{
@@ -1622,7 +1624,7 @@ func TestReconcileManagedConfigMapReturnsNameConflictForNonOwnedConfigMap(t *tes
 	vaultObj := &vaultv1alpha1.Vault{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       testVaultName,
-			Namespace:  ns,
+			Namespace:  "default",
 			Generation: 11,
 		},
 		Spec: vaultv1alpha1.VaultSpec{
@@ -1681,11 +1683,11 @@ func TestReconcileManagedConfigMapPreservesExistingVaultURIWhenStatusIsUnavailab
 	vaultObj := &vaultv1alpha1.Vault{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: vaultv1alpha1.GroupVersion.String(),
-			Kind:       vaultKind,
+			Kind:       "Vault",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       testVaultName,
-			Namespace:  ns,
+			Namespace:  "default",
 			Generation: 12,
 			UID:        types.UID("vault-uid"),
 		},
@@ -1703,7 +1705,7 @@ func TestReconcileManagedConfigMapPreservesExistingVaultURIWhenStatusIsUnavailab
 				vaultpkg.ManagedResourceComponentLabel: vaultpkg.ManagedConfigMapComponentValue,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(vaultObj, vaultv1alpha1.GroupVersion.WithKind(vaultKind)),
+				*metav1.NewControllerRef(vaultObj, vaultv1alpha1.GroupVersion.WithKind("Vault")),
 			},
 		},
 		Data: map[string]string{
@@ -1754,7 +1756,7 @@ func TestBuildNetworkPolicyCondition(t *testing.T) {
 	}
 
 	vaultObj := &vaultv1alpha1.Vault{
-		ObjectMeta: metav1.ObjectMeta{Name: testVaultName, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{Name: testVaultName, Namespace: "default"},
 		Spec: vaultv1alpha1.VaultSpec{
 			IdentityRef: &vaultv1alpha1.ApplicationIdentityRef{Name: "app-identity-sample"},
 		},


### PR DESCRIPTION
## Context

[#3615](https://github.com/Altinn/altinn-platform/pull/3615) was a Renovate digest bump that also carried a hand-added refactor extracting repeated test string literals into new `testconst_test.go` files to satisfy the `goconst` linter. Several extractions hurt readability and introduced cross-package naming drift. This PR addresses the lint complaint at its source and, in doing so, also fixes a local↔CI linter version drift it surfaced.

## Change 1 — scope `goconst` out of tests, revert low-value extractions

`goconst` (default settings, no test exclusion) flags any string literal repeated ≥3×. Applied to **test fixtures** it forced extractions that:
- **Hurt readability** — `"team"`/`"platform"`/`"default"`/`"Vault"` became `labelTeam`/`teamPlatform`/`ns`/`vaultKind` (jump-to-definition instead of a self-evident value at the assertion site).
- **Created cross-package naming drift** — `"vault-sample"` became `testVaultName` in the controller package but `testVaultSampleName` in the vault package, while `testVaultName` *also* already meant `"my-app-vault"` there.
- **Gave false safety** — `vaultKind = "Vault"` is a test-only constant duplicating a production literal (`cmd/main.go`, `internal/vault/builders.go`); they can drift independently.

Fix:
1. **Exclude `goconst` from `*_test.go`** in `.golangci.yml` — consistent with the existing `dupl` exclusion for `internal/*`.
2. **Revert** `vaultKind`→`"Vault"`, `labelTeam`→`"team"`, `teamPlatform`→`"platform"`, and restore `ns` to its original local `const` in the `Describe` block.
3. **Keep** the genuinely useful shared fixtures from #3615: `testAKSSubnetID`, the `OperatorConfig` values, `testExistingVaultURI`.

## Change 2 — align golangci-lint pin with CI (v2.11.3 → v2.12.2)

Running the AGENTS.md-required `make run-checks-ci-cache` surfaced a pre-existing drift: the Makefile pinned `golangci-lint v2.11.3` while CI (golangci-lint-action) and `dis-pgsql-operator` use **v2.12.2**. The older staticcheck in v2.11.3 emits **false-positive `SA5011`** ("possible nil pointer dereference") on the standard `if x == nil { t.Fatalf(...) }; use x` pattern (e.g. `internal/vault/builders_test.go`) because it doesn't model `t.Fatalf` as terminating — so the lint step failed locally while CI stayed green. Bumping the pin to v2.12.2 fixes it (verified: 0 issues across the module) and removes the local↔CI divergence.

## Validation

Ran the full repo-sanctioned sequence per [`services/dis-vault-operator/AGENTS.md`](https://github.com/Altinn/altinn-platform/blob/main/services/dis-vault-operator/AGENTS.md) — `make run-checks-ci-cache` (= `fmt-cache` → `generate-cache` → `manifests-cache` → `test-ci-cache` → `lint-cache`):
- `fmt` / `generate` / `manifests` — clean, no diff
- `test-ci` — full suite passes (envtest); coverage unchanged (config 88%, vault 70%)
- `lint` — **0 issues** under v2.12.2

All substitutions in Change 1 are value-preserving (each literal equals the constant it replaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite configuration and standardized test case setup.
  * Refactored test constants and namespace usage across test cases.
  * Adjusted test assertions and owner reference validation.

* **Chores**
  * Updated linter configuration to exclude specific validation rules for test files.
  * Upgraded build tool to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->