### PR TITLE
fix(tf-azdev-agent): suppress Go stdlib CVE-2026-39823/39825/39826 in trivyignore

### DIFF
--- a/infrastructure/images/terraform-azure-devops-agent/.trivyignore
+++ b/infrastructure/images/terraform-azure-devops-agent/.trivyignore
@@ -32,6 +32,13 @@ CVE-2026-39820
 CVE-2026-39836
 # https://avd.aquasec.com/nvd/cve-2026-42499
 CVE-2026-42499
+# golang library vulnerabilities in kubectl/helm binaries - will be resolved when upstream tools rebuild with fixed dependencies
+# https://avd.aquasec.com/nvd/cve-2026-39823
+CVE-2026-39823
+# https://avd.aquasec.com/nvd/cve-2026-39825
+CVE-2026-39825
+# https://avd.aquasec.com/nvd/cve-2026-39826
+CVE-2026-39826
 # containerd vulnerability - will be resolved when base image updates containerd
 # https://avd.aquasec.com/nvd/cve-2026-46680
 CVE-2026-46680


### PR DESCRIPTION
## Summary

- Trivy scan [failed](https://github.com/Altinn/altinn-platform/actions/runs/26623098498) with 3 new HIGH vulnerabilities in `stdlib` v1.26.2 embedded in `kubectl`/`helm` binaries
- CVE-2026-39823, CVE-2026-39825, CVE-2026-39826 — all fixed in Go 1.26.3, but kubectl/helm have not yet released builds using the fixed Go version
- Suppressed in `.trivyignore` following the same pattern as existing golang binary CVE suppressions

## Test plan

- [ ] CI Trivy scan passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to ignore known vulnerabilities in build infrastructure components related to Golang library dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->