### PR TITLE
Deploy a push gateway

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_push_gateway.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_push_gateway.tf
@@ -1,0 +1,21 @@
+resource "helm_release" "prometheus_push_gateway" {
+  depends_on = [
+    helm_release.kube_prometheus_stack,
+  ]
+  lint             = true
+  name             = "prometheus-pushgateway"
+  namespace        = "monitoring"
+  create_namespace = false
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-pushgateway"
+  skip_crds        = true
+  version          = "3.6.1"
+
+  values = [
+    "${templatefile(
+      "${path.module}/k6_tests_rg_kube_prometheus_push_gateway_values.tftpl",
+      {
+      }
+    )}"
+  ]
+}

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_push_gateway_values.tftpl
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_kube_prometheus_push_gateway_values.tftpl
@@ -1,0 +1,3 @@
+serviceMonitor:
+  enabled: true
+  namespace: monitoring


### PR DESCRIPTION
Used by the Playwright runner to push metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Prometheus Pushgateway monitoring component added to the infrastructure stack.
  * Service monitoring enabled and configured for the monitoring namespace.
  * Integration established with the existing Prometheus monitoring system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->