### PR TITLE
chore(dis-console): pin syncroot image to v1.1.0 and let Renovate bump it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,39 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/^syncroot/.+\\.ya?ml$/"
+    ]
+  },
   "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/altinn/altinn-platform/dis-console"
+      ],
+      "versioning": "semver",
+      "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
+      "pinDigests": false,
+      "groupName": "dis console image tags",
+      "groupSlug": "dis-console-tags"
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/altinn/altinn-platform/dis-console"
+      ],
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
+      "enabled": false
+    },
     {
       "matchManagers": [
         "terraform",

--- a/syncroot/at22/dis-console.yaml
+++ b/syncroot/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:latest
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.1.0
           ports:
             - name: http
               containerPort: 8080

--- a/syncroot/at23/dis-console.yaml
+++ b/syncroot/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:latest
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.1.0
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## What

- Pin the dis-console Deployment in `syncroot/at22` and `syncroot/at23` from the floating `:latest` to the immutable `:v1.1.0` (published via #3645).
- Enable Renovate to keep that pin current.

## Why `:latest` was wrong

A floating tag isn't reproducible, can't be pinned to a digest, and Renovate can't track it — the cluster silently drifts whenever `main` rebuilds `:latest`. The dis-* operators avoid this by pinning an immutable `vX.Y.Z` that Renovate bumps; this brings dis-console in line.

## How Renovate tracks it

Renovate's built-in **`kubernetes` manager** is off by default (it has no default file matching), so it's enabled and scoped to `syncroot/` via `managerFilePatterns`. That manager parses the Deployment's `image:` field directly (docker datasource), so **no `# renovate:` annotation is needed** — keeping the syncroot YAML comment-free.

> This differs from the operators, whose version lives inside a Flux `Kustomization` CR (`newTag:`) that no built-in manager understands — hence their custom regex manager + `# renovate:` comment. Our image is a plain `image:` field in a real k8s manifest, so the native manager handles it.

A `packageRule` constrains bumps to semver `vX.Y.Z` tags (ignoring `:latest`, `:scan`, and digests) and groups them, mirroring the operator image rules.

## Depends on

- #3645 (publishes `:v1.1.0`) — merged; image confirmed published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)