### PR TITLE
docs(dis-resources): document the connection ConfigMap consumption

### DIFF
--- a/.claude/skills/dis-resources/SKILL.md
+++ b/.claude/skills/dis-resources/SKILL.md
@@ -56,7 +56,9 @@ Translate the request into the set of resources to author, in order:
 
 - **"A database for one app"** → an `ApplicationIdentity` for the app + a
   `DatabaseServer` (if the team has none yet) + a `Database` that references
-  both. Giving the app its own server is the *single-tenant* layout.
+  both. Giving the app its own server is the *single-tenant* layout. The
+  operator then publishes a connection ConfigMap the app's workload consumes —
+  always tell the user how to connect (see [references/database.md](references/database.md)).
 - **"Databases for several apps that share infrastructure"** → one
   `DatabaseServer` with `mode: Shared` (plus `network`) + one `Database` per app,
   each with its own `access.principals`. This is the *multitenant* layout.
@@ -79,6 +81,10 @@ their repo, reference it rather than recreating it — ask if you're unsure.
    consistent and in a single namespace.
 5. Validate (below).
 6. Place the manifest at the team's GitOps path for that namespace.
+7. For a `Database`, the app's connection details are published by the operator
+   as a ConfigMap, not set in the manifest — surface its deterministic name and
+   keys and give the user the workload snippet that consumes it (see
+   [references/database.md](references/database.md)).
 
 ## Validation
 

--- a/.claude/skills/dis-resources/references/database.md
+++ b/.claude/skills/dis-resources/references/database.md
@@ -82,3 +82,56 @@ spec:
 ([DatabaseServer](databaseserver.md)), and each `identityRef.name` an
 `ApplicationIdentity` in that namespace. The group `principalId` is the Entra
 group object ID (quote it so YAML keeps it a string).
+
+## Connecting an app — the connection ConfigMap
+
+Authoring the `Database` is only half the job: the app still has to connect, and
+this is the step the manifest alone does not cover. You request nothing for it —
+once the Database is `Ready`, dis-pgsql-operator automatically publishes a
+ConfigMap in the same namespace, **one per `access.principals[]` entry that uses
+`identityRef`** (group principals get none). The workload **must** consume it, or
+it has no coordinates to connect with.
+
+- **Name (deterministic — derivable before it exists):**
+  `<database.metadata.name>-<identityRef.name>-dis-pgsql`, sanitized to DNS-1123
+  and hash-suffixed if it would exceed 63 chars. For the multitenant template
+  above (Database `orders`, identity `myproduct-orders-dev`) →
+  `orders-myproduct-orders-dev-dis-pgsql`.
+- **Keys:** `host`, `port`, `dbname`, `user`, `sslmode` (always `require`), and
+  `uri` (`postgresql://<user>@<host>:5432/<dbname>?sslmode=require`).
+- **No password.** Auth is Entra workload identity: the pod runs as the
+  ServiceAccount the app's `ApplicationIdentity` created and authenticates with a
+  short-lived token, so the ConfigMap carries only non-secret coordinates. The
+  `user` value is the resolved managed-identity name, which can differ from
+  `identityRef.name`.
+
+Wire the workload to it — the workload-identity ServiceAccount plus the
+ConfigMap:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders
+  namespace: myteam-dev
+spec:
+  template:
+    metadata:
+      labels:
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: myproduct-orders-dev
+      containers:
+        - name: app
+          env:
+            - name: DB_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: orders-myproduct-orders-dev-dis-pgsql
+                  key: uri
+```
+
+`serviceAccountName` is the app's `ApplicationIdentity` name (the operator
+creates a ServiceAccount of that name); the pod label switches on the
+workload-identity webhook. Source of truth for the name and keys:
+`services/dis-pgsql-operator/internal/connection/configmap.go`.


### PR DESCRIPTION
## Problem
The `dis-resources` skill authors a correct `Database` CR but stops there — it never tells the user the one thing they need next: how to connect their app to the database. A user who provisions a DB is left at "provisioned, but my app cannot connect."

## Fix
- **`references/database.md`** — new **"Connecting an app — the connection ConfigMap"** section documenting the ConfigMap the operator publishes automatically: deterministic name `<database>-<identityRef>-dis-pgsql`, keys (`host`/`port`/`dbname`/`user`/`sslmode`/`uri`), and no-password workload-identity auth — plus a ready-to-paste `Deployment` snippet (`serviceAccountName` + `azure.workload.identity/use` label + `configMapKeyRef`).
- **`SKILL.md`** — make surfacing this non-optional: a decision-guide note and an authoring-workflow step, so the skill always tells the user how to connect, not just how to provision.

Docs only. Verified against `services/dis-pgsql-operator/internal/connection/configmap.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)