### PR TITLE
fix(dis-console): rename central DatabaseServer to dis-console-central

### DIFF
--- a/deploy/admin/base/dis-console-databaseserver.yaml
+++ b/deploy/admin/base/dis-console-databaseserver.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.dis.altinn.cloud/v1alpha1
 kind: DatabaseServer
 metadata:
-  name: dis-console-db-server
+  name: dis-console-central
   namespace: product-dis
 spec:
   version: 17

--- a/deploy/templates/dis-console-tenant-db-template/database.yaml
+++ b/deploy/templates/dis-console-tenant-db-template/database.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   name: ${DISDB_PGNAME}
   server:
-    name: dis-console-db-server
+    name: dis-console-central
   access:
     principals:
       - role: Owner


### PR DESCRIPTION
## Problem

The central `dis-console-db-server` we added in #3716 never provisions on admin-test — its ASO `FlexibleServer` fails with `ServerNameAlreadyExists`.

Root cause: Azure PostgreSQL Flexible Server names are **globally unique**, and the dis-pgsql operator uses the `DatabaseServer` `metadata.name` **verbatim** as the Azure server name (`serverName := db.Name` → `AzureName: serverName`). The legacy per-cluster dis-console PoC already owns the name `dis-console-db-server` (its `DatabaseServer` CRs are still on main in `deploy/common/at22` and `deploy/common/at23`), so the central one collides. Freeing the name isn't viable (those CRs are still applied and `deletionPolicy: Retain` keeps the Azure server), so we rename the central server instead.

## Change

- `deploy/admin/base/dis-console-databaseserver.yaml` → `metadata.name: dis-console-central`
- `deploy/templates/dis-console-tenant-db-template/database.yaml` → `spec.server.name: dis-console-central`

The legacy per-cluster `dis-console-db-server` servers are intentionally untouched (they keep their name until decommissioned). The new name is permanent — no rename-back later.

## Follow-ups (separate repos)

- **ttd infra**: `terraform/at23/dis-pgsql.tf` `database_server_name` → `dis-console-central` (drives the derived private DNS zone; must match). Handled in the ttd repo.
- **operator hardening** (tracked separately): the failure surfaced as a misleading "Server Parameter Errors: owner FlexibleServer cannot be found" instead of a clear `ServerNameAlreadyExists` on the DatabaseServer status, and there's no admission guard for globally-taken names.

## After merge

Re-dispatch **Publish DIS Admin Syncroot Artifacts** (`test`) so the renamed manifests ship; the operator then provisions `dis-console-central` and the FlexibleServer should reach Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database server naming and configuration references in deployment templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->