### PR TITLE
fix(dis-operators): pin e2e to a dedicated Kind kubeconfig

### DIFF
--- a/services/dis-apim-operator/Makefile
+++ b/services/dis-apim-operator/Makefile
@@ -67,6 +67,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= dis-apim-operator-test-e2e
 
+# Dedicated kubeconfig for the Kind e2e cluster. The whole e2e flow points KUBECONFIG
+# here so every kubectl/make step targets the Kind cluster this Makefile created, never
+# the caller's current context (which would otherwise silently apply to the wrong cluster).
+KIND_KUBECONFIG ?= $(LOCALBIN)/kind-$(KIND_CLUSTER).kubeconfig
+
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	@command -v $(KIND) >/dev/null 2>&1 || { \
@@ -80,10 +85,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@mkdir -p "$(LOCALBIN)"
+	@$(KIND) export kubeconfig --name "$(KIND_CLUSTER)" --kubeconfig "$(KIND_KUBECONFIG)"
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
+	KUBECONFIG="$(KIND_KUBECONFIG)" KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/services/dis-identity-operator/Makefile
+++ b/services/dis-identity-operator/Makefile
@@ -67,6 +67,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= dis-identity-operator-test-e2e
 
+# Dedicated kubeconfig for the Kind e2e cluster. The whole e2e flow points KUBECONFIG
+# here so every kubectl/make step targets the Kind cluster this Makefile created, never
+# the caller's current context (which would otherwise silently apply to the wrong cluster).
+KIND_KUBECONFIG ?= $(LOCALBIN)/kind-$(KIND_CLUSTER).kubeconfig
+
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	@command -v $(KIND) >/dev/null 2>&1 || { \
@@ -80,10 +85,12 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@mkdir -p "$(LOCALBIN)"
+	@$(KIND) export kubeconfig --name "$(KIND_CLUSTER)" --kubeconfig "$(KIND_KUBECONFIG)"
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
+	KUBECONFIG="$(KIND_KUBECONFIG)" KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/services/dis-vault-operator/Makefile
+++ b/services/dis-vault-operator/Makefile
@@ -194,6 +194,7 @@ seed-dis-identity-kind: setup-test-e2e ## Seed ApplicationIdentity and ready sta
 		-p '{"status":{"managedIdentityName":"app-identity-sample-managed","principalId":"app-identity-sample-principal","conditions":[{"type":"Ready","status":"True","reason":"Ready","message":"Seeded for Kind e2e","lastTransitionTime":"2026-01-01T00:00:00Z"}]}}'
 
 .PHONY: test-e2e-kind
+test-e2e-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
 test-e2e-kind: cleanup-test-e2e setup-test-e2e docker-build kind-load install install-aso-crds-kind install-dis-identity-crd-kind install-external-secrets-crd-kind deploy-kind ## Setup Kind e2e env and apply samples.
 	$(MAKE) seed-dis-identity-kind
 	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) --context kind-$(KIND_CLUSTER) apply -k config/samples


### PR DESCRIPTION
## What
Roll out the dedicated-kubeconfig e2e fix (mirrors #3720 / #3721) to the remaining standalone operators, so e2e steps always target the Kind cluster the Makefile creates — never the caller's current kube-context.

## Changes
- **dis-identity-operator**, **dis-apim-operator**: add `KIND_KUBECONFIG`, export it in `setup-test-e2e`, and run the e2e `go test` under that `KUBECONFIG`. The suites shell out to `make`/`kubectl` via `utils.Run` (inherits env), so the var propagates to every sub-step.
- **dis-vault-operator**: already pinned via inline `KUBECONFIG=… --context kind-…`; this adds a target-scoped `export KUBECONFIG` to `test-e2e-kind` so its generic `install` prereq also lands on Kind. Deferred `=` (not `:=`) because `$(LOCALBIN)` is defined later and `:=` empties it under GNU Make 3.81 (the bug from #3720).

## Out of scope
- `lakmus` (no Kind e2e targets), `dis-console` (#3721), `dis-pgsql-operator` (#3720).
- Approach B (migrate to `Makefile.common`) left as a separate convergence effort.

## Test
- `make -n setup-test-e2e` / `test-e2e` (identity, apim): kubeconfig resolves to an absolute path; the `go test` line carries `KUBECONFIG`.
- Verified on GNU Make 3.81 that the deferred `=` target-scoped export expands at recipe time (`:=` would empty `$(LOCALBIN)`).
- Full `make test-e2e` on Kind not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
