### PR TITLE
fix(dis-pgsql-operator): surface FlexibleServer errors on DatabaseServer status

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -2233,6 +2233,127 @@ var _ = Describe("DatabaseServer controller", func() {
 			Should(Equal(metav1.ConditionTrue))
 	})
 
+	It("surfaces a ServerNameConflict and suppresses owner-not-found parameter errors when the FlexibleServer name is taken", func() {
+		db := newDedicatedDatabaseServer("my-app-db-name-conflict", adminAuth(
+			adminManagedIdentity,
+			adminManagedIdentityID,
+			adminManagedIdentity,
+		))
+		db.Spec.ServerParams = []storagev1alpha1.DatabaseServerParameter{
+			{
+				Name:  paramAutovacuumNaptime,
+				Value: intstr.FromInt(15),
+			},
+		}
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+
+		parameterConfigName := serverParameterConfigResourceName(db.Name, paramAutovacuumNaptime)
+
+		// Wait until the operator has created the FlexibleServer and its parameter
+		// configuration child.
+		Eventually(func(g Gomega) {
+			var server dbforpostgresqlv1.FlexibleServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &server)).To(Succeed())
+
+			var configuration dbforpostgresqlv1.FlexibleServersConfiguration
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      parameterConfigName,
+				Namespace: db.Namespace,
+			}, &configuration)).To(Succeed())
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		// Azure rejects the create because the (globally unique) server name is taken.
+		// ASO classifies this as retryable, so it is reported as a Warning-severity
+		// Ready=False on the FlexibleServer (distinct from the Info-severity
+		// "Reconciling" state used during normal provisioning).
+		Eventually(func() error {
+			var server dbforpostgresqlv1.FlexibleServer
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &server); err != nil {
+				return err
+			}
+			server.Status.Conditions = []asoconditions.Condition{
+				{
+					Type:               asoconditions.ConditionTypeReady,
+					Status:             metav1.ConditionFalse,
+					Severity:           asoconditions.ConditionSeverityWarning,
+					Reason:             azureReasonServerNameAlreadyExists,
+					Message:            fmt.Sprintf("Server name '%s' already exists.", db.Name),
+					LastTransitionTime: metav1.Now(),
+					ObservedGeneration: server.Generation,
+				},
+			}
+			return k8sClient.Status().Update(ctx, &server)
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		// ASO then blocks the child configuration on its missing owner. This is the
+		// misleading symptom that must NOT surface on the DatabaseServer.
+		Eventually(func() error {
+			var configuration dbforpostgresqlv1.FlexibleServersConfiguration
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      parameterConfigName,
+				Namespace: db.Namespace,
+			}, &configuration); err != nil {
+				return err
+			}
+			configuration.Status.Conditions = []asoconditions.Condition{
+				{
+					Type:               asoconditions.ConditionTypeReady,
+					Status:             metav1.ConditionFalse,
+					Severity:           asoconditions.ConditionSeverityWarning,
+					Reason:             "ReconciliationBlocked",
+					Message:            fmt.Sprintf("Owner %q cannot be found. Progress is blocked until the owner is created.", db.Name),
+					LastTransitionTime: metav1.Now(),
+					ObservedGeneration: configuration.Generation,
+				},
+			}
+			return k8sClient.Status().Update(ctx, &configuration)
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		// The DatabaseServer surfaces the real Azure error with an actionable message.
+		Eventually(func(g Gomega) {
+			var updated storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &updated)).To(Succeed())
+
+			ready := meta.FindStatusCondition(updated.Status.Conditions, databaseServerConditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(ready.Reason).To(Equal(databaseServerReasonServerNameConflict))
+			g.Expect(ready.Message).To(ContainSubstring(db.Name))
+			g.Expect(ready.Message).To(ContainSubstring("globally unique"))
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		// It never surfaces the misleading owner-not-found parameter error, and stays in
+		// the conflict state instead of flapping back to it.
+		Consistently(func(g Gomega) {
+			var updated storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &updated)).To(Succeed())
+
+			g.Expect(updated.Status.ServerParameterErrors).To(BeEmpty())
+			g.Expect(meta.FindStatusCondition(updated.Status.Conditions, serverParametersReadyConditionType)).To(BeNil())
+
+			ready := meta.FindStatusCondition(updated.Status.Conditions, databaseServerConditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Reason).To(Equal(databaseServerReasonServerNameConflict))
+		}).WithTimeout(3 * time.Second).WithPolling(250 * time.Millisecond).
+			Should(Succeed())
+	})
+
 	It("resolves ApplicationIdentity references for server admin", func() {
 		createApplicationIdentity(ctx, "adminidentity", adminManagedIdentity, adminManagedIdentityID)
 

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	identityv1alpha1 "github.com/Altinn/altinn-platform/services/dis-identity-operator/api/v1alpha1"
@@ -33,6 +34,15 @@ const (
 	databaseServerConditionReady = "Ready"
 	databaseServerReasonReady    = "Ready"
 	databaseServerReasonWaiting  = "Waiting"
+
+	// databaseServerReasonServerNameConflict marks a DatabaseServer whose Azure server
+	// name is already taken. Flexible Server names are globally unique, so this is a
+	// blocked state the author must resolve by choosing a unique DatabaseServer name.
+	databaseServerReasonServerNameConflict = "ServerNameConflict"
+
+	// azureReasonServerNameAlreadyExists is the reason ASO sets on the FlexibleServer's
+	// Ready condition when Azure rejects the create because the name is already in use.
+	azureReasonServerNameAlreadyExists = "ServerNameAlreadyExists"
 )
 
 // DatabaseServerReconciler reconciles the current DatabaseServer CRD as a PostgreSQL server.
@@ -228,6 +238,19 @@ func (r *DatabaseServerReconciler) reconcileCommonDatabaseServerResources(
 	logger logr.Logger,
 	db *storagev1alpha1.DatabaseServer,
 ) (ctrl.Result, error) {
+	// Surface a blocked/failed FlexibleServer (e.g. a globally-taken server name) on the
+	// DatabaseServer before reconciling the server's child resources. The owned
+	// FlexibleServersConfiguration/administrator children only report a misleading
+	// "owner cannot be found" error while the server itself is the resource that failed,
+	// so checking the server first keeps the real cause visible. Skipped under az fakes,
+	// mirroring the asoResourcesReady check below.
+	if !r.Config.UseAzFakes {
+		blocked, result, err := r.surfaceBlockedFlexibleServer(ctx, logger, db)
+		if err != nil || blocked {
+			return result, err
+		}
+	}
+
 	if err := r.ensurePostgresExtensionSettings(ctx, logger, db); err != nil {
 		logger.Error(err, "failed to ensure PostgreSQL extension settings for database server")
 		return ctrl.Result{}, err
@@ -397,13 +420,120 @@ func (r *DatabaseServerReconciler) asoResourcesReady(
 func readyConditionInfo(
 	conds []asoconditions.Condition,
 ) (status metav1.ConditionStatus, reason, message string, ok bool) {
+	cond, found := findReadyCondition(conds)
+	if !found {
+		return "", "", "", false
+	}
+	return cond.Status, cond.Reason, cond.Message, true
+}
+
+// findReadyCondition returns the ASO Ready condition, if present.
+func findReadyCondition(conds []asoconditions.Condition) (asoconditions.Condition, bool) {
 	for i := range conds {
-		cond := conds[i]
-		if cond.Type == asoconditions.ConditionTypeReady {
-			return cond.Status, cond.Reason, cond.Message, true
+		if conds[i].Type == asoconditions.ConditionTypeReady {
+			return conds[i], true
 		}
 	}
-	return "", "", "", false
+	return asoconditions.Condition{}, false
+}
+
+// surfaceBlockedFlexibleServer inspects the owned FlexibleServer after it has been
+// ensured. When the server reports a non-transient Ready=False state (an actual Azure
+// failure such as ServerNameAlreadyExists, as opposed to the normal "Reconciling"
+// progress, which is also Ready=False but with Info severity), it records that failure on
+// the DatabaseServer Ready condition, clears any stale server-parameter errors, and asks
+// the caller to stop before the server's child resources are reconciled. It returns
+// blocked=false for the healthy/in-progress cases so reconciliation proceeds as usual.
+func (r *DatabaseServerReconciler) surfaceBlockedFlexibleServer(
+	ctx context.Context,
+	logger logr.Logger,
+	db *storagev1alpha1.DatabaseServer,
+) (bool, ctrl.Result, error) {
+	var server dbforpostgresqlv1.FlexibleServer
+	if err := r.Get(ctx, types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, &server); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Just created (or cache lag): nothing to surface yet.
+			return false, ctrl.Result{}, nil
+		}
+		return false, ctrl.Result{}, fmt.Errorf("get FlexibleServer %s/%s: %w", db.Namespace, db.Name, err)
+	}
+
+	cond, ok := findReadyCondition(server.Status.Conditions)
+	if !ok || cond.Status != metav1.ConditionFalse {
+		// No Ready condition yet, or it is True/Unknown: not a failure.
+		return false, ctrl.Result{}, nil
+	}
+	if cond.Severity == asoconditions.ConditionSeverityInfo || cond.Severity == asoconditions.ConditionSeverityNone {
+		// Ready=False at Info severity is the normal in-progress (Reconciling) state.
+		return false, ctrl.Result{}, nil
+	}
+
+	reason, message := describeBlockedFlexibleServer(db.Name, cond.Reason, cond.Message)
+	logger.Info("FlexibleServer reported a blocked state; surfacing it on the DatabaseServer and deferring child resources",
+		"server", db.Name,
+		"flexibleServerReason", cond.Reason,
+		"severity", string(cond.Severity),
+	)
+	if err := r.setDatabaseServerBlockedCondition(ctx, db, reason, message); err != nil {
+		return false, ctrl.Result{}, err
+	}
+
+	// Requeue: the block may clear once the conflicting name is freed.
+	return true, ctrl.Result{RequeueAfter: time.Minute}, nil
+}
+
+// describeBlockedFlexibleServer maps a FlexibleServer Ready=False reason/message to a
+// DatabaseServer condition reason/message, giving known-terminal Azure errors an
+// actionable explanation while passing other failures through unchanged.
+func describeBlockedFlexibleServer(serverName, asoReason, asoMessage string) (reason, message string) {
+	asoMessage = strings.TrimSpace(asoMessage)
+	switch asoReason {
+	case azureReasonServerNameAlreadyExists:
+		message = fmt.Sprintf(
+			"Azure PostgreSQL server name %q is already in use. Flexible Server names are globally unique, so choose a unique DatabaseServer name.",
+			serverName,
+		)
+		if asoMessage != "" {
+			message = fmt.Sprintf("%s Azure reported: %s", message, asoMessage)
+		}
+		return databaseServerReasonServerNameConflict, message
+	default:
+		if asoMessage == "" {
+			asoMessage = "FlexibleServer is not ready"
+		}
+		if asoReason == "" {
+			asoReason = databaseServerReasonWaiting
+		}
+		return asoReason, asoMessage
+	}
+}
+
+// setDatabaseServerBlockedCondition records a blocked Ready=False state and drops any
+// server-parameter errors/condition. While the server itself is blocked, those children
+// only echo the misleading "owner cannot be found" failure, so they are cleared in the
+// same status update to keep the real cause visible.
+func (r *DatabaseServerReconciler) setDatabaseServerBlockedCondition(
+	ctx context.Context,
+	db *storagev1alpha1.DatabaseServer,
+	reason, message string,
+) error {
+	previousStatus := db.Status.DeepCopy()
+
+	db.Status.ServerParameterErrors = nil
+	meta.RemoveStatusCondition(&db.Status.Conditions, serverParametersReadyConditionType)
+	meta.SetStatusCondition(&db.Status.Conditions, metav1.Condition{
+		Type:               databaseServerConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: db.Generation,
+	})
+
+	if apiequality.Semantic.DeepEqual(previousStatus, &db.Status) {
+		return nil
+	}
+
+	return r.Status().Update(ctx, db)
 }
 
 func (r *DatabaseServerReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
## Problem
When two `DatabaseServer`s resolve to the same Azure PostgreSQL Flexible Server name (the name is globally unique), the second never provisions and the failure is **slow and misleading**: ASO reports `ServerNameAlreadyExists` on the owned `FlexibleServer`, but the `DatabaseServer` status instead shows `Server Parameter Errors: Owner "…" cannot be found. Progress is blocked until the owner is created.` — pointing at the wrong resource, because the operator creates the parameter/extension/admin children while the server itself is the thing that actually failed.

## Fix
Before reconciling the server's child resources, inspect the owned `FlexibleServer`'s `Ready` condition (`surfaceBlockedFlexibleServer`):
- If it reports a real failure — `Ready=False` with **non-Info severity** (an actual Azure error; note the normal "Reconciling" progress is *also* `Ready=False` but Info severity) — record it on the `DatabaseServer` `Ready` condition and stop **before** the child resources are reconciled.
- The known-terminal `ServerNameAlreadyExists` is mapped to a distinct reason **`ServerNameConflict`** with an actionable message ("…name is already in use. Flexible Server names are globally unique, so choose a unique DatabaseServer name."), and any stale `serverParameterErrors` are cleared in the same status update.
- Requeues (the block may clear once the name is freed). Skipped under az fakes, mirroring the existing `asoResourcesReady` check.

No name mangling: the Azure server name is a contract (the private DNS zone is derived from it, and the external `dis-pgsql-tenant-access` module derives the same zone), so uniqueness stays the author's responsibility (per RFC 0013).

## Test
New envtest spec reproduces the collision — `FlexibleServer` `Ready=False`/`ServerNameAlreadyExists` plus a child config reporting the misleading "owner cannot be found" — and asserts the `DatabaseServer` surfaces `ServerNameConflict` and never the parameter error.

## Validation
- `make run-checks-ci-cache` — pass (fmt/generate/manifests clean, lint 0 issues).
- `make test-cache` (envtest) — pass; `internal/controller` ~76% coverage, including the new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for Azure FlexibleServer name conflicts with clearer status messages indicating globally unique server name requirements
  * Improved detection and reporting of blocked Azure server states during reconciliation to prevent misleading error messages

* **Tests**
  * Added integration test for verifying proper error reporting when Azure server name conflicts occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->