### PR TITLE
feat(skills): add dis-resources skill (PoC) for authoring DIS custom resources

### DIFF
--- a/.claude/skills/dis-resources/SKILL.md
+++ b/.claude/skills/dis-resources/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: dis-resources
+description: >-
+  Create and configure Altinn DIS platform custom resources as GitOps-ready
+  Kubernetes manifests — PostgreSQL Database and DatabaseServer, Azure Key
+  Vault, and ApplicationIdentity. Use this whenever the user wants to provision
+  or wire up DIS infrastructure for an Altinn app: creating a database, standing
+  up a postgres server (dedicated or shared), requesting a key vault or secret
+  store, or creating an application / managed identity — even when they don't
+  name the CRD or the operator. Do NOT use this for developing the dis-*
+  operators themselves (controller/reconciler code, regenerating CRD manifests).
+---
+
+# Authoring Altinn DIS resources
+
+DIS ("Declarative Infrastructure Services") is a set of Kubernetes operators
+that reconcile custom resources into Azure infrastructure. App teams get
+self-service infra by committing a manifest to GitOps — the operator does the
+Azure provisioning and reports back through the resource's `status`.
+
+Your job with this skill is to produce **correct, minimal, GitOps-ready
+manifests** for these resources, getting the cross-resource wiring and the
+cross-field validation rules right the first time. The schemas live in this
+repo, so prefer reading them over guessing.
+
+## Resource catalog
+
+| Kind | apiVersion | Operator | Purpose | Reference |
+| --- | --- | --- | --- | --- |
+| ApplicationIdentity | `application.dis.altinn.cloud/v1alpha1` | dis-identity-operator | Azure managed identity + workload-identity federation for an app | [references/applicationidentity.md](references/applicationidentity.md) |
+| DatabaseServer | `storage.dis.altinn.cloud/v1alpha1` | dis-pgsql-operator | Azure PostgreSQL Flexible Server (dedicated or shared) | [references/databaseserver.md](references/databaseserver.md) |
+| Database | `storage.dis.altinn.cloud/v1alpha1` | dis-pgsql-operator | A PostgreSQL database on a server, with role-based access | [references/database.md](references/database.md) |
+| Vault | `vault.dis.altinn.cloud/v1alpha1` | dis-vault-operator | Azure Key Vault owned by an identity or service account | [references/vault.md](references/vault.md) |
+
+## Dependency graph
+
+`ApplicationIdentity` is the foundation: its `status` exposes the
+`principalId`/`clientId` that the other resources resolve. Most useful setups
+need an identity first, then the resource that references it.
+
+```
+ApplicationIdentity
+   ├─ DatabaseServer.spec.auth.admin.identity.identityRef   (server admin)
+   ├─ Database.spec.access.principals[].identityRef          (app access)
+   └─ Vault.spec.identityRef                                 (vault owner)
+
+DatabaseServer  ──<  Database.spec.server.name   (a Database lives on a server)
+```
+
+All references are **by name within the same namespace**. There is no
+cross-namespace referencing.
+
+## Decision guide
+
+Translate the request into the set of resources to author, in order:
+
+- **"A database for one app"** → an `ApplicationIdentity` for the app + a
+  `DatabaseServer` (if the team has none yet) + a `Database` that references
+  both. Giving the app its own server is the *single-tenant* layout.
+- **"Databases for several apps that share infrastructure"** → one
+  `DatabaseServer` with `mode: Shared` (plus `network`) + one `Database` per app,
+  each with its own `access.principals`. This is the *multitenant* layout.
+- **"A secret store / key vault"** → an `ApplicationIdentity` (if the app has
+  none) + a `Vault` that references it (or an existing `ServiceAccount`).
+- **"Just an identity / workload identity"** → an `ApplicationIdentity` alone.
+
+If an identity, server, or service account the user names already exists in
+their repo, reference it rather than recreating it — ask if you're unsure.
+
+## Authoring workflow
+
+1. Use the decision guide to list the resources needed and the order to apply
+   them.
+2. Open the matching reference file(s) for each Kind.
+3. **Read the live sample(s)** the reference points to before finalizing — the
+   in-repo `config/samples/*.yaml` and `config/crd/bases/*.yaml` are the source
+   of truth and may have moved past these notes.
+4. Copy the template, fill in real values, and keep cross-resource names
+   consistent and in a single namespace.
+5. Validate (below).
+6. Place the manifest at the team's GitOps path for that namespace.
+
+## Validation
+
+- **Best (with a cluster):** from the operator directory run `make
+  install-cache` to install the CRDs, then
+  `kubectl apply --dry-run=server -f <file>.yaml`. Server-side dry-run enforces
+  enums, ranges, required fields, and the cross-field (`XValidation`) rules.
+- **Offline:** check field names, enums, and ranges against the CRD schema at
+  `services/<operator>/config/crd/bases/<group>_<plural>.yaml` (the
+  `openAPIV3Schema` block). Watch these cross-field rules in particular — they
+  are the easiest things to get wrong:
+  - **Vault:** exactly one of `identityRef` / `serviceAccountRef`.
+  - **DatabaseServer:** `network` is required when `mode: Shared` and must be
+    omitted when `mode: Dedicated`; `mode` is immutable once created.
+  - **Database access principal:** exactly one of `identityRef` / `group`.
+  - **Server admin identity:** either `identityRef`, or both `name` and
+    `principalId` — not a mix.
+
+## Conventions
+
+- Write manifests as **pure YAML with no inline comments** — rationale belongs
+  in the PR description, not the file.
+- Always set `metadata.namespace` explicitly; every cross-resource reference
+  resolves within that namespace.
+- Use the same name for a resource and the references that point at it (e.g. an
+  app's `ApplicationIdentity` name and the `identityRef.name` that uses it), so
+  the wiring is obvious.
+
+## Where these are heading
+
+These CRDs are the low-level building blocks. A higher-level `DisApp` resource
+(via kro) is planned to compose them into a single app abstraction, so treat the
+names and labels you set here as a stable contract other tooling will depend on.

--- a/.claude/skills/dis-resources/SKILL.md
+++ b/.claude/skills/dis-resources/SKILL.md
@@ -38,7 +38,7 @@ repo, so prefer reading them over guessing.
 `principalId`/`clientId` that the other resources resolve. Most useful setups
 need an identity first, then the resource that references it.
 
-```
+```text
 ApplicationIdentity
    ├─ DatabaseServer.spec.auth.admin.identity.identityRef   (server admin)
    ├─ Database.spec.access.principals[].identityRef          (app access)

--- a/.claude/skills/dis-resources/evals/evals.json
+++ b/.claude/skills/dis-resources/evals/evals.json
@@ -1,0 +1,51 @@
+{
+  "skill_name": "dis-resources",
+  "evals": [
+    {
+      "id": 0,
+      "name": "database-on-existing-shared-server",
+      "prompt": "We've already got a shared postgres server called `shared-db` in our `myteam-dev` namespace. Can you give me a Database manifest for a db named `orders`? Our app identity is `myproduct-orders-dev` and it needs read/write access, and the `my-team-db-owners` group (object id 11111111-1111-1111-1111-111111111111) should be the owner.",
+      "expected_output": "A single Database manifest (storage.dis.altinn.cloud/v1alpha1) named orders on server shared-db in namespace myteam-dev, with a Writer principal using identityRef myproduct-orders-dev and an Owner principal using the group. Pure YAML, no comments.",
+      "files": [],
+      "assertions": [
+        "Output contains a manifest with apiVersion 'storage.dis.altinn.cloud/v1alpha1' and kind 'Database'",
+        "spec.name is 'orders' and spec.server.name is 'shared-db'",
+        "An access principal has role 'Writer' and identityRef.name 'myproduct-orders-dev'",
+        "An access principal has role 'Owner' with group.name 'my-team-db-owners' and group.principalId '11111111-1111-1111-1111-111111111111'",
+        "Every access principal sets exactly one of identityRef or group, never both",
+        "metadata.namespace is 'myteam-dev'",
+        "The manifest is valid YAML with no inline comments"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "dedicated-server-plus-database",
+      "prompt": "I need a dedicated PostgreSQL 16 server for production with HA turned on, in namespace `myteam-dev`. Put a database called `router` on it for my router service — the service identity is `myproduct-router-dev` and it should be the owner. The server admin identity is `db-admin`.",
+      "expected_output": "A DatabaseServer (Dedicated, version 16, serverType prod, HA enabled, no network block, admin identityRef db-admin) plus a Database named router referencing that server with an Owner principal for myproduct-router-dev. All in namespace myteam-dev with consistent names. Optionally also the ApplicationIdentity resources. Pure YAML, no comments.",
+      "files": [],
+      "assertions": [
+        "Output contains a manifest with kind 'DatabaseServer' (storage.dis.altinn.cloud/v1alpha1) with spec.version 16, spec.serverType 'prod', and spec.highAvailabilityEnabled true",
+        "The DatabaseServer omits spec.network (it is Dedicated mode)",
+        "DatabaseServer spec.auth.admin.identity.identityRef.name is 'db-admin'",
+        "Output contains a manifest with kind 'Database' named 'router' whose spec.server.name matches the DatabaseServer's metadata.name",
+        "The Database has an access principal with role 'Owner' referencing identityRef.name 'myproduct-router-dev'",
+        "All resources are in namespace 'myteam-dev' and cross-resource references are name-consistent",
+        "All manifests are valid YAML with no inline comments"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "identity-backed-vault-with-external-secrets",
+      "prompt": "Set up an Azure Key Vault for my orders app in the `myteam-dev` namespace. It should be owned by the app's identity `myproduct-orders-dev`, and I want ExternalSecrets enabled so we can sync secrets into the namespace.",
+      "expected_output": "A Vault manifest (vault.dis.altinn.cloud/v1alpha1) in namespace myteam-dev with identityRef myproduct-orders-dev, externalSecrets true, and no serviceAccountRef. Pure YAML, no comments.",
+      "files": [],
+      "assertions": [
+        "Output contains a manifest with apiVersion 'vault.dis.altinn.cloud/v1alpha1' and kind 'Vault'",
+        "spec.identityRef.name is 'myproduct-orders-dev' and spec.serviceAccountRef is absent (exactly one owner)",
+        "spec.externalSecrets is true",
+        "metadata.namespace is 'myteam-dev'",
+        "The manifest is valid YAML with no inline comments"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/dis-resources/evals/evals.json
+++ b/.claude/skills/dis-resources/evals/evals.json
@@ -8,6 +8,7 @@
       "expected_output": "A single Database manifest (storage.dis.altinn.cloud/v1alpha1) named orders on server shared-db in namespace myteam-dev, with a Writer principal using identityRef myproduct-orders-dev and an Owner principal using the group. Pure YAML, no comments.",
       "files": [],
       "assertions": [
+        "Output contains exactly one YAML document (a single Database manifest, since the server and identity are stated to already exist)",
         "Output contains a manifest with apiVersion 'storage.dis.altinn.cloud/v1alpha1' and kind 'Database'",
         "spec.name is 'orders' and spec.server.name is 'shared-db'",
         "An access principal has role 'Writer' and identityRef.name 'myproduct-orders-dev'",
@@ -21,9 +22,10 @@
       "id": 1,
       "name": "dedicated-server-plus-database",
       "prompt": "I need a dedicated PostgreSQL 16 server for production with HA turned on, in namespace `myteam-dev`. Put a database called `router` on it for my router service — the service identity is `myproduct-router-dev` and it should be the owner. The server admin identity is `db-admin`.",
-      "expected_output": "A DatabaseServer (Dedicated, version 16, serverType prod, HA enabled, no network block, admin identityRef db-admin) plus a Database named router referencing that server with an Owner principal for myproduct-router-dev. All in namespace myteam-dev with consistent names. Optionally also the ApplicationIdentity resources. Pure YAML, no comments.",
+      "expected_output": "A DatabaseServer (Dedicated, version 16, serverType prod, HA enabled, no network block, admin identityRef db-admin) plus a Database named router referencing that server with an Owner principal for myproduct-router-dev. All in namespace myteam-dev with consistent names. It also authors prerequisite ApplicationIdentity manifests for db-admin and myproduct-router-dev, since the prompt does not state they already exist. Pure YAML, no comments.",
       "files": [],
       "assertions": [
+        "Because the prompt names identities not stated as pre-existing, output also contains ApplicationIdentity manifests for 'db-admin' and 'myproduct-router-dev'",
         "Output contains a manifest with kind 'DatabaseServer' (storage.dis.altinn.cloud/v1alpha1) with spec.version 16, spec.serverType 'prod', and spec.highAvailabilityEnabled true",
         "The DatabaseServer omits spec.network (it is Dedicated mode)",
         "DatabaseServer spec.auth.admin.identity.identityRef.name is 'db-admin'",
@@ -41,6 +43,7 @@
       "files": [],
       "assertions": [
         "Output contains a manifest with apiVersion 'vault.dis.altinn.cloud/v1alpha1' and kind 'Vault'",
+        "Because the prompt does not state the identity already exists, output also contains an ApplicationIdentity manifest named 'myproduct-orders-dev'",
         "spec.identityRef.name is 'myproduct-orders-dev' and spec.serviceAccountRef is absent (exactly one owner)",
         "spec.externalSecrets is true",
         "metadata.namespace is 'myteam-dev'",

--- a/.claude/skills/dis-resources/references/applicationidentity.md
+++ b/.claude/skills/dis-resources/references/applicationidentity.md
@@ -1,0 +1,56 @@
+# ApplicationIdentity
+
+`application.dis.altinn.cloud/v1alpha1`, owned by **dis-identity-operator**.
+
+Creates an Azure managed identity with workload-identity federation for an app.
+It is the foundational DIS resource: its `status` exposes the `principalId` and
+`clientId` that `DatabaseServer`, `Database`, and `Vault` resolve when they
+reference it. Create it first when an app needs database access, a vault, or its
+own workload identity.
+
+## Source of truth
+
+- Types: `services/dis-identity-operator/api/v1alpha1/applicationidentity_types.go`
+- CRD schema: `services/dis-identity-operator/config/crd/bases/application.dis.altinn.cloud_applicationidentities.yaml`
+- Sample: `services/dis-identity-operator/config/samples/application_v1alpha1_applicationidentity.yaml`
+  — **note this sample is a `# TODO(user)` placeholder with an empty spec.**
+  Take field details from the types file / CRD schema, not the sample.
+
+## Spec fields
+
+| Field | Required | Type | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `azureAudiences` | no | `[]string` | `["api://AzureADTokenExchange"]` | Token audiences accepted from Azure. Leave unset unless a consumer needs a custom audience. |
+| `tags` | no | `map[string]string` | `{}` | Tags propagated to the Azure identities created for this resource. |
+
+Both fields are optional, so the minimal spec is effectively empty. The
+identity's name (`metadata.name`) is what other resources reference via
+`identityRef.name`, so name it for the app/component it serves.
+
+## Template — minimal
+
+```yaml
+apiVersion: application.dis.altinn.cloud/v1alpha1
+kind: ApplicationIdentity
+metadata:
+  name: myproduct-orders-dev
+  namespace: myteam-dev
+spec: {}
+```
+
+## Template — with tags
+
+```yaml
+apiVersion: application.dis.altinn.cloud/v1alpha1
+kind: ApplicationIdentity
+metadata:
+  name: myproduct-orders-dev
+  namespace: myteam-dev
+spec:
+  tags:
+    app: orders
+    env: dev
+```
+
+Replace `myproduct-orders-dev` with a name that identifies the app/component and
+environment, and `myteam-dev` with the team's namespace.

--- a/.claude/skills/dis-resources/references/database.md
+++ b/.claude/skills/dis-resources/references/database.md
@@ -1,0 +1,84 @@
+# Database
+
+`storage.dis.altinn.cloud/v1alpha1`, owned by **dis-pgsql-operator**.
+
+Creates one PostgreSQL database inside an existing `DatabaseServer` and grants
+role-based access to a set of Entra principals (app identities and/or groups).
+A `Database` always needs a `DatabaseServer` to live on — create or pick one
+first.
+
+## Source of truth
+
+- Types: `services/dis-pgsql-operator/api/v1alpha1/database_types.go`
+- CRD schema: `services/dis-pgsql-operator/config/crd/bases/storage.dis.altinn.cloud_databases.yaml`
+- Sample: `services/dis-pgsql-operator/config/samples/storage_v1alpha1_database.yaml`
+  (shows both single-tenant and multitenant layouts)
+
+## Spec fields
+
+| Field | Required | Type | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `name` | **yes** | string (1–63) | — | PostgreSQL database name; unique per server. |
+| `server.name` | **yes** | string | — | Same-namespace `DatabaseServer` to host the database. |
+| `access.principals` | **yes** | list (≥1) | — | Who gets access and at what role. |
+| `access.principals[].role` | **yes** | enum | — | `Reader` (read-only), `Writer` (DML, no DDL), or `Owner` (DML + schema ownership). |
+| `access.principals[].identityRef` | one-of | object | — | `name` of an [ApplicationIdentity](applicationidentity.md) in the same namespace. |
+| `access.principals[].group` | one-of | object | — | An existing Entra group: `{name, principalId}`. |
+| `deletionPolicy` | no | enum `Retain` | `Retain` | Only `Retain` is supported; the DB is kept when the resource is deleted. |
+
+Each principal must set **exactly one** of `identityRef` or `group`. Use
+`identityRef` for an app's managed identity and `group` for a human team
+(e.g. DB owners).
+
+## Template — single-tenant (own server)
+
+```yaml
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: Database
+metadata:
+  name: router
+  namespace: myteam-dev
+spec:
+  name: router
+  server:
+    name: db1
+  access:
+    principals:
+      - role: Owner
+        identityRef:
+          name: myproduct-router-dev
+      - role: Owner
+        group:
+          name: my-team-db-owners
+          principalId: "11111111-1111-1111-1111-111111111111"
+  deletionPolicy: Retain
+```
+
+## Template — multitenant (shared server)
+
+```yaml
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: Database
+metadata:
+  name: orders
+  namespace: myteam-dev
+spec:
+  name: orders
+  server:
+    name: shared-db
+  access:
+    principals:
+      - role: Writer
+        identityRef:
+          name: myproduct-orders-dev
+      - role: Owner
+        group:
+          name: my-team-db-owners
+          principalId: "11111111-1111-1111-1111-111111111111"
+  deletionPolicy: Retain
+```
+
+`server.name` must match a `DatabaseServer` in the same namespace
+([DatabaseServer](databaseserver.md)), and each `identityRef.name` an
+`ApplicationIdentity` in that namespace. The group `principalId` is the Entra
+group object ID (quote it so YAML keeps it a string).

--- a/.claude/skills/dis-resources/references/databaseserver.md
+++ b/.claude/skills/dis-resources/references/databaseserver.md
@@ -1,0 +1,87 @@
+# DatabaseServer
+
+`storage.dis.altinn.cloud/v1alpha1`, owned by **dis-pgsql-operator**.
+
+Provisions an Azure PostgreSQL Flexible Server. A `DatabaseServer` hosts one or
+more `Database` resources; it does not create app databases itself. Two modes:
+
+- **Dedicated** (default) — a server for a single app/team. Omit `network`.
+- **Shared** — a server that hosts many apps' databases. Requires `network`
+  pointing at a pre-existing delegated subnet + private DNS zone.
+
+`mode` is **immutable** after creation.
+
+## Source of truth
+
+- Types: `services/dis-pgsql-operator/api/v1alpha1/databaseserver_types.go`
+- CRD schema: `services/dis-pgsql-operator/config/crd/bases/storage.dis.altinn.cloud_databaseservers.yaml`
+- Sample: `services/dis-pgsql-operator/config/samples/storage_v1alpha1_databaseserver.yaml`
+
+## Spec fields
+
+| Field | Required | Type | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `version` | **yes** | int (≥9) | — | PostgreSQL major version, e.g. `16`, `17`. |
+| `serverType` | **yes** | string | — | Size/profile, e.g. `dev`, `prod`. Drives HA/backup defaults. |
+| `auth.admin.identity` | **yes** | IdentitySource | — | Either `identityRef.name`, **or** both `name` + `principalId` — not a mix. |
+| `auth.admin.serviceAccountName` | no | string | `identityRef.name` | ServiceAccount used for workload identity when provisioning child Database access. |
+| `mode` | no | enum `Dedicated`/`Shared` | `Dedicated` | Immutable. `Shared` requires `network`. |
+| `network` | for Shared | object | — | Required iff `mode: Shared`; must be omitted for Dedicated. |
+| `network.delegatedSubnetResourceId` | for Shared | string | — | ARM ID of an existing delegated subnet. |
+| `network.privateDnsZoneResourceId` | for Shared | string | — | ARM ID of an existing private DNS zone. |
+| `storage.sizeGB` | no | int32 | operator default | Initial storage size. |
+| `storage.tier` | no | string | operator default | Performance tier, e.g. `P10`. |
+| `highAvailabilityEnabled` | no | bool | `true` for prod, else `false` | Zone-redundant HA. |
+| `backupRetentionDays` | no | int (7–35) | `30` prod / `14` non-prod | Backup retention. |
+| `enableExtensions` | no | enum set | — | Subset of `hstore`, `pg_cron`, `pg_stat_statements`, `pgaudit`, `uuid-ossp`. |
+| `serverParams` | no | list `{name,value}` | — | PostgreSQL params. `azure.extensions`, `shared_preload_libraries`, `pgbouncer.*`, and `max_connections` are managed by the operator and rejected here. |
+
+## Template — dedicated server
+
+```yaml
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: DatabaseServer
+metadata:
+  name: db1
+  namespace: myteam-dev
+spec:
+  version: 16
+  serverType: prod
+  highAvailabilityEnabled: true
+  backupRetentionDays: 30
+  storage:
+    sizeGB: 128
+    tier: P10
+  auth:
+    admin:
+      identity:
+        identityRef:
+          name: db-admin
+```
+
+## Template — shared server
+
+```yaml
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: DatabaseServer
+metadata:
+  name: shared-db
+  namespace: myteam-dev
+spec:
+  mode: Shared
+  version: 17
+  serverType: prod
+  network:
+    delegatedSubnetResourceId: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-dis-admin-network/providers/Microsoft.Network/virtualNetworks/vnet-dis-admin-dbs/subnets/snet-postgres-shared
+    privateDnsZoneResourceId: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-dis-admin-network/providers/Microsoft.Network/privateDnsZones/shared.private.postgres.database.azure.com
+  auth:
+    admin:
+      identity:
+        identityRef:
+          name: db-admin
+```
+
+The admin `identityRef` points at an [ApplicationIdentity](applicationidentity.md)
+in the same namespace. The network ARM IDs in the shared template are
+placeholders — use the real subnet and private DNS zone IDs for the
+environment.

--- a/.claude/skills/dis-resources/references/vault.md
+++ b/.claude/skills/dis-resources/references/vault.md
@@ -1,0 +1,82 @@
+# Vault
+
+`vault.dis.altinn.cloud/v1alpha1`, owned by **dis-vault-operator**.
+
+Provisions an Azure Key Vault owned by either an `ApplicationIdentity` or a
+`ServiceAccount`, optionally wired to ExternalSecrets for syncing secrets into
+the namespace.
+
+## Source of truth
+
+- Types: `services/dis-vault-operator/api/v1alpha1/vault_types.go`
+- CRD schema: `services/dis-vault-operator/config/crd/bases/vault.dis.altinn.cloud_vaults.yaml`
+- Samples: `services/dis-vault-operator/config/samples/vault_v1alpha1_vault.yaml`,
+  `vault_v1alpha1_service_account_vault.yaml`, `external_secrets_vault.yaml`
+
+## Spec fields
+
+| Field | Required | Type | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `identityRef` | one-of | object | — | `name` of an [ApplicationIdentity](applicationidentity.md) that owns the vault. |
+| `serviceAccountRef` | one-of | object | — | `name` of a ServiceAccount that owns the vault. |
+| `groupObjectId` | no | string | — | Entra group object ID granted access. Must be a **lowercase** GUID. |
+| `externalSecrets` | no | bool | `false` | Create a namespaced ExternalSecrets `SecretStore` for the vault. |
+| `sku` | no | enum `standard`/`premium` | `standard` | Key Vault SKU. |
+| `publicNetworkAccess` | no | enum `Enabled` | `Enabled` | Only `Enabled` is supported in v1. |
+| `softDeleteRetentionDays` | no | int (7–90) | `90` | Soft-delete retention. |
+| `purgeProtectionEnabled` | no | bool | `true` | Purge protection. |
+| `tags` | no | `map[string]string` | — | Tags propagated to Azure. |
+
+Set **exactly one** of `identityRef` or `serviceAccountRef` — the CRD rejects
+both or neither.
+
+## Template — identity-backed
+
+```yaml
+apiVersion: vault.dis.altinn.cloud/v1alpha1
+kind: Vault
+metadata:
+  name: orders-vault
+  namespace: myteam-dev
+spec:
+  identityRef:
+    name: myproduct-orders-dev
+  sku: standard
+  tags:
+    app: orders
+    env: dev
+```
+
+## Template — service-account-backed
+
+```yaml
+apiVersion: vault.dis.altinn.cloud/v1alpha1
+kind: Vault
+metadata:
+  name: orders-vault
+  namespace: myteam-dev
+spec:
+  serviceAccountRef:
+    name: orders-sa
+  sku: standard
+```
+
+## Template — with ExternalSecrets and group access
+
+```yaml
+apiVersion: vault.dis.altinn.cloud/v1alpha1
+kind: Vault
+metadata:
+  name: orders-vault
+  namespace: myteam-dev
+spec:
+  identityRef:
+    name: myproduct-orders-dev
+  externalSecrets: true
+  groupObjectId: 11111111-1111-1111-1111-111111111111
+  sku: standard
+```
+
+`groupObjectId` must be lowercase; defaults (`publicNetworkAccess: Enabled`,
+`softDeleteRetentionDays: 90`, `purgeProtectionEnabled: true`) are applied by
+the CRD, so omit them unless overriding.


### PR DESCRIPTION
## Summary

Adds a unified Claude Code skill, `dis-resources`, under `.claude/skills/` that helps author GitOps-ready manifests for the DIS platform CRDs — `ApplicationIdentity`, `DatabaseServer`, `Database`, and `Vault`.

- `SKILL.md` routes the work: a resource catalog, the dependency graph (rooted at `ApplicationIdentity`), a decision guide, an authoring workflow, validation guidance, and conventions.
- One reference file per resource with a minimal template, a curated field table, the cross-field validation rules, and pointers to the live `config/samples/` and `config/crd/bases/` as the source of truth.

## Status: proof of concept 🧪

Kept **in-repo** for now so we can dogfood it. We'll exercise it in our syncroot while testing the `dis-*` operators — authoring real `Database` / `Vault` / `ApplicationIdentity` resources against the CRDs. If it proves useful, we'll graduate it to a proper release: make the reference files self-contained and distribute it as a plugin/marketplace so teams that don't clone this repo can install it.

Not for merge until we've validated it in practice.

## Scope

- v1 covers identity + PostgreSQL (`Database` / `DatabaseServer`) + `Vault`. APIM (`Api` / `Backend`) is intentionally deferred to a later phase.

## Validation

- Benchmarked the 3 prompts in `evals/evals.json` with and without the skill; all runs produced schema-valid manifests. With the skill, Claude additionally authored the prerequisite `ApplicationIdentity` resources and followed the dependency graph, whereas the no-skill baseline referenced identities without creating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive guides added for authoring DIS Kubernetes custom resources as GitOps-ready manifests, including dependency graphs, validation approaches, and YAML conventions
  * Reference documentation added for ApplicationIdentity, Database, DatabaseServer, and Vault resources with practical YAML examples, constraints, and configuration guidelines

* **Tests**
  * Evaluation test cases added for DIS resource configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->