### PR TITLE
feat(syncroots): add syncroot source repo for altinn-studio

### DIFF
--- a/infrastructure/syncroots/terraform.tfvars.json
+++ b/infrastructure/syncroots/terraform.tfvars.json
@@ -30,6 +30,13 @@
       "branches": [
         "main"
       ]
+    },
+    "studio": {
+      "repo_name": "altinn-studio",
+      "environments": [],
+      "branches": [
+        "main"
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds `altinn-studio` to `product_syncroot_source_repos`, provisioning a managed pusher (UAMI federated to `altinn-studio@main`, ACR push ABAC-scoped to `studio/*` on `altinncr`, and the `DIS_SYNCROOT_AZURE_*` repo secrets) so altinn-studio can publish a new admin syncroot (workflow-engine shared dis-pgsql `DatabaseServer`/`Database`) for the admin clusters to pull.

**Replaces the legacy setup:** altinn-studio's current push to `altinncr` relies on a grant from the deprecated/disabled products pipeline (`products.yaml`) — legacy and no longer in any live IaC. This is the sanctioned, owned-as-code replacement.
