### PR TITLE
ci(dis-console): publish immutable image on release via post-release hook

### DIFF
--- a/release-please-post-config.json
+++ b/release-please-post-config.json
@@ -18,6 +18,11 @@
         }
       ]
     },
+    "services/dis-console": {
+      "dispatch-pipelines": [
+        {"filename": "dis-console-release.yml"}
+      ]
+    },
     "services/dis-pgsql-operator": {
       "dispatch-pipelines": [
         {"filename": "dis-pgsql-release.yml"}


### PR DESCRIPTION
## What

Adds the missing `services/dis-console` entry to `release-please-post-config.json` so a dis-console release publishes an immutable `ghcr.io/altinn/altinn-platform/dis-console:vX.Y.Z` image — mirroring `services/lakmus` and the dis-* operators.

## Why

`release-please` runs with `GITHUB_TOKEN`, so the `dis-console-v*` tag it creates does **not** trigger `dis-console-release.yml` directly (token-created tags don't trigger workflows). Immutable `:vX.Y.Z` images are published by that workflow's `release-tag` job, which only runs when the `trigger-post-release-workflows` job in `release-please.yml` **dispatches** the workflow at the tag ref.

There was no `services/dis-console` hook in `release-please-post-config.json`, so that dispatch never fired. As a result **no immutable tag has ever been published for dis-console** — only `:latest` (via the `release-main` job on each push to `main`). That's why the syncroot deployment had to reference `:latest`.

## Effect

On merge, `release-please` re-attempts the still-pending `dis-console-v1.1.0` release (PR #3639, currently `autorelease: pending`); the post-release dispatch then fires and publishes `:v1.1.0`, and every future dis-console release publishes its immutable tag automatically.

Follow-up PR pins the syncroot deployment to `:v1.1.0` and wires Renovate to bump it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->