### PR TITLE
feat(syncroots): add adminservices environments for the studio pusher

### DIFF
--- a/infrastructure/syncroots/terraform.tfvars.json
+++ b/infrastructure/syncroots/terraform.tfvars.json
@@ -33,7 +33,10 @@
     },
     "studio": {
       "repo_name": "altinn-studio",
-      "environments": [],
+      "environments": [
+        "adminservices_test",
+        "adminservices_prod"
+      ],
       "branches": [
         "main"
       ]


### PR DESCRIPTION
Adds `adminservices_test` and `adminservices_prod` to the `studio` entry, so the syncroot-github-repo module creates federated credentials for the subjects `repo:Altinn/altinn-studio:environment:adminservices_test|adminservices_prod`.

## Why

Altinn/altinn-studio#19150 adds a workflow that pushes the studio admin syncroot. Review feedback there (and the existing runtime pattern, e.g. `runtime_tt_ring1`) is to run the tag jobs under area-specific GitHub environments. A job that declares `environment:` gets an environment-scoped OIDC subject, which the pusher's current federated credentials (branch `main` only) don't match — this PR adds the matching credentials.

`adminservices_prod` is included now so prod onboarding later only needs a tag-matrix entry plus required reviewers on the environment; the credential is inert until a job uses it. The `main` branch credential stays for the sha-push job. Secrets remain repo-level (environment jobs can read them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration for environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->