### PR TITLE
fix(dis-operators): resolve goconst lint debt under golangci-lint v2.12.2

### DIFF
--- a/services/dis-apim-operator/Makefile
+++ b/services/dis-apim-operator/Makefile
@@ -200,7 +200,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/services/dis-apim-operator/internal/controller/predicates_test.go
+++ b/services/dis-apim-operator/internal/controller/predicates_test.go
@@ -10,6 +10,13 @@ import (
 	apimv1alpha1 "github.com/Altinn/altinn-platform/services/dis-apim-operator/api/v1alpha1"
 )
 
+const (
+	nsTest         = "test"
+	nsResourceTest = "resource-test"
+	nsResourceProd = "resource-prod"
+	nsTestProd     = "test-prod"
+)
+
 var _ = Describe("DefaultPredicate", func() {
 	var (
 		namespaceSuffix string
@@ -17,7 +24,7 @@ var _ = Describe("DefaultPredicate", func() {
 	)
 
 	BeforeEach(func() {
-		namespaceSuffix = "test"
+		namespaceSuffix = nsTest
 		pred = defaultPredicate(namespaceSuffix)
 	})
 
@@ -26,7 +33,7 @@ var _ = Describe("DefaultPredicate", func() {
 			createEvent := event.CreateEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 			}
@@ -37,7 +44,7 @@ var _ = Describe("DefaultPredicate", func() {
 			createEvent := event.CreateEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
+						Namespace: nsTest,
 					},
 				},
 			}
@@ -48,7 +55,7 @@ var _ = Describe("DefaultPredicate", func() {
 			createEvent := event.CreateEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-prod",
+						Namespace: nsResourceProd,
 					},
 				},
 			}
@@ -58,7 +65,7 @@ var _ = Describe("DefaultPredicate", func() {
 			createEvent := event.CreateEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-prod",
+						Namespace: nsTestProd,
 					},
 				},
 			}
@@ -71,7 +78,7 @@ var _ = Describe("DefaultPredicate", func() {
 			deleteEvent := event.DeleteEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 			}
@@ -82,7 +89,7 @@ var _ = Describe("DefaultPredicate", func() {
 			deleteEvent := event.DeleteEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
+						Namespace: nsTest,
 					},
 				},
 			}
@@ -93,7 +100,7 @@ var _ = Describe("DefaultPredicate", func() {
 			deleteEvent := event.DeleteEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-prod",
+						Namespace: nsResourceProd,
 					},
 				},
 			}
@@ -103,7 +110,7 @@ var _ = Describe("DefaultPredicate", func() {
 			deleteEvent := event.DeleteEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-prod",
+						Namespace: nsTestProd,
 					},
 				},
 			}
@@ -116,12 +123,12 @@ var _ = Describe("DefaultPredicate", func() {
 			updateEvent := event.UpdateEvent{
 				ObjectOld: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 				ObjectNew: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 			}
@@ -132,12 +139,12 @@ var _ = Describe("DefaultPredicate", func() {
 			updateEvent := event.UpdateEvent{
 				ObjectOld: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
+						Namespace: nsTest,
 					},
 				},
 				ObjectNew: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
+						Namespace: nsTest,
 					},
 				},
 			}
@@ -148,12 +155,12 @@ var _ = Describe("DefaultPredicate", func() {
 			updateEvent := event.UpdateEvent{
 				ObjectOld: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 				ObjectNew: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-prod",
+						Namespace: nsResourceProd,
 					},
 				},
 			}
@@ -164,12 +171,12 @@ var _ = Describe("DefaultPredicate", func() {
 			updateEvent := event.UpdateEvent{
 				ObjectOld: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 				ObjectNew: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-prod",
+						Namespace: nsTestProd,
 					},
 				},
 			}
@@ -182,7 +189,7 @@ var _ = Describe("DefaultPredicate", func() {
 			genericEvent := event.GenericEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-test",
+						Namespace: nsResourceTest,
 					},
 				},
 			}
@@ -193,7 +200,7 @@ var _ = Describe("DefaultPredicate", func() {
 			genericEvent := event.GenericEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
+						Namespace: nsTest,
 					},
 				},
 			}
@@ -204,7 +211,7 @@ var _ = Describe("DefaultPredicate", func() {
 			genericEvent := event.GenericEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "resource-prod",
+						Namespace: nsResourceProd,
 					},
 				},
 			}
@@ -215,7 +222,7 @@ var _ = Describe("DefaultPredicate", func() {
 			genericEvent := event.GenericEvent{
 				Object: &apimv1alpha1.Backend{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-prod",
+						Namespace: nsTestProd,
 					},
 				},
 			}

--- a/services/dis-apim-operator/internal/controller/suite_test.go
+++ b/services/dis-apim-operator/internal/controller/suite_test.go
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 			SubscriptionId:  "fake-subscription-id",
 			ResourceGroup:   "fake-resource-group",
 			ApimServiceName: "fake-apim-service",
-			NamespaceSuffix: "test",
+			NamespaceSuffix: nsTest,
 		},
 		FactoryOptions: &arm.ClientOptions{
 			ClientOptions: azcore.ClientOptions{

--- a/services/dis-apim-operator/internal/utils/policytemplate_test.go
+++ b/services/dis-apim-operator/internal/utils/policytemplate_test.go
@@ -7,6 +7,10 @@ import (
 
 const ValidTemplate = "Hello, {{.Name}}!"
 
+const keyName = "Name"
+
+const valWorld = "World"
+
 var _ = Describe("GeneratePolicyFromTemplate", func() {
 
 	Context("with valid template and data", func() {
@@ -14,7 +18,7 @@ var _ = Describe("GeneratePolicyFromTemplate", func() {
 		It("should generate the correct policy", func() {
 			expected := "Hello, World!"
 			templateContent := ValidTemplate
-			data := map[string]string{"Name": "World"}
+			data := map[string]string{keyName: valWorld}
 			result, err := GeneratePolicyFromTemplate(templateContent, data)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(expected))
@@ -25,7 +29,7 @@ var _ = Describe("GeneratePolicyFromTemplate", func() {
 		It("should generate the correct policy", func() {
 			expected := `Hello, "World"!`
 			templateContent := `Hello, "{{.Name}}"!`
-			data := map[string]string{"Name": "World"}
+			data := map[string]string{keyName: valWorld}
 			result, err := GeneratePolicyFromTemplate(templateContent, data)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(expected))
@@ -36,7 +40,7 @@ var _ = Describe("GeneratePolicyFromTemplate", func() {
 		It("should generate the correct policy", func() {
 			expected := `Hello, "World"!`
 			templateContent := `Hello, "{{ .Name }}"!`
-			data := map[string]string{"Name": "World"}
+			data := map[string]string{keyName: valWorld}
 			result, err := GeneratePolicyFromTemplate(templateContent, data)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(expected))
@@ -68,7 +72,7 @@ var _ = Describe("GeneratePolicyFromTemplate", func() {
 		It("should return an error", func() {
 			expected := ""
 			templateContent := "Hello, {{.Name"
-			data := map[string]string{"Name": "World"}
+			data := map[string]string{keyName: valWorld}
 			result, err := GeneratePolicyFromTemplate(templateContent, data)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(Equal(expected))
@@ -79,7 +83,7 @@ var _ = Describe("GeneratePolicyFromTemplate", func() {
 		It("should return empty string", func() {
 			expected := ""
 			templateContent := ""
-			data := map[string]string{"Name": "World"}
+			data := map[string]string{keyName: valWorld}
 			result, err := GeneratePolicyFromTemplate(templateContent, data)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(expected))

--- a/services/dis-identity-operator/Makefile
+++ b/services/dis-identity-operator/Makefile
@@ -200,7 +200,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/services/dis-identity-operator/internal/controller/applicationidentity_controller.go
+++ b/services/dis-identity-operator/internal/controller/applicationidentity_controller.go
@@ -38,6 +38,9 @@ import (
 
 const applicationIdentityFinalizer = "applicationidentity.application.dis.altinn.cloud/finalizer"
 
+// conditionReasonSucceeded is the condition Reason indicating successful provisioning.
+const conditionReasonSucceeded = "Succeeded"
+
 // ApplicationIdentityReconciler reconciles a ApplicationIdentity object
 type ApplicationIdentityReconciler struct {
 	client.Client
@@ -168,7 +171,7 @@ func (r *ApplicationIdentityReconciler) Reconcile(ctx context.Context, req ctrl.
 			logger.Error(err, "unable to create ServiceAccount")
 			_ = r.patchReadyStatusCondition(ctx, applicationIdentity, metav1.Condition{
 				Type:               string(applicationv1alpha1.ConditionReady),
-				Status:             "False",
+				Status:             metav1.ConditionFalse,
 				ObservedGeneration: applicationIdentity.Generation,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "Failed to create ServiceAccount",
@@ -182,7 +185,7 @@ func (r *ApplicationIdentityReconciler) Reconcile(ctx context.Context, req ctrl.
 			logger.Error(err, "unable to update ServiceAccount")
 			_ = r.patchReadyStatusCondition(ctx, applicationIdentity, metav1.Condition{
 				Type:               string(applicationv1alpha1.ConditionReady),
-				Status:             "False",
+				Status:             metav1.ConditionFalse,
 				ObservedGeneration: applicationIdentity.Generation,
 				LastTransitionTime: metav1.Now(),
 				Reason:             "Failed to update ServiceAccount",
@@ -193,10 +196,10 @@ func (r *ApplicationIdentityReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	err = r.patchReadyStatusCondition(ctx, applicationIdentity, metav1.Condition{
 		Type:               string(applicationv1alpha1.ConditionReady),
-		Status:             "True",
+		Status:             metav1.ConditionTrue,
 		ObservedGeneration: applicationIdentity.Generation,
 		LastTransitionTime: metav1.Now(),
-		Reason:             "Succeeded",
+		Reason:             conditionReasonSucceeded,
 		Message:            "",
 	})
 	return ctrl.Result{}, err
@@ -226,13 +229,13 @@ func (r *ApplicationIdentityReconciler) SetupWithManager(mgr ctrl.Manager) error
 
 func getReadyConditionFromStatus(status []conditions.Condition) conditions.Condition {
 	for _, condition := range status {
-		if condition.Type == "Ready" {
+		if condition.Type == conditions.ConditionTypeReady {
 			return condition
 		}
 	}
 	return conditions.Condition{
-		Type:    "Ready",
-		Status:  "False",
+		Type:    conditions.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
 		Reason:  "NoStatus",
 		Message: "No status available from the underlying resource",
 	}

--- a/services/dis-identity-operator/internal/controller/applicationidentity_controller_federation.go
+++ b/services/dis-identity-operator/internal/controller/applicationidentity_controller_federation.go
@@ -5,6 +5,7 @@ import (
 
 	managedidentity "github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,7 +49,7 @@ func (r *ApplicationIdentityReconciler) updateFederatedCredentialsStatus(ctx con
 
 	// Check if the FederatedIdentityCredential is ready
 	readyCondition := getReadyConditionFromStatus(credential.Status.Conditions)
-	if readyCondition.Status == "True" {
+	if readyCondition.Status == metav1.ConditionTrue {
 		applicationIdentity.Status.AzureAudiences = credential.Status.Audiences
 		ready = true
 	}

--- a/services/dis-identity-operator/internal/controller/applicationidentity_controller_identity.go
+++ b/services/dis-identity-operator/internal/controller/applicationidentity_controller_identity.go
@@ -5,6 +5,7 @@ import (
 
 	managedidentity "github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -73,7 +74,7 @@ func (r *ApplicationIdentityReconciler) updateUserAssignedIdentityStatus(ctx con
 	ready := false
 	orig := applicationIdentity.DeepCopy()
 	patch := client.MergeFrom(orig)
-	if readyCondition.Status == "True" {
+	if readyCondition.Status == metav1.ConditionTrue {
 		applicationIdentity.Status.PrincipalID = uaID.Status.PrincipalId
 		applicationIdentity.Status.ClientID = uaID.Status.ClientId
 		applicationIdentity.Status.ManagedIdentityName = utils.ToPointer(uaID.Spec.AzureName)

--- a/services/dis-identity-operator/internal/controller/applicationidentity_controller_test.go
+++ b/services/dis-identity-operator/internal/controller/applicationidentity_controller_test.go
@@ -115,9 +115,9 @@ var _ = Describe("ApplicationIdentity Controller", func() {
 			// Update the UAID status
 			uaID.Status.Conditions = []conditions.Condition{
 				{
-					Type:               "Ready",
-					Status:             "True",
-					Reason:             "Succeeded",
+					Type:               conditions.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             conditionReasonSucceeded,
 					ObservedGeneration: uaID.Generation,
 					LastTransitionTime: metav1.Now(),
 				},
@@ -157,9 +157,9 @@ var _ = Describe("ApplicationIdentity Controller", func() {
 			// Update the UAID status
 			uaID.Status.Conditions = []conditions.Condition{
 				{
-					Type:               "Ready",
-					Status:             "True",
-					Reason:             "Succeeded",
+					Type:               conditions.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             conditionReasonSucceeded,
 					ObservedGeneration: uaID.Generation,
 					LastTransitionTime: metav1.Now(),
 				},
@@ -179,9 +179,9 @@ var _ = Describe("ApplicationIdentity Controller", func() {
 			// Update the FederatedIdentityCredential status
 			federatedCredential.Status.Conditions = []conditions.Condition{
 				{
-					Type:               "Ready",
-					Status:             "True",
-					Reason:             "Succeeded",
+					Type:               conditions.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             conditionReasonSucceeded,
 					ObservedGeneration: federatedCredential.Generation,
 					LastTransitionTime: metav1.Now(),
 				},
@@ -212,7 +212,7 @@ var _ = Describe("ApplicationIdentity Controller", func() {
 				for _, condition := range appIdentity.Status.Conditions {
 					if condition.Type == string(applicationv1alpha1.ConditionReady) {
 						g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
-						g.Expect(condition.Reason).To(Equal("Succeeded"))
+						g.Expect(condition.Reason).To(Equal(conditionReasonSucceeded))
 						g.Expect(condition.ObservedGeneration).To(Equal(appIdentity.Generation))
 					}
 				}


### PR DESCRIPTION
## What
Resolve pre-existing `goconst` lint debt in `dis-apim-operator` and `dis-identity-operator`. Their lint jobs have been red on `main` since ~2026-05-26 because CI runs golangci-lint **v2.12.2** while both operators pinned **v2.7.2** locally — hiding the findings from local `make lint`.

## Changes
- **dis-identity** (controller + tests): `"True"`/`"False"` → `metav1.ConditionTrue`/`metav1.ConditionFalse` (ASO `conditions.Condition.Status` is `metav1.ConditionStatus`, so this is type-correct), `"Ready"` → ASO's exported `conditions.ConditionTypeReady`, and a new `conditionReasonSucceeded` const for `"Succeeded"`.
- **dis-apim** (tests only): value-named consts in `predicates_test.go` / `suite_test.go` (`nsTest`, `nsResourceTest`, `nsResourceProd`, `nsTestProd`) and `policytemplate_test.go` (`keyName`, `valWorld`).
- **Both Makefiles**: bump `GOLANGCI_LINT_VERSION` `v2.7.2 → v2.12.2` so local `make lint` matches CI going forward (`dis-pgsql` and `dis-vault` already pin v2.12.2).

No behavior change.

## Test
- `GOLANGCI_LINT_VERSION=v2.12.2 make lint` → **0 issues** for both operators.
- `make test` (envtest) passes for both.
- `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code linting tool to a newer version for improved code quality checks.

* **Tests**
  * Refactored test code to use typed constants instead of string literals for improved maintainability.
  * Improved test organization by extracting repeated values into named constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->