### PR TITLE
feat(dis-pgsql-operator): publish connection ConfigMap per access principal

### DIFF
--- a/rfcs/0013-multitenant-dis-databases.md
+++ b/rfcs/0013-multitenant-dis-databases.md
@@ -145,7 +145,9 @@ When `dis-pgsql` reconciles it, it:
 4. creates the PostgreSQL database
 5. resolves `identityRef` values and maps existing Entra groups
 6. grants access through operator-managed PostgreSQL roles
-7. writes status
+7. publishes a connection ConfigMap per service-identity principal once the
+   database and access are ready (see [Connection details](#connection-details))
+8. writes status
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -179,6 +181,10 @@ Status should include:
 - conditions: `Ready`, `DatabaseReady`, `AccessReady`
 - `observedGeneration`
 - validation errors
+
+The connection ConfigMaps (see [Connection details](#connection-details)) add no
+new status condition: they are published on the same path that sets `Ready`, and
+a failure to publish keeps `Ready=False`.
 
 ## Reconciliation
 
@@ -223,6 +229,37 @@ reader, writer, and owner. It grants access by role membership:
 The operator reconciles membership in its managed reader/writer/owner roles,
 including removing principals when removed from `spec.access.principals`. It
 does not drop Entra principals or revoke unrelated/manual grants.
+
+## Connection details
+
+The connection coordinates an app needs (host, port, database name, the Postgres
+user it authenticates as) are only known after the Azure resources exist and the
+operator reports the `Database` ready. The runtime connection step above relies
+on the app discovering those coordinates; `dis-pgsql` publishes them as
+non-secret ConfigMaps rather than requiring app teams to scrape `status`. This
+mirrors the pattern `dis-vault` already uses for Key Vault coordinates.
+
+The operator publishes one ConfigMap per `identityRef` (service-identity) access
+principal once the `Database` is ready. `group` principals get none (no single
+app consumer). Each ConfigMap:
+
+- is named `<database.metadata.name>-<identityRef.name>-dis-pgsql`, sanitized to
+  a valid DNS-1123 name and hash-suffixed if it would exceed 63 characters. The
+  name is a pure function of values known at authoring time, so a consumer can
+  derive it before the database is deployed.
+- carries CloudNativePG-style keys: `host`, `port`, `dbname`, `user` (the
+  resolved managed identity / Postgres role), `sslmode` (`require`), and a
+  passwordless `uri`. It holds **no password / pgpass** — authentication is Entra
+  token based, so the ConfigMap is non-secret.
+- carries labels `pgsql.dis.altinn.cloud/database`,
+  `pgsql.dis.altinn.cloud/principal`, and
+  `pgsql.dis.altinn.cloud/component=connection`. These labels are the stable
+  binding contract: a consumer (or a future `DisApp` kro resource graph, which
+  should consume DB connectivity with no knowledge of platform internals) can
+  select the ConfigMap by label even when the name is hash-suffixed.
+
+The ConfigMap is owned by the `Database`, so it is garbage-collected on delete
+and pruned when its principal is removed from `spec.access.principals`.
 
 ## Networking
 

--- a/services/dis-pgsql-operator/README.md
+++ b/services/dis-pgsql-operator/README.md
@@ -24,6 +24,58 @@ Dedicated and multitenant layouts use the same APIs:
 - Dedicated: one `Database` per `DatabaseServer`.
 - Multitenant: many `Database` resources on one shared `DatabaseServer`.
 
+## Connection ConfigMaps
+
+Once a `Database` is fully ready (its Azure resources exist and access has been
+provisioned), the operator publishes one **non-secret** ConfigMap per
+service-identity access principal so consuming apps can read the connection
+coordinates declaratively. Access principals declared as Entra `group`s do not
+get a ConfigMap (there is no single app consumer).
+
+The ConfigMap name is derivable before the database is deployed, from values
+known at authoring time:
+
+```
+<database.metadata.name>-<identityRef.name>-dis-pgsql
+```
+
+The name is lowercased/sanitized to a valid DNS-1123 name. If it would exceed 63
+characters it is truncated and given a deterministic hash suffix — in that case,
+select the ConfigMap by labels rather than recomputing the name.
+
+Data keys (CloudNativePG-style):
+
+| key       | value                                                              |
+|-----------|--------------------------------------------------------------------|
+| `host`    | PostgreSQL server FQDN                                              |
+| `port`    | `5432`                                                             |
+| `dbname`  | database name                                                      |
+| `user`    | the resolved managed-identity / Postgres role the app connects as  |
+| `sslmode` | `require`                                                          |
+| `uri`     | `postgresql://<user>@<host>:<port>/<dbname>?sslmode=require`        |
+
+There is **no password / pgpass** key: authentication is Entra (Azure AD) token
+based, so the ConfigMap holds no secrets.
+
+Labels (the binding contract; a consumer or a kro resource graph can select on
+these even when the name is hash-suffixed):
+
+- `pgsql.dis.altinn.cloud/database`: the `Database` name
+- `pgsql.dis.altinn.cloud/principal`: the `identityRef.name`
+- `pgsql.dis.altinn.cloud/component`: `connection`
+
+The ConfigMap is owned by the `Database`, so it is garbage-collected when the
+`Database` is deleted, and removed when its principal is dropped from
+`spec.access.principals`.
+
+Apps can consume it directly with `envFrom`:
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: <database>-<identityRef>-dis-pgsql
+```
+
 ## Getting Started
 
 ### Prerequisites

--- a/services/dis-pgsql-operator/config/rbac/role.yaml
+++ b/services/dis-pgsql-operator/config/rbac/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - application.dis.altinn.cloud
   resources:
   - applicationidentities

--- a/services/dis-pgsql-operator/internal/connection/configmap.go
+++ b/services/dis-pgsql-operator/internal/connection/configmap.go
@@ -1,0 +1,115 @@
+// Package connection renders the non-secret ConfigMaps that the operator
+// publishes so consuming apps can read PostgreSQL connection coordinates.
+package connection
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
+	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/naming"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	configMapSuffix   = "dis-pgsql"
+	configMapMaxLen   = 63
+	configMapFallback = "db"
+
+	// CNPG-style lowercase data keys.
+	DataKeyHost    = "host"
+	DataKeyPort    = "port"
+	DataKeyDBName  = "dbname"
+	DataKeyUser    = "user"
+	DataKeySSLMode = "sslmode"
+	DataKeyURI     = "uri"
+
+	// SSLModeRequire is the only sslmode the operator publishes; Azure
+	// PostgreSQL Flexible Server enforces TLS.
+	SSLModeRequire = "require"
+
+	// LabelDatabase, LabelPrincipal and LabelComponent form the binding
+	// contract a consumer (or a kro resource graph) selects on.
+	LabelDatabase  = "pgsql.dis.altinn.cloud/database"
+	LabelPrincipal = "pgsql.dis.altinn.cloud/principal"
+	LabelComponent = "pgsql.dis.altinn.cloud/component"
+	ComponentValue = "connection"
+)
+
+// Coordinates is the resolved, non-secret connection input for one
+// service-identity principal's ConfigMap.
+type Coordinates struct {
+	// Host is the PostgreSQL server FQDN (database.Status.Host).
+	Host string
+	// Port is the PostgreSQL server port (database.Status.Port).
+	Port int32
+	// DBName is the PostgreSQL database name (database.Status.DatabaseName).
+	DBName string
+	// User is the resolved managed-identity name the app authenticates as
+	// (ApplicationIdentity.Status.ManagedIdentityName). It may differ from
+	// IdentityRef.
+	User string
+	// IdentityRef is the spec principal identityRef.name. It drives the
+	// ConfigMap name and the principal label, and is known at authoring time.
+	IdentityRef string
+}
+
+// DeterministicConfigMapName returns the ConfigMap name for a database/principal
+// pair. It is a pure function of values known before the database is deployed
+// (database.metadata.name and identityRef.name), so a consumer can derive it up
+// front. The name is "<database>-<identityRef>-dis-pgsql", sanitized to be a
+// valid DNS-1123 name and hash-suffixed when it would exceed 63 characters.
+func DeterministicConfigMapName(databaseName, identityRefName string) string {
+	base := naming.SanitizeLowerHyphen(databaseName + "-" + identityRefName)
+	if base == "" {
+		base = configMapFallback
+	}
+
+	full := base + "-" + configMapSuffix
+	if len(full) <= configMapMaxLen {
+		return full
+	}
+
+	hash := naming.StableSHA256Hex(base)[:8]
+	return naming.WithRequiredSuffix(base, "-"+configMapSuffix+"-"+hash, configMapMaxLen, configMapFallback)
+}
+
+// BuildConnectionConfigMap renders the desired (un-owned) ConfigMap for one
+// principal. The caller is responsible for setting the controller owner
+// reference before persisting it.
+func BuildConnectionConfigMap(database *storagev1alpha1.Database, coords Coordinates) (*corev1.ConfigMap, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database must not be nil")
+	}
+	if strings.TrimSpace(coords.IdentityRef) == "" {
+		return nil, fmt.Errorf("coords.IdentityRef must not be empty")
+	}
+
+	port := strconv.Itoa(int(coords.Port))
+	uri := fmt.Sprintf(
+		"postgresql://%s@%s:%s/%s?sslmode=%s",
+		coords.User, coords.Host, port, coords.DBName, SSLModeRequire,
+	)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeterministicConfigMapName(database.Name, coords.IdentityRef),
+			Namespace: database.Namespace,
+			Labels: map[string]string{
+				LabelDatabase:  database.Name,
+				LabelPrincipal: coords.IdentityRef,
+				LabelComponent: ComponentValue,
+			},
+		},
+		Data: map[string]string{
+			DataKeyHost:    coords.Host,
+			DataKeyPort:    port,
+			DataKeyDBName:  coords.DBName,
+			DataKeyUser:    coords.User,
+			DataKeySSLMode: SSLModeRequire,
+			DataKeyURI:     uri,
+		},
+	}, nil
+}

--- a/services/dis-pgsql-operator/internal/connection/configmap_test.go
+++ b/services/dis-pgsql-operator/internal/connection/configmap_test.go
@@ -1,0 +1,142 @@
+package connection
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	testDB       = "appdb"
+	testIdentity = "payments-api"
+	testHost     = "appdb-srv.postgres.database.azure.com"
+)
+
+func TestDeterministicConfigMapName(t *testing.T) {
+	t.Parallel()
+
+	got := DeterministicConfigMapName("router", "myproduct-router-dev")
+	want := "router-myproduct-router-dev-dis-pgsql"
+	if got != want {
+		t.Fatalf("DeterministicConfigMapName() = %q, want %q", got, want)
+	}
+}
+
+func TestDeterministicConfigMapNameOverflow(t *testing.T) {
+	t.Parallel()
+
+	db := strings.Repeat("very-long-database-name-", 3)
+	ref := strings.Repeat("very-long-identity-name-", 3)
+
+	got := DeterministicConfigMapName(db, ref)
+	got2 := DeterministicConfigMapName(db, ref)
+
+	if got != got2 {
+		t.Fatalf("expected deterministic output, got %q and %q", got, got2)
+	}
+	if len(got) > configMapMaxLen {
+		t.Fatalf("expected name length <= %d, got %d for %q", configMapMaxLen, len(got), got)
+	}
+	if !strings.Contains(got, "-"+configMapSuffix+"-") {
+		t.Fatalf("expected hashed dis-pgsql suffix, got %q", got)
+	}
+	if errs := validation.IsDNS1123Subdomain(got); len(errs) > 0 {
+		t.Fatalf("expected DNS-1123 compliant name, got %q: %v", got, errs)
+	}
+}
+
+func TestDeterministicConfigMapNameDistinct(t *testing.T) {
+	t.Parallel()
+
+	// Distinct (database, identity) pairs must not collide, including in the
+	// hashed overflow case.
+	long := strings.Repeat("x", 60)
+	pairs := [][2]string{
+		{testDB, testIdentity},
+		{testDB, "analytics"},
+		{"other", testIdentity},
+		{long, testIdentity},
+		{long, "analytics"},
+	}
+
+	seen := map[string]string{}
+	for _, p := range pairs {
+		name := DeterministicConfigMapName(p[0], p[1])
+		key := fmt.Sprintf("%s/%s", p[0], p[1])
+		if other, ok := seen[name]; ok {
+			t.Fatalf("name collision %q between %q and %q", name, other, key)
+		}
+		seen[name] = key
+	}
+}
+
+func TestBuildConnectionConfigMap(t *testing.T) {
+	t.Parallel()
+
+	database := &storagev1alpha1.Database{}
+	database.Name = testDB
+	database.Namespace = "team-a"
+
+	const user = "payments-api-mi" // resolved managed identity name (differs from IdentityRef)
+	coords := Coordinates{
+		Host:        testHost,
+		Port:        5432,
+		DBName:      testDB,
+		User:        user,
+		IdentityRef: testIdentity,
+	}
+
+	cm, err := BuildConnectionConfigMap(database, coords)
+	if err != nil {
+		t.Fatalf("BuildConnectionConfigMap() error: %v", err)
+	}
+
+	if want := DeterministicConfigMapName(testDB, testIdentity); cm.Name != want {
+		t.Fatalf("name = %q, want %q", cm.Name, want)
+	}
+	if cm.Namespace != "team-a" {
+		t.Fatalf("namespace = %q, want %q", cm.Namespace, "team-a")
+	}
+
+	wantLabels := map[string]string{
+		LabelDatabase:  testDB,
+		LabelPrincipal: testIdentity,
+		LabelComponent: ComponentValue,
+	}
+	for k, want := range wantLabels {
+		if got := cm.Labels[k]; got != want {
+			t.Fatalf("label %q = %q, want %q", k, got, want)
+		}
+	}
+
+	wantData := map[string]string{
+		DataKeyHost:    testHost,
+		DataKeyPort:    "5432",
+		DataKeyDBName:  testDB,
+		DataKeyUser:    user,
+		DataKeySSLMode: SSLModeRequire,
+		DataKeyURI:     fmt.Sprintf("postgresql://%s@%s:5432/%s?sslmode=require", user, testHost, testDB),
+	}
+	for k, want := range wantData {
+		if got := cm.Data[k]; got != want {
+			t.Fatalf("data %q = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestBuildConnectionConfigMapValidation(t *testing.T) {
+	t.Parallel()
+
+	if _, err := BuildConnectionConfigMap(nil, Coordinates{IdentityRef: "x"}); err == nil {
+		t.Fatalf("expected error for nil database")
+	}
+
+	database := &storagev1alpha1.Database{}
+	database.Name = testDB
+	if _, err := BuildConnectionConfigMap(database, Coordinates{IdentityRef: "  "}); err == nil {
+		t.Fatalf("expected error for empty IdentityRef")
+	}
+}

--- a/services/dis-pgsql-operator/internal/controller/database_controller.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller.go
@@ -9,6 +9,7 @@ import (
 
 	identityv1alpha1 "github.com/Altinn/altinn-platform/services/dis-identity-operator/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ type DatabaseReconciler struct {
 // +kubebuilder:rbac:groups=dbforpostgresql.azure.com,resources=flexibleserversdatabases/status,verbs=get
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("database", req.NamespacedName)
@@ -561,6 +563,7 @@ func (r *DatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&storagev1alpha1.Database{}).
 		Owns(&dbforpostgresqlv1.FlexibleServersDatabase{}).
 		Owns(&batchv1.Job{}).
+		Owns(&corev1.ConfigMap{}).
 		Watches(&storagev1alpha1.DatabaseServer{}, handler.EnqueueRequestsFromMapFunc(r.mapDatabaseServerToDatabases)).
 		Watches(&identityv1alpha1.ApplicationIdentity{}, handler.EnqueueRequestsFromMapFunc(r.mapApplicationIdentityToDatabases)).
 		WithOptions(controller.Options{

--- a/services/dis-pgsql-operator/internal/controller/database_controller_access_job.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_access_job.go
@@ -7,6 +7,7 @@ import (
 
 	identityv1alpha1 "github.com/Altinn/altinn-platform/services/dis-identity-operator/api/v1alpha1"
 	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
+	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/connection"
 	dbUtil "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/database"
 	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/naming"
 	"github.com/go-logr/logr"
@@ -40,7 +41,7 @@ func (r *DatabaseReconciler) ensureDatabaseAccess(
 		return false, databaseReasonProvisioning, "Waiting for DatabaseServer admin identity", nil
 	}
 
-	accessPrincipals, requeue, message, err := r.resolveDatabaseAccessPrincipals(ctx, logger, database)
+	accessPrincipals, serviceConnections, requeue, message, err := r.resolveDatabaseAccessPrincipals(ctx, logger, database)
 	if err != nil {
 		return false, "", "", err
 	}
@@ -71,18 +72,40 @@ func (r *DatabaseReconciler) ensureDatabaseAccess(
 		return false, "", "", err
 	}
 	if complete {
+		coords := make([]connection.Coordinates, 0, len(serviceConnections))
+		for _, sc := range serviceConnections {
+			coords = append(coords, connection.Coordinates{
+				Host:        database.Status.Host,
+				Port:        database.Status.Port,
+				DBName:      database.Status.DatabaseName,
+				User:        sc.ManagedIdentityName,
+				IdentityRef: sc.IdentityRef,
+			})
+		}
+		if err := r.reconcileConnectionConfigMaps(ctx, database, coords); err != nil {
+			return false, "", "", err
+		}
 		return true, databaseReasonReady, "Database access is ready", nil
 	}
 
 	return false, databaseReasonProvisioning, "Database access provisioning job is running", nil
 }
 
+// resolvedServiceConnection pairs a service principal's spec identityRef.name
+// (known at authoring time; drives the connection ConfigMap name and principal
+// label) with the resolved managed-identity name the app authenticates as.
+type resolvedServiceConnection struct {
+	IdentityRef         string
+	ManagedIdentityName string
+}
+
 func (r *DatabaseReconciler) resolveDatabaseAccessPrincipals(
 	ctx context.Context,
 	logger logr.Logger,
 	database *storagev1alpha1.Database,
-) ([]dbUtil.AccessPrincipal, bool, string, error) {
+) ([]dbUtil.AccessPrincipal, []resolvedServiceConnection, bool, string, error) {
 	accessPrincipals := make([]dbUtil.AccessPrincipal, 0, len(database.Spec.Access.Principals))
+	serviceConnections := make([]resolvedServiceConnection, 0, len(database.Spec.Access.Principals))
 	seen := map[string]struct{}{}
 
 	for _, principal := range database.Spec.Access.Principals {
@@ -112,15 +135,15 @@ func (r *DatabaseReconciler) resolveDatabaseAccessPrincipals(
 		if err := r.Get(ctx, types.NamespacedName{Name: refName, Namespace: database.Namespace}, &appIdentity); err != nil {
 			if apierrors.IsNotFound(err) {
 				logger.Info("ApplicationIdentity for Database access not found yet", "name", refName)
-				return nil, true, fmt.Sprintf("Waiting for ApplicationIdentity %q", refName), nil
+				return nil, nil, true, fmt.Sprintf("Waiting for ApplicationIdentity %q", refName), nil
 			}
-			return nil, false, "", fmt.Errorf("get ApplicationIdentity %s/%s: %w", database.Namespace, refName, err)
+			return nil, nil, false, "", fmt.Errorf("get ApplicationIdentity %s/%s: %w", database.Namespace, refName, err)
 		}
 
 		ready, readyFound := applicationIdentityReady(&appIdentity)
 		if readyFound && !ready {
 			logger.Info("ApplicationIdentity for Database access not ready yet", "name", refName)
-			return nil, true, fmt.Sprintf("Waiting for ApplicationIdentity %q to be ready", refName), nil
+			return nil, nil, true, fmt.Sprintf("Waiting for ApplicationIdentity %q to be ready", refName), nil
 		}
 
 		var managedIdentityName string
@@ -133,7 +156,7 @@ func (r *DatabaseReconciler) resolveDatabaseAccessPrincipals(
 		}
 		if managedIdentityName == "" || principalID == "" {
 			logger.Info("ApplicationIdentity for Database access status not populated yet", "name", refName)
-			return nil, true, fmt.Sprintf("Waiting for ApplicationIdentity %q status", refName), nil
+			return nil, nil, true, fmt.Sprintf("Waiting for ApplicationIdentity %q status", refName), nil
 		}
 
 		accessPrincipal := dbUtil.AccessPrincipal{
@@ -148,12 +171,16 @@ func (r *DatabaseReconciler) resolveDatabaseAccessPrincipals(
 		}
 		seen[key] = struct{}{}
 		accessPrincipals = append(accessPrincipals, accessPrincipal)
+		serviceConnections = append(serviceConnections, resolvedServiceConnection{
+			IdentityRef:         refName,
+			ManagedIdentityName: managedIdentityName,
+		})
 	}
 
 	if len(accessPrincipals) == 0 {
-		return nil, false, "", fmt.Errorf("database access principal resolution produced no principals")
+		return nil, nil, false, "", fmt.Errorf("database access principal resolution produced no principals")
 	}
-	return accessPrincipals, false, "", nil
+	return accessPrincipals, serviceConnections, false, "", nil
 }
 
 func databaseAccessPayloadRole(role storagev1alpha1.DatabaseAccessRole) dbUtil.AccessRole {

--- a/services/dis-pgsql-operator/internal/controller/database_controller_configmap.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_configmap.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	"context"
+
+	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
+	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/connection"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// reconcileConnectionConfigMaps upserts one connection ConfigMap per service
+// principal and deletes any stale ConfigMaps owned by this Database. It is
+// called only once the Database is ready, so the published coordinates are
+// always complete. A returned error blocks Ready and triggers a requeue.
+func (r *DatabaseReconciler) reconcileConnectionConfigMaps(
+	ctx context.Context,
+	database *storagev1alpha1.Database,
+	coords []connection.Coordinates,
+) error {
+	desiredNames := make(map[string]struct{}, len(coords))
+	for i := range coords {
+		desired, err := connection.BuildConnectionConfigMap(database, coords[i])
+		if err != nil {
+			return err
+		}
+		desiredNames[desired.Name] = struct{}{}
+		if err := r.upsertConnectionConfigMap(ctx, database, desired); err != nil {
+			return err
+		}
+	}
+
+	return r.cleanupStaleConnectionConfigMaps(ctx, database, desiredNames)
+}
+
+func (r *DatabaseReconciler) upsertConnectionConfigMap(
+	ctx context.Context,
+	owner *storagev1alpha1.Database,
+	desired *corev1.ConfigMap,
+) error {
+	current := &corev1.ConfigMap{}
+	current.SetName(desired.GetName())
+	current.SetNamespace(desired.GetNamespace())
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, current, func() error {
+		current.Labels = desired.Labels
+		current.Data = desired.Data
+		current.BinaryData = nil
+		return ctrl.SetControllerReference(owner, current, r.Scheme)
+	})
+	return err
+}
+
+// cleanupStaleConnectionConfigMaps deletes connection ConfigMaps that this
+// Database owns but no longer desires (a principal removed from spec or flipped
+// to a group). It lists by the component label and filters by owner reference,
+// so it never depends on the database label value being a legal (<=63 char)
+// label and never deletes a ConfigMap it does not own.
+func (r *DatabaseReconciler) cleanupStaleConnectionConfigMaps(
+	ctx context.Context,
+	owner *storagev1alpha1.Database,
+	desiredNames map[string]struct{},
+) error {
+	var configMaps corev1.ConfigMapList
+	if err := r.List(
+		ctx,
+		&configMaps,
+		client.InNamespace(owner.Namespace),
+		client.MatchingLabels{connection.LabelComponent: connection.ComponentValue},
+	); err != nil {
+		return err
+	}
+
+	for i := range configMaps.Items {
+		current := &configMaps.Items[i]
+		if _, ok := desiredNames[current.Name]; ok {
+			continue
+		}
+		if !metav1.IsControlledBy(current, owner) {
+			continue
+		}
+		if err := client.IgnoreNotFound(r.Delete(ctx, current)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -8,10 +8,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	identityv1alpha1 "github.com/Altinn/altinn-platform/services/dis-identity-operator/api/v1alpha1"
 	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
 	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/config"
+	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/connection"
 	dbUtil "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/database"
 	dbforpostgresqlv1 "github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v20250801"
 	networkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20240601"
@@ -198,6 +200,38 @@ var _ = Describe("DatabaseServer controller", func() {
 		return job
 	}
 
+	completeDatabaseAccessJob := func(ctx context.Context, job batchv1.Job) {
+		Eventually(func() error {
+			var accessJob batchv1.Job
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      job.Name,
+				Namespace: job.Namespace,
+			}, &accessJob); err != nil {
+				return err
+			}
+			now := metav1.Now()
+			accessJob.Status.StartTime = &now
+			accessJob.Status.CompletionTime = &now
+			accessJob.Status.Succeeded = 1
+			accessJob.Status.Conditions = []batchv1.JobCondition{
+				{
+					Type:               batchv1.JobSuccessCriteriaMet,
+					Status:             corev1.ConditionTrue,
+					Reason:             "Completed",
+					LastTransitionTime: now,
+				},
+				{
+					Type:               batchv1.JobComplete,
+					Status:             corev1.ConditionTrue,
+					Reason:             "Completed",
+					LastTransitionTime: now,
+				},
+			}
+			return k8sClient.Status().Update(ctx, &accessJob)
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+	}
+
 	createApplicationIdentity := func(ctx context.Context, name, managedName, principalID string) {
 		appIdentity := &identityv1alpha1.ApplicationIdentity{
 			ObjectMeta: metav1.ObjectMeta{
@@ -324,6 +358,14 @@ var _ = Describe("DatabaseServer controller", func() {
 		// this cleanup is draining the namespace.
 		deleteAll(&storagev1alpha1.Database{})
 		deleteAll(&storagev1alpha1.DatabaseServer{})
+
+		// envtest has no garbage collector, so owner-referenced connection
+		// ConfigMaps are not reclaimed when their Database is deleted. Remove
+		// them by label so they do not leak across specs.
+		Expect(k8sClient.DeleteAllOf(ctx, &corev1.ConfigMap{},
+			client.InNamespace(namespace),
+			client.MatchingLabels{connection.LabelComponent: connection.ComponentValue},
+		)).To(Succeed())
 
 		deleteAll(&batchv1.Job{})
 		deleteAll(&dbforpostgresqlv1.FlexibleServersDatabase{})
@@ -2794,35 +2836,7 @@ var _ = Describe("DatabaseServer controller", func() {
 
 		job := waitForDatabaseAccessJob(ctx, database.Name, database.Namespace)
 
-		Eventually(func() error {
-			var accessJob batchv1.Job
-			if err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      job.Name,
-				Namespace: job.Namespace,
-			}, &accessJob); err != nil {
-				return err
-			}
-			now := metav1.Now()
-			accessJob.Status.StartTime = &now
-			accessJob.Status.CompletionTime = &now
-			accessJob.Status.Succeeded = 1
-			accessJob.Status.Conditions = []batchv1.JobCondition{
-				{
-					Type:               batchv1.JobSuccessCriteriaMet,
-					Status:             corev1.ConditionTrue,
-					Reason:             "Completed",
-					LastTransitionTime: now,
-				},
-				{
-					Type:               batchv1.JobComplete,
-					Status:             corev1.ConditionTrue,
-					Reason:             "Completed",
-					LastTransitionTime: now,
-				},
-			}
-			return k8sClient.Status().Update(ctx, &accessJob)
-		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
-			Should(Succeed())
+		completeDatabaseAccessJob(ctx, job)
 
 		Eventually(func(g Gomega) metav1.ConditionStatus {
 			var updated storagev1alpha1.Database
@@ -2841,6 +2855,122 @@ var _ = Describe("DatabaseServer controller", func() {
 			return ready.Status
 		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).
 			Should(Equal(metav1.ConditionTrue))
+	})
+
+	It("publishes a connection ConfigMap for each service principal when the Database is ready", func() {
+		db := newSharedDatabaseServer("shared-db-conn-configmap")
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+		createApplicationIdentity(ctx, databaseAppIdentityRef, databaseAppManagedIdentity, databaseAppPrincipalID)
+
+		database := newDatabase("router-conn-configmap", db.Name)
+		Expect(k8sClient.Create(ctx, database)).To(Succeed())
+
+		Eventually(func(g Gomega) int {
+			return len(listDatabaseASOChildren(g, database.Name))
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).
+			Should(Equal(1))
+
+		markDatabaseASOReady(ctx, database)
+
+		job := waitForDatabaseAccessJob(ctx, database.Name, database.Namespace)
+
+		cmName := connection.DeterministicConfigMapName(database.Name, databaseAppIdentityRef)
+
+		// The ConfigMap is published only when the Database is fully ready, so
+		// it must not exist while the access Job is still running.
+		Consistently(func() error {
+			var cm corev1.ConfigMap
+			return k8sClient.Get(ctx, types.NamespacedName{Name: cmName, Namespace: database.Namespace}, &cm)
+		}).WithTimeout(2 * time.Second).WithPolling(250 * time.Millisecond).
+			ShouldNot(Succeed())
+
+		completeDatabaseAccessJob(ctx, job)
+
+		var cm corev1.ConfigMap
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: cmName, Namespace: database.Namespace}, &cm)
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).
+			Should(Succeed())
+
+		expectedHost := fmt.Sprintf("%s.postgres.database.azure.com", db.Name)
+		Expect(cm.Data[connection.DataKeyHost]).To(Equal(expectedHost))
+		Expect(cm.Data[connection.DataKeyPort]).To(Equal("5432"))
+		Expect(cm.Data[connection.DataKeyDBName]).To(Equal(database.Spec.Name))
+		// data.user is the resolved managed-identity name, not the identityRef name.
+		Expect(cm.Data[connection.DataKeyUser]).To(Equal(databaseAppManagedIdentity))
+		Expect(cm.Data[connection.DataKeySSLMode]).To(Equal(connection.SSLModeRequire))
+		Expect(cm.Data[connection.DataKeyURI]).To(Equal(fmt.Sprintf(
+			"postgresql://%s@%s:5432/%s?sslmode=require",
+			databaseAppManagedIdentity, expectedHost, database.Spec.Name,
+		)))
+
+		Expect(cm.Labels[connection.LabelDatabase]).To(Equal(database.Name))
+		Expect(cm.Labels[connection.LabelPrincipal]).To(Equal(databaseAppIdentityRef))
+		Expect(cm.Labels[connection.LabelComponent]).To(Equal(connection.ComponentValue))
+
+		Expect(metav1.IsControlledBy(&cm, database)).To(BeTrue())
+
+		// The group principal does not get a ConfigMap: exactly one is published
+		// for this Database.
+		var cms corev1.ConfigMapList
+		Expect(k8sClient.List(ctx, &cms,
+			client.InNamespace(database.Namespace),
+			client.MatchingLabels{
+				connection.LabelComponent: connection.ComponentValue,
+				connection.LabelDatabase:  database.Name,
+			},
+		)).To(Succeed())
+		Expect(cms.Items).To(HaveLen(1))
+	})
+
+	It("removes stale connection ConfigMaps it owns on the ready reconcile", func() {
+		db := newSharedDatabaseServer("shared-db-conn-stale")
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+		createApplicationIdentity(ctx, databaseAppIdentityRef, databaseAppManagedIdentity, databaseAppPrincipalID)
+
+		database := newDatabase("router-conn-stale", db.Name)
+		Expect(k8sClient.Create(ctx, database)).To(Succeed())
+
+		Eventually(func(g Gomega) int {
+			return len(listDatabaseASOChildren(g, database.Name))
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).
+			Should(Equal(1))
+
+		markDatabaseASOReady(ctx, database)
+
+		var owned storagev1alpha1.Database
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: database.Name, Namespace: database.Namespace}, &owned)).To(Succeed())
+
+		// Seed an operator-owned connection ConfigMap for a principal that is no
+		// longer desired; the ready reconcile must prune it.
+		staleName := connection.DeterministicConfigMapName(database.Name, "removed-principal")
+		stale := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      staleName,
+				Namespace: database.Namespace,
+				Labels: map[string]string{
+					connection.LabelDatabase:  database.Name,
+					connection.LabelPrincipal: "removed-principal",
+					connection.LabelComponent: connection.ComponentValue,
+				},
+			},
+			Data: map[string]string{connection.DataKeyHost: "stale"},
+		}
+		Expect(controllerutil.SetControllerReference(&owned, stale, k8sClient.Scheme())).To(Succeed())
+		Expect(k8sClient.Create(ctx, stale)).To(Succeed())
+
+		job := waitForDatabaseAccessJob(ctx, database.Name, database.Namespace)
+		completeDatabaseAccessJob(ctx, job)
+
+		wantName := connection.DeterministicConfigMapName(database.Name, databaseAppIdentityRef)
+		Eventually(func(g Gomega) {
+			var want corev1.ConfigMap
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wantName, Namespace: database.Namespace}, &want)).To(Succeed())
+
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: staleName, Namespace: database.Namespace}, &corev1.ConfigMap{})
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}).WithTimeout(15 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
 	})
 
 	It("recreates the Database access provisioning Job when the current Job is failed", func() {

--- a/services/dis-pgsql-operator/test/e2e/user_provision_test.go
+++ b/services/dis-pgsql-operator/test/e2e/user_provision_test.go
@@ -266,6 +266,43 @@ var _ = Describe("User provisioning", Ordered, func() {
 		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).
 			Should(Equal("True"))
 
+		By("verifying the connection ConfigMap is published for the app (service) principal")
+		connConfigMapName := fmt.Sprintf("%s-%s-dis-pgsql", databaseResourceName, databaseAppIdentity)
+		expectedURI := fmt.Sprintf(
+			"postgresql://%s@postgres.default.svc:5432/%s?sslmode=require",
+			databaseAppIdentity, expectedDatabaseName,
+		)
+		Eventually(func(g Gomega) {
+			get := func(jsonpath string) string {
+				cmd := exec.Command("kubectl", "get", "configmap", connConfigMapName, "-n", namespace, "-o", jsonpath)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				return strings.TrimSpace(output)
+			}
+			g.Expect(get("jsonpath={.data.host}")).To(Equal("postgres.default.svc"))
+			g.Expect(get("jsonpath={.data.port}")).To(Equal("5432"))
+			g.Expect(get("jsonpath={.data.dbname}")).To(Equal(expectedDatabaseName))
+			g.Expect(get("jsonpath={.data.user}")).To(Equal(databaseAppIdentity))
+			g.Expect(get("jsonpath={.data.sslmode}")).To(Equal("require"))
+			g.Expect(get("jsonpath={.data.uri}")).To(Equal(expectedURI))
+			g.Expect(get("jsonpath={.metadata.labels.pgsql\\.dis\\.altinn\\.cloud/principal}")).To(Equal(databaseAppIdentity))
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).
+			Should(Succeed())
+
+		By("verifying the Owner group principal did not get a ConfigMap")
+		Eventually(func(g Gomega) string {
+			cmd := exec.Command(
+				"kubectl", "get", "configmaps",
+				"-n", namespace,
+				"-l", "pgsql.dis.altinn.cloud/component=connection,pgsql.dis.altinn.cloud/database="+databaseResourceName,
+				"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}",
+			)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.TrimSpace(output)
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).
+			Should(Equal(connConfigMapName))
+
 		By("verifying app and owner roles exist in Postgres")
 		output := runPostgresQuery("SELECT 1 FROM pg_roles WHERE rolname = '" + databaseAppIdentity + "';")
 		Expect(strings.TrimSpace(output)).To(Equal("1"))
@@ -300,6 +337,19 @@ var _ = Describe("User provisioning", Ordered, func() {
 		runPostgresQuery(`DROP ROLE IF EXISTS "e2e-database-intruder"; CREATE ROLE "e2e-database-intruder" LOGIN;`)
 		_, err = runPostgresQueryAsUserInDatabase("e2e-database-intruder", expectedDatabaseName, "SELECT 1;")
 		Expect(err).To(HaveOccurred())
+
+		By("verifying the connection ConfigMap is garbage-collected when the Database is deleted")
+		deleteDatabaseAndProvisionJobs(databaseResourceName, namespace)
+		Eventually(func(g Gomega) string {
+			cmd := exec.Command(
+				"kubectl", "get", "configmap", connConfigMapName,
+				"-n", namespace, "--ignore-not-found", "-o", "name",
+			)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.TrimSpace(output)
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).
+			Should(BeEmpty())
 	})
 
 	It("re-provisions without revoking the connecting admin (regression for SQLSTATE 2BP01)", func() {


### PR DESCRIPTION
## What

The operator now publishes a **non-secret** ConfigMap for each service-identity access principal of a `Database`, once the database is fully ready. Consuming apps read their connection coordinates declaratively (e.g. `envFrom`) instead of scraping `Database.status`. This mirrors the existing `dis-vault-operator` published-ConfigMap pattern.

## Design

- **One ConfigMap per `identityRef` principal.** `group` principals are skipped (no single app consumer).
- **Name is derivable before the DB is deployed**, from values known at authoring time: `<database.metadata.name>-<identityRef.name>-dis-pgsql` (sanitized to DNS-1123, hash-suffixed on >63-char overflow).
- **CNPG-style keys**: `host`, `port`, `dbname`, `user`, `sslmode` (`require`), `uri`. **No password / pgpass** — auth is Entra (Azure AD) token based, so the ConfigMap holds no secrets.
- `data.user` is the resolved managed-identity name (the Postgres role), which can differ from `identityRef.name`. The name/label use `identityRef.name`; the `user` value uses `ApplicationIdentity.status.managedIdentityName`.
- **Labels** `pgsql.dis.altinn.cloud/{database,principal,component=connection}` are the stable binding contract — selectable even when the name is hash-suffixed (intended for the future `DisApp`/kro abstraction).
- **Published only when the Database is `Ready`** (host known + access provisioning Job complete). A publish failure blocks `Ready` and requeues — no new status condition.
- **Owned by the Database**: garbage-collected on delete, and pruned (owner-ref + `component` label) when a principal is removed or flipped to a group.

## Implementation

- `internal/connection/configmap.go` — pure builder + deterministic name (reuses `internal/naming`).
- `internal/controller/database_controller_configmap.go` — upsert (`CreateOrUpdate` + owner-ref) and stale cleanup.
- `database_controller_access_job.go` — resolution carries `identityRef.name`; publishes in the access-ready path.
- `database_controller.go` — `Owns(&corev1.ConfigMap{})`, `configmaps` RBAC marker (regenerated into `config/rbac/role.yaml`).

## Docs

README "Connection ConfigMaps" section and RFC 0013 (reconcile step, Status note, new "Connection details" subsection).

## Verification

- `make run-checks-ci` — fmt/generate/manifests/test-ci all pass; `make lint` clean.
- `make test` (envtest) — **52/52** green, including new specs: publish-on-ready with correct contents/labels/owner-ref + group skipped, and stale-ConfigMap pruning.
- Kind e2e (`test/e2e`) — assertions added (contents/labels, group-skipped, GC-on-delete); the deployed operator gets the new `configmaps` RBAC via `config/rbac`. Runs in PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)