### PR TITLE
chore: bump Go builder images to 1.26.4 (CVE-2026-42504)

### DIFF
--- a/services/dis-apim-operator/Dockerfile
+++ b/services/dis-apim-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.26.3 AS builder
+FROM docker.io/golang:1.26.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/services/dis-identity-operator/Dockerfile
+++ b/services/dis-identity-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.26.3 AS builder
+FROM docker.io/golang:1.26.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/services/dis-vault-operator/Dockerfile
+++ b/services/dis-vault-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/services/lakmus/Dockerfile
+++ b/services/lakmus/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Why
The Trivy image-scan gate (severity CRITICAL,HIGH, ignore-unfixed) fails any image built with the Go 1.26.3 stdlib because of CVE-2026-42504 (HIGH, fixed in Go 1.25.11 / 1.26.4). dis-pgsql-operator was already bumped in #3676 and dis-console was bumped in #3726; the remaining services still pinned the vulnerable builder image and would trip the same gate on their next PR.

## What
Bump the Go builder image from 1.26.3 to 1.26.4 in four Dockerfiles, keeping each file's existing registry-prefix style:

- `services/dis-vault-operator`: `golang:1.26.4`
- `services/dis-apim-operator` and `services/dis-identity-operator`: `docker.io/golang:1.26.4`
- `services/lakmus`: `golang:1.26.4-alpine` as a bare tag (digest dropped) — Renovate maintains the digest pins on these images and will open a follow-up PR to re-pin, matching the bare-tag style of the other operators here.

(`services/dis-console` was bumped to 1.26.4 by #3726 and is already on main, so it is not part of this diff.)

No Go code changes: all go.mod `go` directives are <= 1.26.x and unaffected by the builder bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)