### PR TITLE
feat(gh-runners): add dialogporten-manifests runners

### DIFF
--- a/infrastructure/gh-runners/dialogporten-manifests.tf
+++ b/infrastructure/gh-runners/dialogporten-manifests.tf
@@ -1,0 +1,19 @@
+# GitHub: Altinn/dialogporten-manifests (product: altinn-dialogporten)
+module "gh_runners_dialogporten_manifests" {
+  source = "../modules/gh-runners"
+
+  resource_group_name           = azurerm_resource_group.gh_runners.name
+  repository_name               = "dialogporten-manifests"
+  private_runners_address_space = "172.17.134.0/24"
+  private_runners_prefix        = "dpm"
+  altinn_app_id                 = var.altinn_app_id
+  altinn_app_install_id         = var.altinn_app_install_id
+  altinn_app_key                = var.altinn_app_key
+  host_ip                       = var.host_ip
+  runner_cpu                    = "4.0"
+  runner_memory                 = "8Gi"
+  tags = merge(local.tags, {
+    finops_product = "dialogporten"
+    product        = "dialogporten"
+  })
+}


### PR DESCRIPTION
## What

Adds private GitHub Actions runners for [`Altinn/dialogporten-manifests`](https://github.com/altinn/dialogporten-manifests), following the existing per-repo pattern in `infrastructure/gh-runners/`.

## Details

New file `infrastructure/gh-runners/dialogporten-manifests.tf` instantiating the shared `modules/gh-runners` module with:

- **`repository_name`**: `dialogporten-manifests`
- **`private_runners_address_space`**: `172.17.134.0/24` — next free `/24` in the `172.17.128.0/16` range (128–133 already allocated)
- **`private_runners_prefix`**: `dpm` — unique, short (keeps generated Key Vault names within Azure's 24-char limit)
- **`runner_cpu` / `runner_memory`**: `4.0` / `8Gi`
- **tags**: `dialogporten` finops/product — mirroring the sibling `dialogporten.tf`

## Verification

- `terraform fmt -check` passes for the directory
- No CIDR or prefix collisions across existing runner definitions

Could not run `terraform validate`/`plan` locally (requires the Azure backend + credentials); deployment is handled automatically by `altinn-org-gh-runners-deploy.yml` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established GitHub Actions runner infrastructure with configured resource allocation and network settings to support continuous integration and automated deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->