### PR TITLE
feat(syncroot): deploy dis-console workload to at22/at23

### DIFF
--- a/syncroot/at22/dis-console.yaml
+++ b/syncroot/at22/dis-console.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dis-console
+  namespace: product-dis
+  labels:
+    app: dis-console
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dis-console
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: dis-console
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: dis-console
+      automountServiceAccountToken: true
+      # drop legacy per-Service env vars (noise/collisions); KUBERNETES_* still injected
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dis-console
+          image: ghcr.io/altinn/altinn-platform/dis-console:latest
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DB_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: dis-console-db-dis-console-dis-pgsql
+                  key: uri
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dis-console
+  namespace: product-dis
+  labels:
+    app: dis-console
+spec:
+  selector:
+    app: dis-console
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dis-console-reader
+rules:
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dis-console-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dis-console-reader
+subjects:
+  - kind: ServiceAccount
+    name: dis-console
+    namespace: product-dis

--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - dis-console-db-admin.yaml
   - dis-console-databaseserver.yaml
   - dis-console-database.yaml
+  - dis-console.yaml

--- a/syncroot/at23/dis-console.yaml
+++ b/syncroot/at23/dis-console.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dis-console
+  namespace: product-dis
+  labels:
+    app: dis-console
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dis-console
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: dis-console
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: dis-console
+      automountServiceAccountToken: true
+      # drop legacy per-Service env vars (noise/collisions); KUBERNETES_* still injected
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dis-console
+          image: ghcr.io/altinn/altinn-platform/dis-console:latest
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DB_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: dis-console-db-dis-console-dis-pgsql
+                  key: uri
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dis-console
+  namespace: product-dis
+  labels:
+    app: dis-console
+spec:
+  selector:
+    app: dis-console
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dis-console-reader
+rules:
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dis-console-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dis-console-reader
+subjects:
+  - kind: ServiceAccount
+    name: dis-console
+    namespace: product-dis

--- a/syncroot/at23/kustomization.yaml
+++ b/syncroot/at23/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - dis-console-db-admin.yaml
   - dis-console-databaseserver.yaml
   - dis-console-database.yaml
+  - dis-console.yaml


### PR DESCRIPTION
## What

PR 4 (final) of the **DIS Console PoC** — deploy the `dis-console` service to **at22** and **at23**, consuming the DIS identity/database/connection-ConfigMap that landed in #3642.

Per env (`syncroot/at22`, `syncroot/at23`), in `product-dis`:
- **Deployment** `dis-console` — `replicas: 1`, image `ghcr.io/altinn/altinn-platform/dis-console:latest`, container port 8080, liveness `/healthz` + readiness `/readyz`, hardened securityContext (non-root, read-only rootfs, drop ALL caps, `RuntimeDefault` seccomp).
- **Service** `dis-console` — ClusterIP, port 80 → container `http`. Not externally exposed; reach via port-forward.
- **ClusterRole** `dis-console-reader` + **ClusterRoleBinding** — `get,list,watch` on the Flux `kustomize`/`helm`/`source` resources the poller sweeps, bound to the `dis-console` ServiceAccount.
- Added `dis-console.yaml` to each env's `kustomization.yaml`.

## Wiring (authored/validated via the `dis-resources` skill)

- **Workload identity:** pod label `azure.workload.identity/use: "true"` + `serviceAccountName: dis-console` (the SA the dis-identity-operator creates from the `dis-console` `ApplicationIdentity`). Postgres auth is a short-lived Entra token — no static secret.
- **DB connection:** `DB_URI` via `configMapKeyRef` from the operator-published ConfigMap `dis-console-db-dis-console-dis-pgsql` (key `uri`) — the deterministic `<database>-<identityRef>-dis-pgsql` name.
- **`automountServiceAccountToken: true`** — deliberately differs from lakmus (which sets it `false`). dis-console reads Flux CRs through the **in-cluster Kubernetes API** (`rest.InClusterConfig()`), so it needs its SA token mounted; the Azure federated token is injected separately by the workload-identity webhook.
- **Image tag `:latest`** — tracks `main` HEAD (published on every push to main). The released `1.0.0` tag predates the Postgres layer (#3637), so `:latest` is the correct PoC tag.

## Verification

- `kustomize build syncroot/at22` and `syncroot/at23` both succeed — 9 objects each, **byte-identical** renders.
- Re-validated the #3642 DIS CRs against the live CRD schemas (ApplicationIdentity `spec: {}` ok; DatabaseServer required `auth.admin.identity`; Database exactly-one-principal-source rule) — all pass.
- Post-merge (after Flux reconciles): `kubectl -n product-dis logs deploy/dis-console` (schema migrated, sweep counts, no auth errors), `port-forward svc/dis-console 8080:80`, `curl /api/summary`, cross-check counts vs `kubectl get ks/hr -A`.

## Pre-merge check

Confirm the GHCR package `dis-console` is cluster-pullable (public, or an `imagePullSecret` exists in `product-dis`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployed dis-console service across environments with containerized architecture
  * Configured database connectivity and health monitoring capabilities
  * Applied comprehensive security hardening including non-root execution and read-only filesystem protections
  * Enabled automated deployment management and synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->