### PR TITLE
chore(claude): allowlist dis operator make targets

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,22 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(make help)",
+      "Bash(make setup-local-env)",
+      "Bash(make workspace)",
+      "Bash(make workspace-clean)",
+      "Bash(make tidy)",
+      "Bash(make fmt-cache)",
+      "Bash(make generate-cache)",
+      "Bash(make manifests-cache)",
+      "Bash(make lint-cache)",
+      "Bash(make test-cache)",
+      "Bash(make test-ci-cache)",
+      "Bash(make build-cache)",
+      "Bash(make run-checks-ci-cache)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## What

Adds a `permissions.allow` block to the repo-root `.claude/settings.json` so Claude Code runs the well-defined, sandbox-friendly `make` targets of the DIS operators **without a permission prompt**, while keeping the existing `SessionStart` hook intact.

Allowlisted (13 rules):
- Verification (`*-cache`, the targets `AGENTS.md` mandates for agent runs): `run-checks-ci-cache`, `fmt-cache`, `generate-cache`, `manifests-cache`, `lint-cache`, `test-cache`, `test-ci-cache`, `build-cache`
- Safe dev setup: `help`, `setup-local-env`, `workspace`, `workspace-clean`, `tidy`

## Why

These `*-cache` targets already wrap `go vet`/`go build`/etc., use local Go caches, and perform no network/cluster mutation — they're safe to auto-run and are exactly what `AGENTS.md` tells agents to use. Removing the prompts streamlines the verification loop.

Deliberately **not** allowlisted (still prompt): raw `go`/`git`/`gh`/`kubectl`, and any network/cluster/registry targets (`deploy*`, `install*`, `docker-*`, `test-e2e*`, `run`).

## Why repo-root, not per-operator

A per-operator `services/<op>/.claude/settings.json` only loads when a session's working directory is that subfolder. In practice sessions run from the repo/worktree root (worktree sessions always resolve there), so subfolder settings don't load. Placing the allowlist at the repo root makes it effective everywhere; the `*-cache` / `run-checks-ci-cache` target names exist only in the operator Makefiles, so the rules stay effectively operator-scoped and cover all DIS operators uniformly.

## Verification

- `make help` (and the other allowlisted targets) run with no approval prompt; confirmed live via `/permissions`.
- A non-listed target such as `make deploy` still prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Improved development environment configuration with automated command hooks enabling streamlined testing, linting, formatting, and CI validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->