### PR TITLE
chore(claude): auto-bootstrap Go dev tooling on session start

### DIFF
--- a/.claude/hooks/setup-local-env.sh
+++ b/.claude/hooks/setup-local-env.sh
@@ -7,6 +7,16 @@
 set -u
 log() { printf '[setup-local-env] %s\n' "$*" >&2; }
 
+# Emit the one and only line on stdout: a SessionStart JSON object whose
+# `systemMessage` is shown to the user and whose `additionalContext` is injected
+# into the model's context. All other output goes to stderr, so only this is
+# surfaced. Args: $1=systemMessage, $2=additionalContext. Values are plain
+# service names/words (no quotes, backslashes, or newlines), so no JSON escaping
+# is needed and we avoid a jq dependency.
+emit_session_json() {
+  printf '{"systemMessage":"%s","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$1" "$2"
+}
+
 # Resolve the worktree/repo root, cwd-independent and worktree-aware.
 root="${CLAUDE_PROJECT_DIR:-}"
 if [ -z "${root}" ] || { [ ! -e "${root}/.git" ]; }; then
@@ -24,16 +34,28 @@ if ! mkdir "${lock}" 2>/dev/null; then log "bootstrap already running, skipping"
 trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
 
 shopt -s nullglob
-ran=0
+ran=0; ok=""; fail=""
 for mk in services/*/Makefile; do
   grep -qE '^setup-local-env:' "${mk}" || continue
-  svc="$(dirname "${mk}")"; ran=1
+  svc="$(dirname "${mk}")"; name="$(basename "${svc}")"; ran=1
   log "bootstrapping ${svc} …"
   if make -C "${svc}" setup-local-env >&2 2>&1; then
-    log "ok: ${svc}"
+    log "ok: ${svc}"; ok="${ok:+${ok}, }${name}"
   else
     log "WARNING: ${svc} bootstrap failed (continuing; rerun: make -C ${svc} setup-local-env)"
+    fail="${fail:+${fail}, }${name}"
   fi
 done
-[ "${ran}" -eq 0 ] && log "no services declare setup-local-env; nothing to do"
+
+if [ "${ran}" -eq 0 ]; then
+  log "no services declare setup-local-env; nothing to do"
+elif [ -z "${fail}" ]; then
+  emit_session_json \
+    "Dev tooling ready (auto-bootstrapped): ${ok}" \
+    "A SessionStart hook bootstrapped Go dev tooling for: ${ok}. make lint/test use the installed bin/ binaries, so no ad-hoc download is needed."
+else
+  emit_session_json \
+    "Dev tooling bootstrap finished with errors -- ok: [${ok:-none}], FAILED: [${fail}]" \
+    "A SessionStart hook ran. Bootstrapped: ${ok:-none}. Failed: ${fail}. Rerun 'make -C services/<svc> setup-local-env' for the failed ones before make lint/test."
+fi
 exit 0   # always succeed: SessionStart must never block the session

--- a/.claude/hooks/setup-local-env.sh
+++ b/.claude/hooks/setup-local-env.sh
@@ -15,7 +15,11 @@ fi
 cd "${root}" 2>/dev/null || { log "cannot cd to '${root}', skipping"; exit 0; }
 
 # Single-flight guard so parallel sessions don't double-bootstrap.
-lock="${root}/.git/.setup-local-env.lock"
+# Resolve the real git dir: in a linked worktree, "${root}/.git" is a
+# `gitdir:` pointer *file*, so a lock dir can't be created under it. Using the
+# resolved git dir also scopes the lock per worktree (each has its own bin/).
+gitdir="$(git rev-parse --git-dir 2>/dev/null || echo "${root}/.git")"
+lock="${gitdir}/.setup-local-env.lock"
 if ! mkdir "${lock}" 2>/dev/null; then log "bootstrap already running, skipping"; exit 0; fi
 trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
 

--- a/.claude/hooks/setup-local-env.sh
+++ b/.claude/hooks/setup-local-env.sh
@@ -2,20 +2,19 @@
 # Auto-bootstrap Go dev tooling for every service that declares `setup-local-env`,
 # so a fresh worktree is ready for `make lint`/`make test` without ad-hoc downloads.
 # Wired to the SessionStart (startup) hook in .claude/settings.json.
-# Idempotent (make skips installed tools), non-fatal (never blocks the session),
-# quiet (all output to stderr so nothing is injected into the model's context).
+#
+# NON-BLOCKING: the launcher detaches the work and returns immediately, so the
+# session opens without waiting; the bootstrap runs in a detached worker that
+# logs to <git-dir>/setup-local-env.log.
+# FAST: within each service the independent tools (kustomize, controller-gen,
+# golangci-lint, setup-envtest) are pre-built in parallel with `make -j`; the
+# service's own `setup-local-env` then runs as the authoritative finalizer (a
+# no-op for the now-installed tools), so behaviour stays identical to running it
+# directly while the slow compile (golangci-lint dominates) is parallelised.
+# Idempotent, non-fatal, single-flight (lock dir). Services run sequentially
+# because they share a root go.work that `make workspace` rewrites.
 set -u
 log() { printf '[setup-local-env] %s\n' "$*" >&2; }
-
-# Emit the one and only line on stdout: a SessionStart JSON object whose
-# `systemMessage` is shown to the user and whose `additionalContext` is injected
-# into the model's context. All other output goes to stderr, so only this is
-# surfaced. Args: $1=systemMessage, $2=additionalContext. Values are plain
-# service names/words (no quotes, backslashes, or newlines), so no JSON escaping
-# is needed and we avoid a jq dependency.
-emit_session_json() {
-  printf '{"systemMessage":"%s","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$1" "$2"
-}
 
 # Resolve the worktree/repo root, cwd-independent and worktree-aware.
 root="${CLAUDE_PROJECT_DIR:-}"
@@ -24,38 +23,47 @@ if [ -z "${root}" ] || { [ ! -e "${root}/.git" ]; }; then
 fi
 cd "${root}" 2>/dev/null || { log "cannot cd to '${root}', skipping"; exit 0; }
 
-# Single-flight guard so parallel sessions don't double-bootstrap.
-# Resolve the real git dir: in a linked worktree, "${root}/.git" is a
-# `gitdir:` pointer *file*, so a lock dir can't be created under it. Using the
-# resolved git dir also scopes the lock per worktree (each has its own bin/).
+# Resolve the real git dir (a real directory even in linked worktrees, where
+# "${root}/.git" is a `gitdir:` pointer file) for the lock and log paths.
 gitdir="$(git rev-parse --git-dir 2>/dev/null || echo "${root}/.git")"
 lock="${gitdir}/.setup-local-env.lock"
-if ! mkdir "${lock}" 2>/dev/null; then log "bootstrap already running, skipping"; exit 0; fi
-trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
+logfile="${gitdir}/setup-local-env.log"
 
-shopt -s nullglob
-ran=0; ok=""; fail=""
-for mk in services/*/Makefile; do
-  grep -qE '^setup-local-env:' "${mk}" || continue
-  svc="$(dirname "${mk}")"; name="$(basename "${svc}")"; ran=1
-  log "bootstrapping ${svc} …"
-  if make -C "${svc}" setup-local-env >&2 2>&1; then
-    log "ok: ${svc}"; ok="${ok:+${ok}, }${name}"
-  else
-    log "WARNING: ${svc} bootstrap failed (continuing; rerun: make -C ${svc} setup-local-env)"
-    fail="${fail:+${fail}, }${name}"
-  fi
-done
+# --- worker mode: the actual bootstrap, run detached in the background --------
+if [ "${1:-}" = "--worker" ]; then
+  # Single-flight: hold the lock for the worker's whole lifetime.
+  if ! mkdir "${lock}" 2>/dev/null; then log "bootstrap already running, skipping"; exit 0; fi
+  trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
 
-if [ "${ran}" -eq 0 ]; then
-  log "no services declare setup-local-env; nothing to do"
-elif [ -z "${fail}" ]; then
-  emit_session_json \
-    "Dev tooling ready (auto-bootstrapped): ${ok}" \
-    "A SessionStart hook bootstrapped Go dev tooling for: ${ok}. make lint/test use the installed bin/ binaries, so no ad-hoc download is needed."
-else
-  emit_session_json \
-    "Dev tooling bootstrap finished with errors -- ok: [${ok:-none}], FAILED: [${fail}]" \
-    "A SessionStart hook ran. Bootstrapped: ${ok:-none}. Failed: ${fail}. Rerun 'make -C services/<svc> setup-local-env' for the failed ones before make lint/test."
+  jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+  shopt -s nullglob
+  ran=0
+  for mk in services/*/Makefile; do
+    grep -qE '^setup-local-env:' "${mk}" || continue
+    svc="$(dirname "${mk}")"; ran=1
+    log "bootstrapping ${svc} (pre-build -j${jobs}) …"
+    # Best-effort parallel pre-build of the independent tool targets when the
+    # service uses the standard ones. Failures are ignored on purpose — the
+    # authoritative `make setup-local-env` below still runs and is the source of
+    # truth (so this can never skip a step the real target performs).
+    if grep -qE '^kustomize:' "${mk}" && grep -qE '^controller-gen:' "${mk}" \
+       && grep -qE '^golangci-lint:' "${mk}" && grep -qE '^setup-envtest:' "${mk}"; then
+      make -C "${svc}" -j"${jobs}" kustomize controller-gen golangci-lint setup-envtest >&2 2>&1 || true
+    fi
+    if make -C "${svc}" setup-local-env >&2 2>&1; then
+      log "ok: ${svc}"
+    else
+      log "WARNING: ${svc} bootstrap failed (rerun: make -C ${svc} setup-local-env)"
+    fi
+  done
+  [ "${ran}" -eq 0 ] && log "no services declare setup-local-env; nothing to do"
+  log "bootstrap complete"
+  exit 0
 fi
-exit 0   # always succeed: SessionStart must never block the session
+
+# --- launcher mode (what the hook invokes): detach the worker, return now -----
+[ -d "${lock}" ] && exit 0   # a bootstrap is already in flight; nothing to launch
+# Detach so the bootstrap survives the hook returning; worker output -> log file.
+nohup bash "$0" --worker </dev/null >"${logfile}" 2>&1 &
+disown 2>/dev/null || true
+exit 0   # return immediately: SessionStart must never block the session

--- a/.claude/hooks/setup-local-env.sh
+++ b/.claude/hooks/setup-local-env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Auto-bootstrap Go dev tooling for every service that declares `setup-local-env`,
+# so a fresh worktree is ready for `make lint`/`make test` without ad-hoc downloads.
+# Wired to the SessionStart (startup) hook in .claude/settings.json.
+# Idempotent (make skips installed tools), non-fatal (never blocks the session),
+# quiet (all output to stderr so nothing is injected into the model's context).
+set -u
+log() { printf '[setup-local-env] %s\n' "$*" >&2; }
+
+# Resolve the worktree/repo root, cwd-independent and worktree-aware.
+root="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "${root}" ] || { [ ! -e "${root}/.git" ]; }; then
+  root="$(git rev-parse --show-toplevel 2>/dev/null || echo "${PWD}")"
+fi
+cd "${root}" 2>/dev/null || { log "cannot cd to '${root}', skipping"; exit 0; }
+
+# Single-flight guard so parallel sessions don't double-bootstrap.
+lock="${root}/.git/.setup-local-env.lock"
+if ! mkdir "${lock}" 2>/dev/null; then log "bootstrap already running, skipping"; exit 0; fi
+trap 'rmdir "${lock}" 2>/dev/null || true' EXIT
+
+shopt -s nullglob
+ran=0
+for mk in services/*/Makefile; do
+  grep -qE '^setup-local-env:' "${mk}" || continue
+  svc="$(dirname "${mk}")"; ran=1
+  log "bootstrapping ${svc} …"
+  if make -C "${svc}" setup-local-env >&2 2>&1; then
+    log "ok: ${svc}"
+  else
+    log "WARNING: ${svc} bootstrap failed (continuing; rerun: make -C ${svc} setup-local-env)"
+  fi
+done
+[ "${ran}" -eq 0 ] && log "no services declare setup-local-env; nothing to do"
+exit 0   # always succeed: SessionStart must never block the session

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/setup-local-env.sh\"",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds a **`SessionStart` (startup) hook** that auto-bootstraps Go dev tooling for every service declaring a `setup-local-env` target, so a **fresh git worktree is ready for `make lint`/`make test` without an ad-hoc, mid-task download** of the pinned `golangci-lint` / `setup-envtest` / `kustomize` / `controller-gen`.

This emulates, for Claude Code, what Codex got automatically on environment creation — now **shared across the whole team** via `git pull` (no per-developer setup).

Two new files at the repo root:
- **`.claude/hooks/setup-local-env.sh`** — for every `services/*/Makefile` declaring `^setup-local-env:`, bootstraps that service. Auto-detects **`dis-vault-operator`** + **`dis-pgsql-operator`** today; new services are picked up automatically once they add the target.
- **`.claude/settings.json`** — registers the script on `SessionStart` with `matcher: "startup"` (fires on a fresh session start only — not resume/clear/compact).

## How it behaves

- **Non-blocking.** The hook detaches a background worker and returns immediately, so the session opens without waiting on the install. The worker logs to `<git-dir>/setup-local-env.log`.
- **Parallelised (interim).** Within each service the independent tool targets (`kustomize`, `controller-gen`, `golangci-lint`, `setup-envtest`) are pre-built with `make -j`, then the service's own `setup-local-env` runs as the **authoritative finalizer** (a no-op once tools are installed) — so behaviour stays identical to running it directly, with no Makefile changes and no step drift. Measured cold: ~47s → ~16s per service.
- **Sequential across services**, because they share a root `go.work` that `make workspace` rewrites (concurrent writes would corrupt it). Full cold run for both services: ~48s, in the background.
- **Idempotent** (`make` skips installed tools), **non-fatal** (always exits 0 — never blocks the session), **single-flight** (a per-worktree lock dir), and **version-agnostic** (each service uses its own pins; nothing is hardcoded).
- **Quiet.** No stdout — nothing is injected into the model's context.

> **Interim note for reviewers:** the per-service loop + parallel pre-build is a stopgap. Once the planned **common root Makefile** handles the tool targets as proper prerequisites, this hook should simplify to delegating to a single root `make setup-local-env` (or `make -j`), and the pre-build hack can be removed.

## Validated end-to-end (macOS desktop app)

Confirmed in a real fresh worktree session:
- ✅ Hook fires on `SessionStart` and resolves the **worktree** root (lock + tools land in the worktree, not the main checkout).
- ✅ **Non-blocking** — the session opened and was interactive while the worker bootstrapped in the background.
- ✅ Both operators bootstrapped → `bootstrap complete`, lock released, worker exited; `git status` clean (artifacts gitignored).
- ✅ `make lint` uses the installed pinned binary with no download.

## Team rollout notes

- The prompt teammates see is Claude Code's **per-directory trust dialog**, not a per-hook "approve this hook?" prompt:
  - A teammate opening the repo for the **first time** (untrusted dir) sees the trust dialog; accepting it covers the hook.
  - A teammate who **already trusts** the repo typically sees **no prompt** — the hook simply starts running at session start after they pull. (Worth knowing so a background bootstrap on a new worktree isn't surprising.)
- **Opt out locally** by removing/overriding the hook in `.claude/settings.local.json`.

## Out of scope (noted, not done here)

- A **common root Makefile** to centralise dependency/parallelism handling (planned separately) — this hook will simplify once it lands.
- Adding `setup-local-env` to services that lack it (`dis-apim-operator`, `dis-identity-operator`, `lakmus`) — auto-detected once they have the target.
- Reconciling the `golangci-lint` version drift between Makefile pins and CI's `golangci-lint-action` — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
