### PR TITLE
Update refs to point to bitnami instead of bitnami-labs

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_k8s.tf
@@ -59,7 +59,7 @@ resource "azurerm_kubernetes_cluster" "k6tests" {
     name                 = "default"
     auto_scaling_enabled = true
     min_count            = 1
-    max_count            = 10
+    max_count            = 5
     vm_size              = "Standard_D4s_v6"
     upgrade_settings { # Adding these to keep plans clean
       drain_timeout_in_minutes      = 0

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_sealsedsecrets.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_sealsedsecrets.tf
@@ -4,7 +4,7 @@ resource "helm_release" "sealed_secrets" {
   name             = "sealedsecrets"
   namespace        = "sealedsecrets-system"
   create_namespace = true
-  repository       = "https://bitnami-labs.github.io/sealed-secrets"
+  repository       = "https://bitnami.github.io/sealed-secrets"
   chart            = "sealed-secrets"
   version          = "2.18.6"
 }

--- a/infrastructure/adminservices-test/k6tests-rg/modules/services/sealsedsecrets.tf
+++ b/infrastructure/adminservices-test/k6tests-rg/modules/services/sealsedsecrets.tf
@@ -3,7 +3,7 @@ resource "helm_release" "sealed_secrets" {
   name             = "sealedsecrets"
   namespace        = "sealedsecrets-system"
   create_namespace = true
-  repository       = "https://bitnami-labs.github.io/sealed-secrets"
+  repository       = "https://bitnami.github.io/sealed-secrets"
   chart            = "sealed-secrets"
   version          = "2.18.6"
 }

--- a/infrastructure/images/k6-action/Dockerfile
+++ b/infrastructure/images/k6-action/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-alpine@sha256:a6a091eac01ceac4b97496fe2957a49b6cdd83365337d5f46f6f73710424e805  AS builder
 # renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubectl versioning=semver extractVersion=^kubernetes-(?<version>.*)$
 ARG KUBECTL_VERSION=1.36.2
-# renovate: datasource=github-releases depName=kubeseal packageName=bitnami-labs/sealed-secrets versioning=semver extractVersion=^sealed-secrets-(?<version>.*)$
+# renovate: datasource=github-releases depName=kubeseal packageName=bitnami/sealed-secrets versioning=semver extractVersion=^sealed-secrets-(?<version>.*)$
 ARG KUBESEAL_VERSION=0.37.0
 # renovate: datasource=github-releases depName=jsonnet packageName=google/jsonnet versioning=semver
 ARG JSONNET_VERSION=0.22.0
@@ -26,7 +26,7 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kube
     chmod +x kubectl && mv kubectl /usr/local/bin
 
 # Install kubeseal
-RUN curl -OL "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz" &&\
+RUN curl -OL "https://github.com/bitnami/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz" &&\
     tar -xvzf kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz kubeseal &&\
     chmod +x kubeseal && mv kubeseal /usr/local/bin
 

--- a/infrastructure/images/k6-action/get_latest_versions.sh
+++ b/infrastructure/images/k6-action/get_latest_versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 KUBECTL_VERSION="$(curl -L -s https://dl.k8s.io/release/stable.txt)"
-KUBESEAL_VERSION=$(curl -s https://api.github.com/repos/bitnami-labs/sealed-secrets/tags | jq -r '.[0].name')
+KUBESEAL_VERSION=$(curl -s https://api.github.com/repos/bitnami/sealed-secrets/tags | jq -r '.[0].name')
 JSONNET_VERSION=$(curl -s https://api.github.com/repos/google/jsonnet/tags | jq -r '.[0].name')
 K6_VERSION=$(curl -s https://api.github.com/repos/grafana/k6/tags | jq -r '.[0].name')
 JB_VERSION=$(curl -s https://api.github.com/repos/jsonnet-bundler/jsonnet-bundler/tags | jq -r '.[0].name')


### PR DESCRIPTION
They have moved the repository to the bitnami org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Updated Sealed Secrets configuration to reference the current official repository source, ensuring continued compatibility and access to the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->