### PR TITLE
fix(make): pin e2e kubectl to a dedicated Kind kubeconfig in Makefile.common

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -108,6 +108,11 @@ test: $(TEST_DEPS) ## Run tests.
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= $(APP_NAME)-test-e2e
 
+# Dedicated kubeconfig for the Kind e2e cluster. The e2e flow points KUBECONFIG here so
+# every kubectl/make step targets the Kind cluster this Makefile created, never the
+# caller's current context (which would otherwise silently apply to the wrong cluster).
+KIND_KUBECONFIG ?= $(LOCALBIN)/kind-$(KIND_CLUSTER).kubeconfig
+
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	@command -v $(KIND) >/dev/null 2>&1 || { \
@@ -121,10 +126,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@mkdir -p "$(LOCALBIN)"
+	@$(KIND) export kubeconfig --name "$(KIND_CLUSTER)" --kubeconfig "$(KIND_KUBECONFIG)"
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	@rc=0; KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v || rc=$$?; \
+	@rc=0; KUBECONFIG="$(KIND_KUBECONFIG)" KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v || rc=$$?; \
 	$(MAKE) cleanup-test-e2e; \
 	exit $$rc
 


### PR DESCRIPTION
## Problem
The shared e2e flow in `Makefile.common` ran `go test` (and thus every `make` sub-target and `kubectl` the suite shells out to) against the caller's **current** kube-context instead of the Kind cluster `setup-test-e2e` creates. If your current context pointed elsewhere — or you switched it mid-run — e2e steps applied to the wrong cluster (e.g. failing with `ServiceUnavailable`, or silently applying CRDs to whatever cluster you were pointed at).

Same root cause fixed for the standalone dis-pgsql-operator Makefile in #3720; this puts the fix in the shared file so every service that includes `Makefile.common` (today `dis-console`, and others as they migrate) benefits.

## Fix
Isolate the e2e run to a dedicated kubeconfig for the Kind cluster:
- New `KIND_KUBECONFIG ?= $(LOCALBIN)/kind-$(KIND_CLUSTER).kubeconfig`.
- `setup-test-e2e` exports the created/reused cluster's config to that file.
- `test-e2e` runs `go test` with `KUBECONFIG` pointed at it. Via process-env inheritance this reaches every `make` sub-target the Go suite spawns (incl. each service's own `install-aso-crds-kind`) **and** every bare `kubectl` in the Go test code.

The caller's `~/.kube/config` and current-context are left untouched and no longer affect the run.

## Scope / notes
- Standalone Makefiles (`dis-pgsql-operator`, `dis-identity-operator`, `dis-vault-operator`, `dis-apim-operator`, `lakmus`) don't include `Makefile.common`; they each carry the same latent issue and can be fixed as they migrate (dis-pgsql is handled by #3720).
- Per-service `install-aso-crds-kind` targets are covered for the **suite** flow via the inherited `KUBECONFIG`; pinning them for *direct* invocation is a per-service follow-up.

## Validation
- `make -n setup-test-e2e` (via dis-console) emits `kind export kubeconfig --kubeconfig …/services/dis-console/bin/kind-dis-console-test-e2e.kubeconfig`; `KIND_KUBECONFIG` resolves correctly at recipe time.
- Mirrors the mechanism validated end-to-end on Kind in #3720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
