### PR TITLE
fix role name

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_workload_identity.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_workload_identity.tf
@@ -28,9 +28,9 @@ data "azurerm_storage_container" "playwrightartifacts" {
   storage_account_id = data.azurerm_storage_account.playwrightartifacts.id
 }
 
-resource "azurerm_role_assignment" "storage_blob_data_writer" {
+resource "azurerm_role_assignment" "playwright_reports_storage_blob_data_contributor" {
   scope                = data.azurerm_storage_container.playwrightartifacts.id
-  role_definition_name = "Storage Blob Data Writer"
+  role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azuread_service_principal.playwright_reporter.object_id
 }
 


### PR DESCRIPTION
The previous role doesn't exist. Switched to Contributor instead: https://docs.azure.cn/en-us/role-based-access-control/built-in-roles#storage-blob-data-contributor

Has more permissions than needed, but I guess the azcopy command might require more permissions than just write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure role permissions for test infrastructure service principal, changing the role assignment to Storage Blob Data Contributor for enhanced access capabilities on the storage container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->