### PR TITLE
fix(dis-pgsql-operator): pin e2e kubectl to a dedicated Kind kubeconfig

### DIFF
--- a/services/dis-pgsql-operator/Makefile
+++ b/services/dis-pgsql-operator/Makefile
@@ -157,6 +157,11 @@ run-checks-ci: ## Run CI checks with local Go caches.
 KIND_CLUSTER ?= dis-pgsql-operator-test-e2e
 E2E_TEST_TIMEOUT ?= 30m
 
+# Dedicated kubeconfig for the Kind e2e cluster. The whole e2e flow points KUBECONFIG
+# here so every kubectl/make step targets the Kind cluster this Makefile created, never
+# the caller's current context (which would otherwise silently apply to the wrong cluster).
+KIND_KUBECONFIG ?= $(LOCALBIN)/kind-$(KIND_CLUSTER).kubeconfig
+
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	@command -v $(KIND) >/dev/null 2>&1 || { \
@@ -175,20 +180,23 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 		echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 		$(KIND) create cluster --name $(KIND_CLUSTER); \
 	fi
+	@mkdir -p "$(LOCALBIN)"
+	@$(KIND) export kubeconfig --name "$(KIND_CLUSTER)" --kubeconfig "$(KIND_KUBECONFIG)"
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout=$(E2E_TEST_TIMEOUT)
+	KUBECONFIG="$(KIND_KUBECONFIG)" CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout=$(E2E_TEST_TIMEOUT)
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: test-e2e-kind
+test-e2e-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
 test-e2e-kind: cleanup-test-e2e setup-test-e2e docker-build kind-load install install-aso-crds-kind install-dis-identity-crd-kind deploy-kind
 	kubectl apply -f config/samples/storage_v1alpha1_databaseserver.yaml
 	$(MAKE) seed-dis-identity-kind
 
 .PHONY: test-e2e-kind-ci
 test-e2e-kind-ci: cleanup-test-e2e setup-test-e2e manifests generate fmt vet install-aso-crds-kind install-dis-identity-crd-kind ## Run the e2e tests on Kind and cleanup (CI).
-	CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout=$(E2E_TEST_TIMEOUT)
+	KUBECONFIG="$(KIND_KUBECONFIG)" CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout=$(E2E_TEST_TIMEOUT)
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e
@@ -196,6 +204,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: install-aso-crds-kind
+install-aso-crds-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
 install-aso-crds-kind: aso-crds
 	kubectl apply --server-side --force-conflicts -f bin/aso-crds/
 
@@ -225,10 +234,12 @@ install-aso-crds-kind: aso-crds
 	-p='[{"op":"replace","path":"/spec/conversion","value":{"strategy":"None"}}]'
 
 .PHONY: install-dis-identity-crd-kind
+install-dis-identity-crd-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
 install-dis-identity-crd-kind: dis-identity-crd
 	kubectl apply --server-side --force-conflicts -f $(DIS_IDENTITY_CRD_FILE)
 
 .PHONY: seed-dis-identity-kind
+seed-dis-identity-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
 seed-dis-identity-kind: ## Apply ApplicationIdentity stubs and patch status for Kind tests.
 	kubectl apply -f config/kind/applicationidentities.yaml
 	kubectl patch applicationidentity adminidentity -n default \
@@ -329,6 +340,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 		"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
 
 .PHONY: deploy-kind
+deploy-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
 deploy-kind: manifests kustomize ## Deploy controller to a Kind cluster (IfNotPresent pull policy).
 	@set -e; \
 		trap '$(MAKE) -C "$(CURDIR)" restore-kustomize >/dev/null' EXIT; \


### PR DESCRIPTION
## Problem
The e2e flow ran bare `kubectl` against the caller's **current** kube-context instead of the Kind cluster the suite creates. `setup-test-e2e` only pins `--context` for its reachability probe; `install-aso-crds-kind` (and the other `*-kind` targets, plus the Go-side `kubectl` calls) did not. So if your current context pointed elsewhere — or you switched it mid-run — `make install-aso-crds-kind` applied the full ASO CRD catalog to the wrong cluster, failing with `ServiceUnavailable` (or silently applying ~200 CRDs to whatever cluster you were pointed at).

## Fix
Isolate the entire e2e run to a dedicated kubeconfig for the Kind cluster:

- `setup-test-e2e` exports the created/reused cluster's config to `bin/kind-<cluster>.kubeconfig`.
- `test-e2e` / `test-e2e-kind-ci` run `go test` with `KUBECONFIG` pointed at that file. Via process-env inheritance this reaches every `make` sub-target the Go suite spawns **and** every bare `kubectl` it runs.
- The Kind-specific targets (`install-aso-crds-kind`, `install-dis-identity-crd-kind`, `seed-dis-identity-kind`, `deploy-kind`, `test-e2e-kind`) also pin it via target-scoped `export KUBECONFIG = $(KIND_KUBECONFIG)`, so direct invocations are safe too — and a missing kubeconfig fails cleanly instead of hitting the wrong cluster.

The generic `install` / `uninstall` / `undeploy` targets are left untouched (they're dual-use for real clusters); they only inherit the Kind kubeconfig when invoked by the suite.

> Note: the target-scoped assignment uses deferred `=` (not `:=`) because macOS ships GNU Make 3.81, which expands target-scoped `:=` at parse time — before `LOCALBIN` is defined later in the file — producing an empty path.

## Validation
- `make -n` dry-runs confirm the wiring (kubeconfig export in `setup-test-e2e`, `KUBECONFIG=` on the `go test` line, and target-scoped resolution to the full `bin/…kubeconfig` path).
- `make test-e2e` runs against the Kind cluster (podman); the current kube-context no longer affects the run and `~/.kube/config` is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure configuration for consistent kubeconfig handling in e2e testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->