### PR TITLE
feat(dis-console): server — central sync engine + fleet API

### DIFF
--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -77,8 +77,7 @@ Do not claim checks passed unless you actually ran them.
 - `internal/store` — tenant pgxpool store: embedded `schema.sql`, `Migrate`,
   `Sync` (content-hash-gated upsert + `flux_status_event` history + prune,
   touches the `meta` row), the `meta` bookkeeping table (`InitMeta`/`GetMeta`,
-  `SchemaVersion`), summary/list/get queries, and the server-side tenant readers
-  (`ChangedSince`/`Keys`).
+  `SchemaVersion`), and the server-side tenant readers (`ChangedSince`/`Keys`).
 - `internal/central` — the server's central read model: cluster-keyed
   `schema.sql`, `Apply` (per-cluster upsert + prune + `cluster_report` in one
   tx), tenant `Discover`, the sync `Engine` (pulls each tenant incrementally via

--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -5,9 +5,10 @@ dis-console is a small Go service (plain `net/http`) with two subcommands:
 - `dis-console agent` — runs per cluster: reads Flux custom resources across all
   namespaces and persists a normalized snapshot into that cluster's own tenant
   PostgreSQL database. Exposes only `/healthz` and `/readyz` (no JSON API).
-- `dis-console server` — runs centrally: syncs the tenant databases into a
-  central read model and serves the fleet JSON API. Placeholder for now; the
-  central sync loop and API land in a later slice (it `log.Fatalln`s if invoked).
+- `dis-console server` — runs centrally: migrates the central read model,
+  incrementally syncs every tenant database on the shared server into it, and
+  serves the fleet JSON API over it (`/api/clusters`, `?cluster=` filters,
+  staleness) plus `/healthz` + `/readyz`.
 
 It is NOT a kubebuilder operator: no controllers, no CRDs, and no
 controller-gen/envtest toolchain. (controller-runtime is present only as an
@@ -63,10 +64,9 @@ CI). This is the dis-console analogue of the operators' `test-e2e-kind-ci` job.
 Do not claim checks passed unless you actually ran them.
 
 ## Layout
-- `cmd/main.go` — subcommand dispatch (`agent`, `server`). `agent` owns the
-  poller ticker, DB wiring, and the agent flags (`--http-address`,
-  `--poll-interval`, `--local`, `--db-uri`, `--db-disable-entra`); `server` is a
-  placeholder.
+- `cmd/main.go` — subcommand dispatch. `agent` runs the per-cluster sweep loop
+  (health probes only); `server` migrates the central schema, runs the tenant
+  sync loop, and serves the fleet API. Each wires its own DB pool and flags.
 - `internal/flux` — version-agnostic dynamic-client reader; `normalize.go`
   decodes the projected status into the typed Flux `api` structs (kustomize/helm/
   source `api` + `pkg/apis/meta`) via runtime conversion, while keeping the full
@@ -74,12 +74,19 @@ Do not claim checks passed unless you actually ran them.
   `resourceVersion`), computes the `content_hash`, and caps `raw` at `MaxRawBytes`.
 - `internal/dbauth` — pgxpool builder; Entra-token `BeforeConnect` hook in the
   cluster, PGPASSWORD/trust fallback when Entra is disabled (Kind/CI/local).
-- `internal/store` — pgxpool store: embedded `schema.sql`, `Migrate`, `Sync`
-  (content-hash-gated upsert + `flux_status_event` history + prune, touches the
-  `meta` row), the `meta` bookkeeping table (`InitMeta`/`GetMeta`,
-  `SchemaVersion`), and summary/list/get queries.
+- `internal/store` — tenant pgxpool store: embedded `schema.sql`, `Migrate`,
+  `Sync` (content-hash-gated upsert + `flux_status_event` history + prune,
+  touches the `meta` row), the `meta` bookkeeping table (`InitMeta`/`GetMeta`,
+  `SchemaVersion`), summary/list/get queries, and the server-side tenant readers
+  (`ChangedSince`/`Keys`).
+- `internal/central` — the server's central read model: cluster-keyed
+  `schema.sql`, `Apply` (per-cluster upsert + prune + `cluster_report` in one
+  tx), tenant `Discover`, the sync `Engine` (pulls each tenant incrementally via
+  `updated_at > cursor`), and the fleet-API read methods (`Clusters` with
+  staleness, `Summary`/`List`/`Get`).
 - `internal/health` — `/healthz` + `/readyz` handlers used by the agent.
-- `internal/api` — `net/http` mux + JSON handlers serving from the store; for
-  the server subcommand (over the central read model), not yet wired.
-- `test/e2e` — `e2e`-tagged store test run against Kind Postgres.
+- `internal/api` — the fleet API: `net/http` mux + JSON handlers reading the
+  central store (`/api/clusters`, `?cluster=` filters, detail by cluster), wired
+  by `server`.
+- `test/e2e` — `e2e`-tagged store + central tests run against Kind Postgres.
 - `config/kind/postgres.yaml` — trust-auth Postgres for the e2e.

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -15,9 +15,10 @@ to cover other DIS state later.
 >   and persists a normalized snapshot (plus a `flux_status_event` history table)
 >   into that cluster's own tenant PostgreSQL database. It exposes only health
 >   probes.
-> - `dis-console server` runs centrally: it syncs the tenant databases into a
->   central read model and serves the fleet JSON API below. **Not built yet** —
->   it's a placeholder; the endpoints table is the target contract.
+> - `dis-console server` runs centrally: it incrementally syncs the tenant
+>   databases into a central read model and serves the fleet JSON API below over
+>   it (`/api/clusters`, `?cluster=` filters, staleness). Status `history` in the
+>   detail endpoint is the one piece still pending.
 
 ## What it reads
 
@@ -49,19 +50,21 @@ structs, never the framework.
 
 ## Endpoints
 
-The `agent` serves only `/healthz` and `/readyz`. The `/api/*` endpoints are the
-**fleet API** the `server` will serve over the central read model (not built
-yet); they are listed here as the target contract.
+Both `agent` and `server` serve `/healthz` and `/readyz`. The `/api/*` endpoints
+are the **fleet API** the `server` serves over the central read model; every
+list/summary endpoint takes an optional `?cluster=` filter. (Status `history` in
+the detail endpoint is not populated yet.)
 
 | method | path | served by | description |
 |---|---|---|---|
-| GET | `/healthz` | agent (server planned) | liveness (always 200) |
-| GET | `/readyz` | agent (server planned) | 200 once the first sweep has been persisted **and** the database pings |
-| GET | `/api/summary` | server | counts per kind by ready state (+ suspended) |
-| GET | `/api/resources?kind=&namespace=&ready=` | server | normalized rows; `ready=False` is the "what's broken" view |
-| GET | `/api/kustomizations` | server | alias for `?kind=Kustomization` |
-| GET | `/api/helmreleases` | server | alias for `?kind=HelmRelease` |
-| GET | `/api/resources/{kind}/{namespace}/{name}` | server | single row incl. the full `raw` object + recent status `history` |
+| GET | `/healthz` | agent + server | liveness (always 200) |
+| GET | `/readyz` | agent + server | 200 once the first sweep (agent) / sync cycle (server) completes **and** the database pings |
+| GET | `/api/clusters` | server | every synced cluster + sweep/sync times, counts, and a `stale` flag |
+| GET | `/api/summary?cluster=` | server | counts per kind by ready state (+ suspended); fleet-wide or one cluster |
+| GET | `/api/resources?cluster=&kind=&namespace=&ready=` | server | normalized rows; `ready=False` is the "what's broken" view |
+| GET | `/api/kustomizations?cluster=` | server | alias for `?kind=Kustomization` |
+| GET | `/api/helmreleases?cluster=` | server | alias for `?kind=HelmRelease` |
+| GET | `/api/resources/{cluster}/{kind}/{namespace}/{name}` | server | single row incl. the full `raw` object (status `history` pending) |
 
 ## Database & auth
 

--- a/services/dis-console/cmd/main.go
+++ b/services/dis-console/cmd/main.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/api"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/central"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/dbauth"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/health"
@@ -162,16 +164,75 @@ func runAgent(args []string) {
 	}
 }
 
-// runServer is a placeholder: the central sync loop, central schema, and fleet
-// API land in a later slice of the dis-console fleet work.
+// runServer runs the central read model: it migrates the central schema, then
+// incrementally syncs every tenant database on the shared server into it and
+// serves the fleet JSON API (plus health probes) reading only the central DB.
 func runServer(args []string) {
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
-		fmt.Fprintln(os.Stderr, "dis-console server: not implemented yet — the central sync "+
-			"loop and fleet API land in a later slice. Use `dis-console agent`.")
-		return
+	fs := flag.NewFlagSet("server", flag.ExitOnError)
+	httpAddr := fs.String("http-address", ":8080", "Address for the fleet API and health probes")
+	syncInterval := fs.Duration("sync-interval", 30*time.Second, "Tenant database sync interval (e.g. 30s, 1m)")
+	staleAfter := fs.Duration("stale-after", 2*time.Minute,
+		"Mark a cluster stale when its agent sweep / console sync is older than this")
+	dbURI := fs.String("db-uri", os.Getenv("DB_URI"),
+		"Central PostgreSQL connection URI without password (default from DB_URI env). "+
+			"Tenant databases are discovered on the same server.")
+	dbDisableEntra := fs.Bool("db-disable-entra", envBool("DB_DISABLE_ENTRA"),
+		"Skip Entra token auth; use PGPASSWORD or trust auth instead. For Kind/CI/local "+
+			"without Azure workload identity (default from DB_DISABLE_ENTRA env)")
+	_ = fs.Parse(args)
+
+	if *syncInterval <= 0 {
+		log.Fatalf("--sync-interval must be greater than 0, got %s", *syncInterval)
 	}
-	log.Fatalln("dis-console server: not implemented yet — the central sync loop and " +
-		"fleet API land in a later slice; use `dis-console agent` for the per-cluster sweep.")
+	if *dbURI == "" {
+		log.Fatalf("--db-uri (or DB_URI env) must be set")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var cred azcore.TokenCredential
+	if !*dbDisableEntra {
+		var err error
+		cred, err = azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			log.Fatalf("azure credential: %v", err)
+		}
+	}
+
+	pool, err := dbauth.NewPool(ctx, *dbURI, cred)
+	if err != nil {
+		log.Fatalf("db pool: %v", err)
+	}
+	cs := central.New(pool)
+	defer cs.Close()
+
+	migrateCtx, cancel := context.WithTimeout(ctx, migrateTimeout)
+	err = cs.Migrate(migrateCtx)
+	cancel()
+	if err != nil {
+		log.Fatalf("migrate central schema: %v", err)
+	}
+	log.Println("central schema migrated")
+
+	srv := api.NewServer(cs, *staleAfter)
+	httpServer := &http.Server{
+		Addr:              *httpAddr,
+		Handler:           srv.Routes(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		log.Printf("dis-console server: fleet API on %s", *httpAddr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("http server error: %v", err)
+		}
+	}()
+
+	// Run the sync loop until shutdown; readiness flips after the first cycle.
+	engine := central.NewEngine(cs, *dbURI, cred, *syncInterval)
+	engine.Run(ctx, srv.MarkSynced)
+
+	gracefulShutdown(httpServer)
 }
 
 func poll(ctx context.Context, client *flux.Client, st *store.Store, h *health.Server) {

--- a/services/dis-console/cmd/main.go
+++ b/services/dis-console/cmd/main.go
@@ -184,6 +184,9 @@ func runServer(args []string) {
 	if *syncInterval <= 0 {
 		log.Fatalf("--sync-interval must be greater than 0, got %s", *syncInterval)
 	}
+	if *staleAfter <= 0 {
+		log.Fatalf("--stale-after must be greater than 0, got %s", *staleAfter)
+	}
 	if *dbURI == "" {
 		log.Fatalf("--db-uri (or DB_URI env) must be set")
 	}

--- a/services/dis-console/internal/api/server.go
+++ b/services/dis-console/internal/api/server.go
@@ -1,6 +1,6 @@
-// Package api serves the read-only JSON API backed by the PostgreSQL store the
-// poller writes to. The poller calls MarkSynced after each successful sweep so
-// /readyz reports ready only once data has been persisted and the DB pings.
+// Package api serves the read-only fleet JSON API backed by the central read
+// model the server's sync loop fills. /readyz reports ready only once the first
+// sync cycle has completed (MarkSynced) and the central database pings.
 package api
 
 import (
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/central"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/store"
 )
@@ -19,64 +20,56 @@ import (
 // readyzPingTimeout bounds the DB ping done by /readyz.
 const readyzPingTimeout = 3 * time.Second
 
-// Store is the read surface the API needs from the persistence layer. The
-// concrete *store.Store satisfies it; tests use an in-memory fake.
+// Store is the read surface the fleet API needs from the central read model.
+// The concrete *central.Store satisfies it; tests use an in-memory fake.
 type Store interface {
-	Summary(ctx context.Context) ([]store.KindCount, error)
-	List(ctx context.Context, kind, namespace, ready string) ([]flux.Resource, error)
-	Get(ctx context.Context, kind, namespace, name string) (*flux.Resource, []store.Event, error)
-	LastSweep(ctx context.Context) (time.Time, error)
+	Clusters(ctx context.Context, staleAfter time.Duration) ([]central.Cluster, error)
+	Summary(ctx context.Context, cluster string) ([]store.KindCount, error)
+	List(ctx context.Context, cluster, kind, namespace, ready string) ([]central.Resource, error)
+	Get(ctx context.Context, cluster, kind, namespace, name string) (*central.Resource, error)
 	Ping(ctx context.Context) error
 }
 
-// Server serves the API from the store.
+// Server serves the fleet API from the central store.
 type Server struct {
-	store Store
-	ready atomic.Bool
+	store      Store
+	staleAfter time.Duration
+	ready      atomic.Bool
 }
 
-// NewServer returns a Server backed by st. /readyz reports not-ready until
+// NewServer returns a Server backed by st. staleAfter is the threshold for
+// flagging a cluster stale on /api/clusters. /readyz reports not-ready until
 // MarkSynced is first called.
-func NewServer(st Store) *Server {
-	return &Server{store: st}
+func NewServer(st Store, staleAfter time.Duration) *Server {
+	return &Server{store: st, staleAfter: staleAfter}
 }
 
-// MarkSynced records that this process has persisted at least one sweep, which
-// flips /readyz to ready. The "as of" timestamp the API reports comes from the
-// database (LastSweep), not from here, so it survives restarts.
-func (s *Server) MarkSynced() {
-	s.ready.Store(true)
-}
-
-// updatedAt is the timestamp of the most recent persisted sweep, read from the
-// database. On error it logs and returns the zero time rather than failing the
-// data response (the timestamp is metadata, not the payload).
-func (s *Server) updatedAt(r *http.Request) time.Time {
-	t, err := s.store.LastSweep(r.Context())
-	if err != nil {
-		log.Printf("last sweep query failed: %v", err)
-		return time.Time{}
-	}
-	return t
-}
+// MarkSynced records that at least one sync cycle has completed, which flips
+// /readyz to ready.
+func (s *Server) MarkSynced() { s.ready.Store(true) }
 
 // Routes returns the HTTP handler with all endpoints registered.
 func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /readyz", s.handleReadyz)
+	mux.HandleFunc("GET /api/clusters", s.handleClusters)
 	mux.HandleFunc("GET /api/summary", s.handleSummary)
 	mux.HandleFunc("GET /api/resources", s.handleResources)
-	mux.HandleFunc("GET /api/resources/{kind}/{namespace}/{name}", s.handleResourceDetail)
+	mux.HandleFunc("GET /api/resources/{cluster}/{kind}/{namespace}/{name}", s.handleResourceDetail)
 	mux.HandleFunc("GET /api/kustomizations", s.handleKustomizations)
 	mux.HandleFunc("GET /api/helmreleases", s.handleHelmReleases)
 	return mux
 }
 
+type clustersResponse struct {
+	Count    int               `json:"count"`
+	Clusters []central.Cluster `json:"clusters"`
+}
+
 type listResponse struct {
-	UpdatedAt time.Time       `json:"updatedAt"`
-	Count     int             `json:"count"`
-	Resources []flux.Resource `json:"resources"`
+	Count     int                `json:"count"`
+	Resources []central.Resource `json:"resources"`
 }
 
 type kindSummary struct {
@@ -89,23 +82,18 @@ type kindSummary struct {
 }
 
 type summaryResponse struct {
-	UpdatedAt time.Time     `json:"updatedAt"`
-	Total     int           `json:"total"`
-	Kinds     []kindSummary `json:"kinds"`
-}
-
-type detailResponse struct {
-	flux.Resource
-	History []store.Event `json:"history"`
+	Cluster string        `json:"cluster,omitempty"`
+	Total   int           `json:"total"`
+	Kinds   []kindSummary `json:"kinds"`
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleReadyz reports ready only once the first sweep has been persisted and
-// the DB still pings. Liveness (/healthz) stays 200 regardless, so a transient
-// DB blip does not get the pod killed.
+// handleReadyz reports ready only once the first sync cycle has completed and
+// the central DB still pings. Liveness (/healthz) stays 200 regardless, so a
+// transient DB blip does not get the pod killed.
 func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 	if !s.ready.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -120,8 +108,18 @@ func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func (s *Server) handleClusters(w http.ResponseWriter, r *http.Request) {
+	clusters, err := s.store.Clusters(r.Context(), s.staleAfter)
+	if err != nil {
+		s.fail(w, "clusters", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, clustersResponse{Count: len(clusters), Clusters: clusters})
+}
+
 func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
-	counts, err := s.store.Summary(r.Context())
+	cluster := r.URL.Query().Get("cluster")
+	counts, err := s.store.Summary(r.Context(), cluster)
 	if err != nil {
 		s.fail(w, "summary", err)
 		return
@@ -139,42 +137,37 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 		})
 		total += c.Total
 	}
-	writeJSON(w, http.StatusOK, summaryResponse{
-		UpdatedAt: s.updatedAt(r),
-		Total:     total,
-		Kinds:     kinds,
-	})
+	writeJSON(w, http.StatusOK, summaryResponse{Cluster: cluster, Total: total, Kinds: kinds})
 }
 
 func (s *Server) handleResources(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	s.writeFiltered(w, r, q.Get("kind"), q.Get("namespace"), q.Get("ready"))
+	s.writeFiltered(w, r, q.Get("cluster"), q.Get("kind"), q.Get("namespace"), q.Get("ready"))
 }
 
 func (s *Server) handleKustomizations(w http.ResponseWriter, r *http.Request) {
-	s.writeFiltered(w, r, flux.KindKustomization, r.URL.Query().Get("namespace"), r.URL.Query().Get("ready"))
+	q := r.URL.Query()
+	s.writeFiltered(w, r, q.Get("cluster"), flux.KindKustomization, q.Get("namespace"), q.Get("ready"))
 }
 
 func (s *Server) handleHelmReleases(w http.ResponseWriter, r *http.Request) {
-	s.writeFiltered(w, r, flux.KindHelmRelease, r.URL.Query().Get("namespace"), r.URL.Query().Get("ready"))
+	q := r.URL.Query()
+	s.writeFiltered(w, r, q.Get("cluster"), flux.KindHelmRelease, q.Get("namespace"), q.Get("ready"))
 }
 
-func (s *Server) writeFiltered(w http.ResponseWriter, r *http.Request, kind, namespace, ready string) {
-	rows, err := s.store.List(r.Context(), kind, namespace, ready)
+func (s *Server) writeFiltered(w http.ResponseWriter, r *http.Request, cluster, kind, namespace, ready string) {
+	rows, err := s.store.List(r.Context(), cluster, kind, namespace, ready)
 	if err != nil {
 		s.fail(w, "list", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, listResponse{
-		UpdatedAt: s.updatedAt(r),
-		Count:     len(rows),
-		Resources: rows,
-	})
+	writeJSON(w, http.StatusOK, listResponse{Count: len(rows), Resources: rows})
 }
 
 func (s *Server) handleResourceDetail(w http.ResponseWriter, r *http.Request) {
-	res, history, err := s.store.Get(r.Context(), r.PathValue("kind"), r.PathValue("namespace"), r.PathValue("name"))
-	if errors.Is(err, store.ErrNotFound) {
+	res, err := s.store.Get(r.Context(),
+		r.PathValue("cluster"), r.PathValue("kind"), r.PathValue("namespace"), r.PathValue("name"))
+	if errors.Is(err, central.ErrNotFound) {
 		writeJSON(w, http.StatusNotFound, errorBody("resource not found"))
 		return
 	}
@@ -182,7 +175,7 @@ func (s *Server) handleResourceDetail(w http.ResponseWriter, r *http.Request) {
 		s.fail(w, "get", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, detailResponse{Resource: *res, History: history})
+	writeJSON(w, http.StatusOK, res)
 }
 
 // fail logs the underlying error and returns a generic 500 to the client.

--- a/services/dis-console/internal/api/server_test.go
+++ b/services/dis-console/internal/api/server_test.go
@@ -10,35 +10,32 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/central"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
 	"github.com/Altinn/altinn-platform/services/dis-console/internal/store"
 )
 
-// fakeStore is an in-memory Store implementing the same filtering/summary
-// semantics as the SQL store, so the HTTP handlers can be exercised without a
-// database.
+// fakeStore is an in-memory Store implementing the same cluster/kind/namespace/
+// ready filtering as the central SQL store, so the handlers run without a DB.
 type fakeStore struct {
-	resources []flux.Resource
-	history   map[string][]store.Event
+	resources []central.Resource
+	clusters  []central.Cluster
 	pingErr   error
 }
 
 func (f *fakeStore) Ping(context.Context) error { return f.pingErr }
 
-func (f *fakeStore) LastSweep(context.Context) (time.Time, error) {
-	return time.Unix(1700000000, 0).UTC(), nil
+func (f *fakeStore) Clusters(context.Context, time.Duration) ([]central.Cluster, error) {
+	return f.clusters, nil
 }
 
-// histKey mirrors the real store, which looks up history by the full resource
-// identity (kind + namespace + name), not just the name.
-func histKey(kind, namespace, name string) string {
-	return kind + "\x00" + namespace + "\x00" + name
-}
-
-func (f *fakeStore) Summary(context.Context) ([]store.KindCount, error) {
+func (f *fakeStore) Summary(_ context.Context, cluster string) ([]store.KindCount, error) {
 	byKind := map[string]*store.KindCount{}
 	order := []string{}
 	for _, r := range f.resources {
+		if cluster != "" && r.Cluster != cluster {
+			continue
+		}
 		c, ok := byKind[r.Kind]
 		if !ok {
 			c = &store.KindCount{Kind: r.Kind}
@@ -65,9 +62,12 @@ func (f *fakeStore) Summary(context.Context) ([]store.KindCount, error) {
 	return out, nil
 }
 
-func (f *fakeStore) List(_ context.Context, kind, namespace, ready string) ([]flux.Resource, error) {
-	out := []flux.Resource{}
+func (f *fakeStore) List(_ context.Context, cluster, kind, namespace, ready string) ([]central.Resource, error) {
+	out := []central.Resource{}
 	for _, r := range f.resources {
+		if cluster != "" && r.Cluster != cluster {
+			continue
+		}
 		if kind != "" && !strings.EqualFold(r.Kind, kind) {
 			continue
 		}
@@ -83,33 +83,43 @@ func (f *fakeStore) List(_ context.Context, kind, namespace, ready string) ([]fl
 	return out, nil
 }
 
-func (f *fakeStore) Get(_ context.Context, kind, namespace, name string) (*flux.Resource, []store.Event, error) {
+func (f *fakeStore) Get(_ context.Context, cluster, kind, namespace, name string) (*central.Resource, error) {
 	for i := range f.resources {
 		r := f.resources[i]
-		if strings.EqualFold(r.Kind, kind) && r.Namespace == namespace && r.Name == name {
-			return &r, f.history[histKey(r.Kind, r.Namespace, r.Name)], nil
+		if r.Cluster == cluster && strings.EqualFold(r.Kind, kind) && r.Namespace == namespace && r.Name == name {
+			return &r, nil
 		}
 	}
-	return nil, nil, store.ErrNotFound
+	return nil, central.ErrNotFound
+}
+
+func res(cluster, kind, namespace, name, ready, reason string, suspended bool) central.Resource {
+	return central.Resource{
+		Cluster: cluster,
+		Resource: flux.Resource{
+			Kind: kind, Namespace: namespace, Name: name, Ready: ready, Reason: reason, Suspended: suspended,
+		},
+	}
 }
 
 func testServer() *Server {
 	s := NewServer(&fakeStore{
-		resources: []flux.Resource{
-			{Kind: "Kustomization", Namespace: "flux-system", Name: "apps", Ready: flux.ReadyTrue},
-			{Kind: "Kustomization", Namespace: "apps", Name: "broken", Ready: flux.ReadyFalse, Reason: "ReconciliationFailed"},
-			{Kind: "HelmRelease", Namespace: "apps", Name: "chart", Ready: flux.ReadyUnknown, Suspended: true},
+		resources: []central.Resource{
+			res("ttd_at23", "Kustomization", "flux-system", "apps", flux.ReadyTrue, "", false),
+			res("ttd_at23", "Kustomization", "apps", "broken", flux.ReadyFalse, "ReconciliationFailed", false),
+			res("skd_at23", "HelmRelease", "apps", "chart", flux.ReadyUnknown, "", true),
 		},
-		history: map[string][]store.Event{
-			histKey("Kustomization", "apps", "broken"): {{Ready: flux.ReadyFalse, Reason: "ReconciliationFailed", ObservedAt: time.Now()}},
+		clusters: []central.Cluster{
+			{Cluster: "ttd_at23", Environment: "at23", ResourceCount: 2, Stale: false},
+			{Cluster: "skd_at23", Environment: "at23", ResourceCount: 1, Stale: true},
 		},
-	})
+	}, time.Minute)
 	s.MarkSynced()
 	return s
 }
 
 func TestReadyzBeforeSync(t *testing.T) {
-	s := NewServer(&fakeStore{})
+	s := NewServer(&fakeStore{}, time.Minute)
 	rec := httptest.NewRecorder()
 	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -118,7 +128,7 @@ func TestReadyzBeforeSync(t *testing.T) {
 }
 
 func TestReadyzAfterSyncPingFails(t *testing.T) {
-	s := NewServer(&fakeStore{pingErr: errors.New("db down")})
+	s := NewServer(&fakeStore{pingErr: errors.New("db down")}, time.Minute)
 	s.MarkSynced()
 	rec := httptest.NewRecorder()
 	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
@@ -127,13 +137,45 @@ func TestReadyzAfterSyncPingFails(t *testing.T) {
 	}
 }
 
+func TestClusters(t *testing.T) {
+	s := testServer()
+	rec := httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/clusters", nil))
+	var resp clustersResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 2 {
+		t.Fatalf("expected 2 clusters, got %d", resp.Count)
+	}
+	var stale int
+	for _, c := range resp.Clusters {
+		if c.Stale {
+			stale++
+		}
+	}
+	if stale != 1 {
+		t.Fatalf("expected 1 stale cluster, got %d", stale)
+	}
+}
+
+func TestResourcesClusterFilter(t *testing.T) {
+	s := testServer()
+	rec := httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources?cluster=skd_at23", nil))
+	var resp listResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 1 || resp.Resources[0].Cluster != "skd_at23" {
+		t.Fatalf("unexpected cluster filter result: %+v", resp)
+	}
+}
+
 func TestResourcesReadyFalseFilter(t *testing.T) {
 	s := testServer()
 	rec := httptest.NewRecorder()
 	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources?ready=False", nil))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: %d", rec.Code)
-	}
 	var resp listResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -165,31 +207,32 @@ func TestSummaryCounts(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if resp.Total != 3 {
-		t.Fatalf("expected total 3, got %d", resp.Total)
+		t.Fatalf("expected total 3 across the fleet, got %d", resp.Total)
 	}
-	var ks *kindSummary
-	for i := range resp.Kinds {
-		if resp.Kinds[i].Kind == "Kustomization" {
-			ks = &resp.Kinds[i]
-		}
-	}
-	if ks == nil || ks.Ready != 1 || ks.NotReady != 1 {
-		t.Fatalf("unexpected kustomization summary: %+v", ks)
-	}
-}
 
-func TestResourceDetailWithHistory(t *testing.T) {
-	s := testServer()
-	rec := httptest.NewRecorder()
-	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources/Kustomization/apps/broken", nil))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: %d", rec.Code)
-	}
-	var resp detailResponse
+	// Scoped to one cluster.
+	rec = httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/summary?cluster=ttd_at23", nil))
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Name != "broken" || len(resp.History) != 1 {
+	if resp.Cluster != "ttd_at23" || resp.Total != 2 {
+		t.Fatalf("unexpected per-cluster summary: %+v", resp)
+	}
+}
+
+func TestResourceDetail(t *testing.T) {
+	s := testServer()
+	rec := httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources/ttd_at23/Kustomization/apps/broken", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var resp central.Resource
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "broken" || resp.Cluster != "ttd_at23" {
 		t.Fatalf("unexpected detail: %+v", resp)
 	}
 }
@@ -197,7 +240,7 @@ func TestResourceDetailWithHistory(t *testing.T) {
 func TestResourceDetailNotFound(t *testing.T) {
 	s := testServer()
 	rec := httptest.NewRecorder()
-	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources/Kustomization/apps/missing", nil))
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources/ttd_at23/Kustomization/apps/missing", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
 	}

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -70,13 +70,13 @@ func (s *Store) Cursor(ctx context.Context, cluster string) (time.Time, error) {
 
 const discoverStmt = `
 SELECT datname FROM pg_database
-WHERE datname LIKE $1 AND datname <> current_database() AND datistemplate = false
+WHERE starts_with(datname, $1) AND datname <> current_database() AND datistemplate = false
 ORDER BY datname`
 
 // Discover lists the tenant databases on the shared server (by the dis_console_
 // prefix), excluding the console's own central database.
 func (s *Store) Discover(ctx context.Context) ([]string, error) {
-	rows, err := s.pool.Query(ctx, discoverStmt, dbPrefix+"%")
+	rows, err := s.pool.Query(ctx, discoverStmt, dbPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("discover databases: %w", err)
 	}

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -1,0 +1,418 @@
+// Package central holds the console's central read model — a cluster-keyed
+// mirror of every tenant database on the shared server — plus the sync engine
+// that incrementally fills it. The fleet API (a later slice) reads only this
+// central database; agents never read it.
+package central
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/store"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+//go:embed schema.sql
+var schemaSQL string
+
+// dbPrefix is the naming prefix of the per-tenant databases on the shared
+// server. The server discovers tenants by this prefix and derives a cluster id
+// by stripping it.
+const dbPrefix = "dis_console_"
+
+// Store is the central read model in PostgreSQL (the console's own database).
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// New wraps an existing pool connected to the central database.
+func New(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// Close releases the pool.
+func (s *Store) Close() { s.pool.Close() }
+
+// Ping verifies the central database is reachable.
+func (s *Store) Ping(ctx context.Context) error { return s.pool.Ping(ctx) }
+
+// Migrate applies the embedded central schema (idempotent).
+func (s *Store) Migrate(ctx context.Context) error {
+	if _, err := s.pool.Exec(ctx, schemaSQL); err != nil {
+		return fmt.Errorf("apply central schema: %w", err)
+	}
+	return nil
+}
+
+const cursorStmt = `SELECT sync_cursor FROM cluster_report WHERE cluster = $1`
+
+// Cursor returns a cluster's last synced high-water (the newest tenant
+// updated_at mirrored so far). Zero time means the cluster has never synced.
+func (s *Store) Cursor(ctx context.Context, cluster string) (time.Time, error) {
+	var t *time.Time
+	err := s.pool.QueryRow(ctx, cursorStmt, cluster).Scan(&t)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cursor query: %w", err)
+	}
+	if t == nil {
+		return time.Time{}, nil
+	}
+	return t.UTC(), nil
+}
+
+const discoverStmt = `
+SELECT datname FROM pg_database
+WHERE datname LIKE $1 AND datname <> current_database() AND datistemplate = false
+ORDER BY datname`
+
+// Discover lists the tenant databases on the shared server (by the dis_console_
+// prefix), excluding the console's own central database.
+func (s *Store) Discover(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, discoverStmt, dbPrefix+"%")
+	if err != nil {
+		return nil, fmt.Errorf("discover databases: %w", err)
+	}
+	defer rows.Close()
+
+	var dbs []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan datname: %w", err)
+		}
+		dbs = append(dbs, name)
+	}
+	return dbs, rows.Err()
+}
+
+// ClusterState is one cluster's sync result, applied to the central DB atomically.
+type ClusterState struct {
+	Cluster       string
+	Environment   string
+	Changed       []store.ChangedResource // rows to upsert (content changed since the cursor)
+	Keys          []store.ResourceKey     // the tenant's full current key set (prune basis)
+	Cursor        time.Time               // new high-water
+	SchemaVersion int
+	AgentVersion  string
+	LastSweepAt   time.Time // agent's last sweep (data freshness), from tenant meta
+}
+
+const upsertStmt = `
+INSERT INTO flux_resource (
+    cluster, kind, api_version, namespace, name,
+    ready, reason, message, revision, suspended,
+    generation, observed_generation, last_transition, raw, content_hash,
+    updated_at, synced_at
+) VALUES (
+    $1, $2, $3, $4, $5,
+    $6, $7, $8, $9, $10,
+    $11, $12, $13, $14, $15,
+    $16, now()
+)
+ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
+    api_version         = EXCLUDED.api_version,
+    ready               = EXCLUDED.ready,
+    reason              = EXCLUDED.reason,
+    message             = EXCLUDED.message,
+    revision            = EXCLUDED.revision,
+    suspended           = EXCLUDED.suspended,
+    generation          = EXCLUDED.generation,
+    observed_generation = EXCLUDED.observed_generation,
+    last_transition     = EXCLUDED.last_transition,
+    raw                 = EXCLUDED.raw,
+    content_hash        = EXCLUDED.content_hash,
+    updated_at          = EXCLUDED.updated_at,
+    synced_at           = now()`
+
+// pruneStmt deletes the cluster's mirrored rows whose identity is not in the
+// tenant's current key set (passed as parallel arrays). An empty key set drops
+// every row for the cluster, which is correct when the tenant has none.
+const pruneStmt = `
+DELETE FROM flux_resource c
+WHERE c.cluster = $1
+  AND NOT EXISTS (
+    SELECT 1 FROM unnest($2::text[], $3::text[], $4::text[]) AS k(kind, namespace, name)
+    WHERE k.kind = c.kind AND k.namespace = c.namespace AND k.name = c.name
+  )`
+
+const reportStmt = `
+INSERT INTO cluster_report (
+    cluster, environment, sync_cursor, last_synced_at, last_sweep_at, agent_version, schema_version, resource_count
+) VALUES ($1, $2, $3, now(), $4, $5, $6, $7)
+ON CONFLICT (cluster) DO UPDATE SET
+    environment    = EXCLUDED.environment,
+    sync_cursor    = EXCLUDED.sync_cursor,
+    last_synced_at = now(),
+    last_sweep_at  = EXCLUDED.last_sweep_at,
+    agent_version  = EXCLUDED.agent_version,
+    schema_version = EXCLUDED.schema_version,
+    resource_count = EXCLUDED.resource_count`
+
+// Apply mirrors one cluster's state into the central DB in a single transaction
+// — upsert the changed rows, prune the ones that disappeared, and record the
+// cluster_report — so readers never observe a half-synced cluster.
+func (s *Store) Apply(ctx context.Context, st ClusterState) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if len(st.Changed) > 0 {
+		batch := &pgx.Batch{}
+		for i := range st.Changed {
+			c := &st.Changed[i]
+			raw := c.Raw
+			if len(raw) == 0 {
+				raw = json.RawMessage("{}")
+			}
+			batch.Queue(upsertStmt,
+				st.Cluster, c.Kind, c.APIVersion, c.Namespace, c.Name,
+				c.Ready, c.Reason, c.Message, c.Revision, c.Suspended,
+				c.Generation, c.ObservedGeneration, c.LastTransition, []byte(raw), c.ContentHash,
+				c.UpdatedAt,
+			)
+		}
+		br := tx.SendBatch(ctx, batch)
+		for range st.Changed {
+			if _, err := br.Exec(); err != nil {
+				_ = br.Close()
+				return fmt.Errorf("upsert cluster %s: %w", st.Cluster, err)
+			}
+		}
+		if err := br.Close(); err != nil {
+			return fmt.Errorf("close batch: %w", err)
+		}
+	}
+
+	kinds, namespaces, names := splitKeys(st.Keys)
+	if _, err := tx.Exec(ctx, pruneStmt, st.Cluster, kinds, namespaces, names); err != nil {
+		return fmt.Errorf("prune cluster %s: %w", st.Cluster, err)
+	}
+
+	var cursor, lastSweep *time.Time
+	if !st.Cursor.IsZero() {
+		c := st.Cursor.UTC()
+		cursor = &c
+	}
+	if !st.LastSweepAt.IsZero() {
+		ls := st.LastSweepAt.UTC()
+		lastSweep = &ls
+	}
+	if _, err := tx.Exec(ctx, reportStmt,
+		st.Cluster, st.Environment, cursor, lastSweep, st.AgentVersion, st.SchemaVersion, len(st.Keys),
+	); err != nil {
+		return fmt.Errorf("cluster_report %s: %w", st.Cluster, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+func splitKeys(keys []store.ResourceKey) (kinds, namespaces, names []string) {
+	kinds = make([]string, len(keys))
+	namespaces = make([]string, len(keys))
+	names = make([]string, len(keys))
+	for i, k := range keys {
+		kinds[i], namespaces[i], names[i] = k.Kind, k.Namespace, k.Name
+	}
+	return kinds, namespaces, names
+}
+
+// clusterID strips the tenant-database prefix to get the cluster identifier
+// (e.g. "dis_console_ttd_at23" -> "ttd_at23").
+func clusterID(dbName string) string { return strings.TrimPrefix(dbName, dbPrefix) }
+
+// environmentOf derives the environment from a cluster id as the segment after
+// the last underscore (e.g. "ttd_at23" -> "at23"); "" when there is none.
+func environmentOf(cluster string) string {
+	if i := strings.LastIndex(cluster, "_"); i >= 0 && i < len(cluster)-1 {
+		return cluster[i+1:]
+	}
+	return ""
+}
+
+// schemaSupported reports whether the server can read a tenant at the given
+// meta.schema_version. It supports the current version and the previous one;
+// anything else is flagged by the caller and skipped rather than misread.
+func schemaSupported(version int) bool {
+	return version >= store.SchemaVersion-1 && version <= store.SchemaVersion
+}
+
+// advanceCursor returns the new high-water: the newest updated_at among the
+// pulled rows, or the old cursor when nothing changed (it never regresses).
+func advanceCursor(old time.Time, changed []store.ChangedResource) time.Time {
+	next := old
+	for i := range changed {
+		if changed[i].UpdatedAt.After(next) {
+			next = changed[i].UpdatedAt
+		}
+	}
+	return next
+}
+
+// --- read side (the fleet API reads only these) ---
+
+// ErrNotFound is returned by Get when no central row matches.
+var ErrNotFound = errors.New("resource not found")
+
+// Resource is a mirrored resource tagged with the cluster it came from.
+type Resource struct {
+	flux.Resource
+	Cluster string `json:"cluster"`
+}
+
+// Cluster is a tenant's sync status, served by /api/clusters.
+type Cluster struct {
+	Cluster       string    `json:"cluster"`
+	Environment   string    `json:"environment,omitempty"`
+	LastSweepAt   time.Time `json:"lastSweepAt"`
+	LastSyncedAt  time.Time `json:"lastSyncedAt"`
+	AgentVersion  string    `json:"agentVersion,omitempty"`
+	SchemaVersion int       `json:"schemaVersion"`
+	ResourceCount int       `json:"resourceCount"`
+	Stale         bool      `json:"stale"`
+}
+
+const clustersStmt = `
+SELECT cluster, environment, last_sweep_at, last_synced_at, agent_version, schema_version, resource_count
+FROM cluster_report
+ORDER BY cluster`
+
+// Clusters returns every synced cluster with a staleness flag — set when the
+// agent stopped sweeping or the console stopped syncing it (either timestamp
+// older than staleAfter).
+func (s *Store) Clusters(ctx context.Context, staleAfter time.Duration) ([]Cluster, error) {
+	rows, err := s.pool.Query(ctx, clustersStmt)
+	if err != nil {
+		return nil, fmt.Errorf("clusters query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Cluster{}
+	for rows.Next() {
+		var c Cluster
+		var sweep, synced *time.Time
+		if err := rows.Scan(&c.Cluster, &c.Environment, &sweep, &synced,
+			&c.AgentVersion, &c.SchemaVersion, &c.ResourceCount); err != nil {
+			return nil, fmt.Errorf("scan cluster: %w", err)
+		}
+		if sweep != nil {
+			c.LastSweepAt = sweep.UTC()
+		}
+		if synced != nil {
+			c.LastSyncedAt = synced.UTC()
+		}
+		c.Stale = staleSince(c.LastSweepAt, staleAfter) || staleSince(c.LastSyncedAt, staleAfter)
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// staleSince reports whether t is missing or older than d relative to now.
+func staleSince(t time.Time, d time.Duration) bool {
+	return t.IsZero() || time.Since(t) > d
+}
+
+const summaryStmt = `
+SELECT kind,
+       count(*),
+       count(*) FILTER (WHERE ready = 'True'),
+       count(*) FILTER (WHERE ready = 'False'),
+       count(*) FILTER (WHERE ready NOT IN ('True', 'False')),
+       count(*) FILTER (WHERE suspended)
+FROM flux_resource
+WHERE ($1 = '' OR cluster = $1)
+GROUP BY kind
+ORDER BY kind`
+
+// Summary returns per-kind ready-state counts across the fleet, or for one
+// cluster when cluster is non-empty.
+func (s *Store) Summary(ctx context.Context, cluster string) ([]store.KindCount, error) {
+	rows, err := s.pool.Query(ctx, summaryStmt, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("summary query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.KindCount{}
+	for rows.Next() {
+		var c store.KindCount
+		if err := rows.Scan(&c.Kind, &c.Total, &c.Ready, &c.NotReady, &c.Unknown, &c.Suspended); err != nil {
+			return nil, fmt.Errorf("scan summary: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+const listStmt = `
+SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
+       suspended, generation, observed_generation, last_transition
+FROM flux_resource
+WHERE ($1 = '' OR cluster = $1)
+  AND ($2 = '' OR lower(kind) = lower($2))
+  AND ($3 = '' OR namespace = $3)
+  AND ($4 = '' OR lower(ready) = lower($4))
+ORDER BY cluster, kind, namespace, name`
+
+// List returns matching resources (without the raw payload) across the fleet,
+// or for one cluster when cluster is non-empty. An empty kind/namespace/ready
+// means "any".
+func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string) ([]Resource, error) {
+	rows, err := s.pool.Query(ctx, listStmt, cluster, kind, namespace, ready)
+	if err != nil {
+		return nil, fmt.Errorf("list query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Resource{}
+	for rows.Next() {
+		var r Resource
+		if err := rows.Scan(
+			&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
+			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
+			&r.ObservedGeneration, &r.LastTransition,
+		); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+const getStmt = `
+SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
+       suspended, generation, observed_generation, last_transition, raw
+FROM flux_resource
+WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
+
+// Get returns one resource (including its raw payload) in a cluster, or
+// ErrNotFound when no row matches.
+func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) (*Resource, error) {
+	var r Resource
+	var raw []byte
+	err := s.pool.QueryRow(ctx, getStmt, cluster, kind, namespace, name).Scan(
+		&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
+		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
+		&r.ObservedGeneration, &r.LastTransition, &raw,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get query: %w", err)
+	}
+	r.Raw = raw
+	return &r, nil
+}

--- a/services/dis-console/internal/central/central_test.go
+++ b/services/dis-console/internal/central/central_test.go
@@ -1,0 +1,87 @@
+package central
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/store"
+)
+
+func TestClusterID(t *testing.T) {
+	if got := clusterID("dis_console_ttd_at23"); got != "ttd_at23" {
+		t.Fatalf("clusterID: got %q", got)
+	}
+	// No prefix: returned unchanged.
+	if got := clusterID("weird_name"); got != "weird_name" {
+		t.Fatalf("clusterID without prefix: got %q", got)
+	}
+}
+
+func TestEnvironmentOf(t *testing.T) {
+	cases := map[string]string{
+		"ttd_at23": "at23",
+		"skd_tt02": "tt02",
+		"prod":     "", // no underscore
+		"a_":       "", // trailing underscore, no segment
+	}
+	for in, want := range cases {
+		if got := environmentOf(in); got != want {
+			t.Fatalf("environmentOf(%q): got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSchemaSupported(t *testing.T) {
+	// Supports the current version and the previous one; flags the rest.
+	if !schemaSupported(store.SchemaVersion) {
+		t.Fatalf("current schema_version %d should be supported", store.SchemaVersion)
+	}
+	if !schemaSupported(store.SchemaVersion - 1) {
+		t.Fatalf("previous schema_version %d should be supported", store.SchemaVersion-1)
+	}
+	if schemaSupported(store.SchemaVersion + 1) {
+		t.Fatalf("newer schema_version %d must not be claimed supported", store.SchemaVersion+1)
+	}
+	if schemaSupported(store.SchemaVersion - 2) {
+		t.Fatalf("older schema_version %d must not be claimed supported", store.SchemaVersion-2)
+	}
+}
+
+func TestAdvanceCursor(t *testing.T) {
+	old := time.Date(2026, 6, 18, 10, 0, 0, 0, time.UTC)
+
+	// No changed rows: cursor must not move.
+	if got := advanceCursor(old, nil); !got.Equal(old) {
+		t.Fatalf("empty changed should keep cursor, got %v", got)
+	}
+
+	newer := old.Add(2 * time.Minute)
+	older := old.Add(-time.Minute)
+	changed := []store.ChangedResource{
+		{UpdatedAt: older},
+		{UpdatedAt: newer},
+		{UpdatedAt: old.Add(time.Minute)},
+	}
+	if got := advanceCursor(old, changed); !got.Equal(newer) {
+		t.Fatalf("advanceCursor should pick the newest updated_at %v, got %v", newer, got)
+	}
+
+	// A batch all older than the cursor (shouldn't happen via the query, but the
+	// function must never regress) keeps the old cursor.
+	if got := advanceCursor(old, []store.ChangedResource{{UpdatedAt: older}}); !got.Equal(old) {
+		t.Fatalf("advanceCursor must not regress, got %v", got)
+	}
+}
+
+func TestStaleSince(t *testing.T) {
+	d := time.Minute
+	if !staleSince(time.Time{}, d) {
+		t.Fatalf("zero time (never synced) should be stale")
+	}
+	if staleSince(time.Now(), d) {
+		t.Fatalf("a just-now timestamp should not be stale")
+	}
+	if !staleSince(time.Now().Add(-2*time.Minute), d) {
+		t.Fatalf("2m old should be stale with a 1m threshold")
+	}
+}

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -1,0 +1,125 @@
+package central
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/dbauth"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/store"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/jackc/pgx/v5"
+)
+
+// Engine incrementally syncs every tenant database on the shared server into
+// the central read model. It connects to each tenant by overriding the database
+// name on its own (central) connection URI, so they share host/user/auth.
+type Engine struct {
+	central  *Store
+	baseURI  string
+	cred     azcore.TokenCredential
+	interval time.Duration
+}
+
+// NewEngine builds a sync engine. baseURI is the central database URI; tenant
+// connections derive from it (same server, different database). cred is nil for
+// Kind/CI/local (trust/PGPASSWORD).
+func NewEngine(central *Store, baseURI string, cred azcore.TokenCredential, interval time.Duration) *Engine {
+	return &Engine{central: central, baseURI: baseURI, cred: cred, interval: interval}
+}
+
+// Run syncs all tenant databases once, calls ready (so /readyz can flip), then
+// repeats every interval until ctx is cancelled.
+func (e *Engine) Run(ctx context.Context, ready func()) {
+	e.syncOnce(ctx)
+	ready()
+
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.syncOnce(ctx)
+		}
+	}
+}
+
+// syncOnce discovers the tenant databases and syncs each in turn. One tenant's
+// failure is logged and skipped so it cannot stall the rest of the fleet.
+func (e *Engine) syncOnce(ctx context.Context) {
+	dbs, err := e.central.Discover(ctx)
+	if err != nil {
+		log.Printf("discover tenant databases failed: %v", err)
+		return
+	}
+
+	var synced, failed int
+	for _, db := range dbs {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := e.syncCluster(ctx, db); err != nil {
+			failed++
+			log.Printf("sync %s failed, keeping previous data: %v", db, err)
+			continue
+		}
+		synced++
+	}
+	log.Printf("synced %d/%d tenant databases (%d failed)", synced, len(dbs), failed)
+}
+
+// syncCluster mirrors one tenant database into the central read model: pull the
+// rows changed since the cursor plus the full key set, then apply both (upsert
+// + prune + report) in one central transaction.
+func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
+	pool, err := dbauth.NewPoolForDatabase(ctx, e.baseURI, dbName, e.cred)
+	if err != nil {
+		return fmt.Errorf("tenant pool: %w", err)
+	}
+	defer pool.Close()
+	ts := store.New(pool)
+
+	cluster := clusterID(dbName)
+
+	meta, err := ts.GetMeta(ctx)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// A tenant database without a meta row predates schema versioning;
+		// treat it as version 0 (legacy) rather than failing the cluster.
+		meta = store.Meta{SchemaVersion: 0}
+	} else if err != nil {
+		return fmt.Errorf("read tenant meta: %w", err)
+	}
+	if !schemaSupported(meta.SchemaVersion) {
+		log.Printf("skip %s: unsupported tenant schema_version %d (server supports %d and %d)",
+			cluster, meta.SchemaVersion, store.SchemaVersion-1, store.SchemaVersion)
+		return nil
+	}
+
+	cursor, err := e.central.Cursor(ctx, cluster)
+	if err != nil {
+		return err
+	}
+	changed, err := ts.ChangedSince(ctx, cursor)
+	if err != nil {
+		return err
+	}
+	keys, err := ts.Keys(ctx)
+	if err != nil {
+		return err
+	}
+
+	return e.central.Apply(ctx, ClusterState{
+		Cluster:       cluster,
+		Environment:   environmentOf(cluster),
+		Changed:       changed,
+		Keys:          keys,
+		Cursor:        advanceCursor(cursor, changed),
+		SchemaVersion: meta.SchemaVersion,
+		AgentVersion:  meta.AgentVersion,
+		LastSweepAt:   meta.LastSweepAt,
+	})
+}

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -30,11 +30,14 @@ func NewEngine(central *Store, baseURI string, cred azcore.TokenCredential, inte
 	return &Engine{central: central, baseURI: baseURI, cred: cred, interval: interval}
 }
 
-// Run syncs all tenant databases once, calls ready (so /readyz can flip), then
-// repeats every interval until ctx is cancelled.
+// Run syncs all tenant databases on an interval until ctx is cancelled. It calls
+// ready (flipping /readyz) after the first cycle whose discovery succeeds — a
+// failed initial discovery must not report the server ready. ready is idempotent
+// (MarkSynced), so gating every cycle on it is fine.
 func (e *Engine) Run(ctx context.Context, ready func()) {
-	e.syncOnce(ctx)
-	ready()
+	if e.syncOnce(ctx) {
+		ready()
+	}
 
 	ticker := time.NewTicker(e.interval)
 	defer ticker.Stop()
@@ -43,24 +46,27 @@ func (e *Engine) Run(ctx context.Context, ready func()) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			e.syncOnce(ctx)
+			if e.syncOnce(ctx) {
+				ready()
+			}
 		}
 	}
 }
 
-// syncOnce discovers the tenant databases and syncs each in turn. One tenant's
-// failure is logged and skipped so it cannot stall the rest of the fleet.
-func (e *Engine) syncOnce(ctx context.Context) {
+// syncOnce discovers the tenant databases and syncs each in turn, returning
+// whether discovery succeeded. A per-tenant failure is logged and skipped so it
+// cannot stall the rest of the fleet, and does not fail the cycle.
+func (e *Engine) syncOnce(ctx context.Context) bool {
 	dbs, err := e.central.Discover(ctx)
 	if err != nil {
 		log.Printf("discover tenant databases failed: %v", err)
-		return
+		return false
 	}
 
 	var synced, failed int
 	for _, db := range dbs {
 		if ctx.Err() != nil {
-			return
+			return true
 		}
 		if err := e.syncCluster(ctx, db); err != nil {
 			failed++
@@ -70,6 +76,7 @@ func (e *Engine) syncOnce(ctx context.Context) {
 		synced++
 	}
 	log.Printf("synced %d/%d tenant databases (%d failed)", synced, len(dbs), failed)
+	return true
 }
 
 // syncCluster mirrors one tenant database into the central read model: pull the

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS flux_resource (
+    cluster             text        NOT NULL,
+    kind                text        NOT NULL,
+    api_version         text        NOT NULL,
+    namespace           text        NOT NULL,
+    name                text        NOT NULL,
+    ready               text        NOT NULL DEFAULT 'Unknown',
+    reason              text,
+    message             text,
+    revision            text,
+    suspended           boolean     NOT NULL DEFAULT false,
+    generation          bigint,
+    observed_generation bigint,
+    last_transition     timestamptz,
+    raw                 jsonb       NOT NULL,
+    content_hash        text,
+    updated_at          timestamptz NOT NULL,
+    synced_at           timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (cluster, kind, namespace, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_central_resource_ready   ON flux_resource (lower(ready));
+CREATE INDEX IF NOT EXISTS idx_central_resource_kind    ON flux_resource (lower(kind));
+CREATE INDEX IF NOT EXISTS idx_central_resource_cluster ON flux_resource (cluster);
+
+CREATE TABLE IF NOT EXISTS cluster_report (
+    cluster        text        PRIMARY KEY,
+    environment    text        NOT NULL DEFAULT '',
+    sync_cursor    timestamptz,
+    last_synced_at timestamptz NOT NULL DEFAULT now(),
+    last_sweep_at  timestamptz,
+    agent_version  text        NOT NULL DEFAULT '',
+    schema_version integer     NOT NULL DEFAULT 0,
+    resource_count integer     NOT NULL DEFAULT 0
+);

--- a/services/dis-console/internal/dbauth/token.go
+++ b/services/dis-console/internal/dbauth/token.go
@@ -36,6 +36,29 @@ const maxConnLifetime = 30 * time.Minute
 // workload identity exists): the connection uses PGPASSWORD if set, otherwise
 // no password (e.g. a trust-auth Postgres).
 func NewPool(ctx context.Context, dbURI string, cred azcore.TokenCredential) (*pgxpool.Pool, error) {
+	cfg, err := configFor(dbURI, cred)
+	if err != nil {
+		return nil, err
+	}
+	return newPool(ctx, cfg)
+}
+
+// NewPoolForDatabase builds a pool to a sibling database on the same server as
+// baseURI — same host, user, sslmode and auth — overriding only the database
+// name. The server uses this to reach each tenant database (dis_console_*) on
+// the shared server it also hosts its own central database on.
+func NewPoolForDatabase(ctx context.Context, baseURI, database string, cred azcore.TokenCredential) (*pgxpool.Pool, error) {
+	cfg, err := configFor(baseURI, cred)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConnConfig.Database = database
+	return newPool(ctx, cfg)
+}
+
+// configFor parses dbURI and wires the auth: an Entra-token BeforeConnect hook
+// when cred is set, otherwise PGPASSWORD (or no password) for Kind/CI/local.
+func configFor(dbURI string, cred azcore.TokenCredential) (*pgxpool.Config, error) {
 	cfg, err := pgxpool.ParseConfig(dbURI)
 	if err != nil {
 		return nil, fmt.Errorf("parse db uri: %w", err)
@@ -54,7 +77,10 @@ func NewPool(ctx context.Context, dbURI string, cred azcore.TokenCredential) (*p
 	} else if pw := os.Getenv("PGPASSWORD"); pw != "" {
 		cfg.ConnConfig.Password = pw
 	}
+	return cfg, nil
+}
 
+func newPool(ctx context.Context, cfg *pgxpool.Config) (*pgxpool.Pool, error) {
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create connection pool: %w", err)

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -400,3 +400,80 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 	}
 	return &r, events, nil
 }
+
+// ResourceKey identifies a stored resource. The server uses the full key set to
+// reconcile a tenant's current resources against the central mirror (pruning
+// the ones that disappeared).
+type ResourceKey struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+// ChangedResource is a resource row plus its updated_at, so the server can
+// advance its per-cluster sync cursor to the newest row it pulled.
+type ChangedResource struct {
+	flux.Resource
+	UpdatedAt time.Time
+}
+
+const changedSinceStmt = `
+SELECT kind, api_version, namespace, name, ready, reason, message, revision,
+       suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at
+FROM flux_resource
+WHERE updated_at > $1
+ORDER BY updated_at`
+
+// ChangedSince returns the resources whose content changed after cursor (the
+// server's per-cluster high-water), including the raw payload. Because the
+// agent only advances updated_at on a real content change, an idle cluster
+// returns no rows and transfers no payloads.
+func (s *Store) ChangedSince(ctx context.Context, cursor time.Time) ([]ChangedResource, error) {
+	rows, err := s.pool.Query(ctx, changedSinceStmt, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("changed-since query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []ChangedResource{}
+	for rows.Next() {
+		var c ChangedResource
+		var raw []byte
+		var hash *string
+		if err := rows.Scan(
+			&c.Kind, &c.APIVersion, &c.Namespace, &c.Name, &c.Ready, &c.Reason,
+			&c.Message, &c.Revision, &c.Suspended, &c.Generation,
+			&c.ObservedGeneration, &c.LastTransition, &raw, &hash, &c.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan changed row: %w", err)
+		}
+		c.Raw = raw
+		if hash != nil {
+			c.ContentHash = *hash
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+const keysStmt = `SELECT kind, namespace, name FROM flux_resource`
+
+// Keys returns the identity of every resource currently stored, so the server
+// can prune central rows for resources that no longer exist in the tenant.
+func (s *Store) Keys(ctx context.Context) ([]ResourceKey, error) {
+	rows, err := s.pool.Query(ctx, keysStmt)
+	if err != nil {
+		return nil, fmt.Errorf("keys query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []ResourceKey{}
+	for rows.Next() {
+		var k ResourceKey
+		if err := rows.Scan(&k.Kind, &k.Namespace, &k.Name); err != nil {
+			return nil, fmt.Errorf("scan key: %w", err)
+		}
+		out = append(out, k)
+	}
+	return out, rows.Err()
+}

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -1,0 +1,263 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/central"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/dbauth"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/store"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newCentral creates a fresh central database (and one tenant database for the
+// discovery test) on the test server, then migrates the central schema. It
+// exercises dbauth.NewPoolForDatabase — the same database-name override the
+// server uses to reach sibling databases on the shared server.
+func newCentral(t *testing.T) (*central.Store, *pgxpool.Pool) {
+	t.Helper()
+	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
+	if uri == "" {
+		t.Skip("DISCONSOLE_TEST_DB_URI not set; run via `make test-e2e-kind-ci`")
+	}
+	ctx := context.Background()
+
+	admin, err := dbauth.NewPool(ctx, uri, nil)
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	defer admin.Close()
+
+	var pingErr error
+	for i := 0; i < 30; i++ {
+		pctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		pingErr = admin.Ping(pctx)
+		cancel()
+		if pingErr == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if pingErr != nil {
+		t.Fatalf("database never became reachable: %v", pingErr)
+	}
+
+	// Recreate the central database and a tenant database from scratch.
+	for _, db := range []string{"dis_console_central_e2e", "dis_console_ttd_at23"} {
+		if _, err := admin.Exec(ctx, "DROP DATABASE IF EXISTS "+db+" WITH (FORCE)"); err != nil {
+			t.Fatalf("drop %s: %v", db, err)
+		}
+		if _, err := admin.Exec(ctx, "CREATE DATABASE "+db); err != nil {
+			t.Fatalf("create %s: %v", db, err)
+		}
+	}
+
+	pool, err := dbauth.NewPoolForDatabase(ctx, uri, "dis_console_central_e2e", nil)
+	if err != nil {
+		t.Fatalf("central pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	cs := central.New(pool)
+	if err := cs.Migrate(ctx); err != nil {
+		t.Fatalf("migrate central: %v", err)
+	}
+	return cs, pool
+}
+
+func changed(name, kind, ready, hash string, at time.Time) store.ChangedResource {
+	return store.ChangedResource{
+		Resource: flux.Resource{
+			Kind:        kind,
+			APIVersion:  "kustomize.toolkit.fluxcd.io/v1",
+			Namespace:   "flux-system",
+			Name:        name,
+			Ready:       ready,
+			ContentHash: hash,
+			Raw:         json.RawMessage(`{"kind":"` + kind + `"}`),
+		},
+		UpdatedAt: at,
+	}
+}
+
+// TestCentralApplyUpsertPruneCursor drives the central store contract against
+// real PostgreSQL: a first apply mirrors rows and records the cluster_report; a
+// second apply upserts a changed row, prunes a disappeared one, and advances
+// the cursor — all scoped to the one cluster.
+func TestCentralApplyUpsertPruneCursor(t *testing.T) {
+	cs, pool := newCentral(t)
+	ctx := context.Background()
+
+	t1 := time.Now().UTC().Truncate(time.Microsecond)
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:     "ttd_at23",
+		Environment: "at23",
+		Changed: []store.ChangedResource{
+			changed("apps", "Kustomization", flux.ReadyTrue, "h-apps-1", t1),
+			changed("chart", "HelmRelease", flux.ReadyFalse, "h-chart-1", t1),
+		},
+		Keys: []store.ResourceKey{
+			{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"},
+			{Kind: "HelmRelease", Namespace: "flux-system", Name: "chart"},
+		},
+		Cursor:        t1,
+		SchemaVersion: store.SchemaVersion,
+		AgentVersion:  "test",
+	}); err != nil {
+		t.Fatalf("apply 1: %v", err)
+	}
+
+	if n := countRows(t, pool, "ttd_at23"); n != 2 {
+		t.Fatalf("after apply 1: expected 2 rows, got %d", n)
+	}
+	if cur, err := cs.Cursor(ctx, "ttd_at23"); err != nil || !cur.Equal(t1) {
+		t.Fatalf("cursor after apply 1: got %v err %v, want %v", cur, err, t1)
+	}
+	var env string
+	var count int
+	if err := pool.QueryRow(ctx,
+		"SELECT environment, resource_count FROM cluster_report WHERE cluster=$1", "ttd_at23",
+	).Scan(&env, &count); err != nil {
+		t.Fatalf("cluster_report: %v", err)
+	}
+	if env != "at23" || count != 2 {
+		t.Fatalf("cluster_report: env=%q count=%d", env, count)
+	}
+
+	// Second sweep: "apps" recovers (changed), "chart" disappears (pruned).
+	t2 := t1.Add(time.Minute)
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:       "ttd_at23",
+		Environment:   "at23",
+		Changed:       []store.ChangedResource{changed("apps", "Kustomization", flux.ReadyFalse, "h-apps-2", t2)},
+		Keys:          []store.ResourceKey{{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"}},
+		Cursor:        t2,
+		SchemaVersion: store.SchemaVersion,
+		AgentVersion:  "test",
+	}); err != nil {
+		t.Fatalf("apply 2: %v", err)
+	}
+
+	if n := countRows(t, pool, "ttd_at23"); n != 1 {
+		t.Fatalf("after apply 2: expected 1 row (chart pruned), got %d", n)
+	}
+	var ready string
+	if err := pool.QueryRow(ctx,
+		"SELECT ready FROM flux_resource WHERE cluster=$1 AND name='apps'", "ttd_at23",
+	).Scan(&ready); err != nil {
+		t.Fatalf("read apps: %v", err)
+	}
+	if ready != flux.ReadyFalse {
+		t.Fatalf("apps ready: got %q, want %q", ready, flux.ReadyFalse)
+	}
+	if cur, err := cs.Cursor(ctx, "ttd_at23"); err != nil || !cur.Equal(t2) {
+		t.Fatalf("cursor after apply 2: got %v err %v, want %v", cur, err, t2)
+	}
+}
+
+// TestCentralDiscover checks tenant discovery returns the dis_console_* tenant
+// databases and excludes the console's own (central) database.
+func TestCentralDiscover(t *testing.T) {
+	cs, _ := newCentral(t)
+	dbs, err := cs.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	var sawTenant, sawCentral bool
+	for _, db := range dbs {
+		switch db {
+		case "dis_console_ttd_at23":
+			sawTenant = true
+		case "dis_console_central_e2e":
+			sawCentral = true
+		}
+	}
+	if !sawTenant {
+		t.Fatalf("discover should include the tenant db, got %v", dbs)
+	}
+	if sawCentral {
+		t.Fatalf("discover must exclude the central (current) db, got %v", dbs)
+	}
+}
+
+func countRows(t *testing.T, pool *pgxpool.Pool, cluster string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM flux_resource WHERE cluster=$1", cluster).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return n
+}
+
+// TestCentralReads exercises the fleet-API read methods (Clusters/Summary/List/
+// Get + staleness) against real PostgreSQL after one apply.
+func TestCentralReads(t *testing.T) {
+	cs, _ := newCentral(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:     "ttd_at23",
+		Environment: "at23",
+		Changed: []store.ChangedResource{
+			changed("apps", "Kustomization", flux.ReadyTrue, "h1", now),
+			changed("broken", "Kustomization", flux.ReadyFalse, "h2", now),
+		},
+		Keys: []store.ResourceKey{
+			{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"},
+			{Kind: "Kustomization", Namespace: "flux-system", Name: "broken"},
+		},
+		Cursor:        now,
+		SchemaVersion: store.SchemaVersion,
+		AgentVersion:  "test",
+		LastSweepAt:   now,
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Clusters: present and fresh with a generous threshold.
+	clusters, err := cs.Clusters(ctx, time.Hour)
+	if err != nil {
+		t.Fatalf("clusters: %v", err)
+	}
+	if len(clusters) != 1 || clusters[0].Cluster != "ttd_at23" || clusters[0].Environment != "at23" ||
+		clusters[0].ResourceCount != 2 || clusters[0].Stale {
+		t.Fatalf("unexpected clusters: %+v", clusters)
+	}
+	// Stale with a sub-tick threshold.
+	if stale, err := cs.Clusters(ctx, time.Nanosecond); err != nil || len(stale) != 1 || !stale[0].Stale {
+		t.Fatalf("expected stale with tiny threshold: %+v err=%v", stale, err)
+	}
+
+	// Summary across the fleet.
+	sum, err := cs.Summary(ctx, "")
+	if err != nil || len(sum) != 1 || sum[0].Kind != "Kustomization" ||
+		sum[0].Total != 2 || sum[0].Ready != 1 || sum[0].NotReady != 1 {
+		t.Fatalf("unexpected summary: %+v err=%v", sum, err)
+	}
+
+	// List with a ready filter, scoped to the cluster.
+	rows, err := cs.List(ctx, "ttd_at23", "", "", flux.ReadyFalse)
+	if err != nil || len(rows) != 1 || rows[0].Name != "broken" || rows[0].Cluster != "ttd_at23" {
+		t.Fatalf("unexpected list: %+v err=%v", rows, err)
+	}
+
+	// Get a resource (case-insensitive kind) including its raw payload.
+	r, err := cs.Get(ctx, "ttd_at23", "kustomization", "flux-system", "apps")
+	if err != nil || r.Name != "apps" || r.Cluster != "ttd_at23" || len(r.Raw) == 0 {
+		t.Fatalf("unexpected get: %+v err=%v", r, err)
+	}
+
+	// Get a missing resource.
+	if _, err := cs.Get(ctx, "ttd_at23", "Kustomization", "flux-system", "missing"); !errors.Is(err, central.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## What
The `server` subcommand — a stub in #3726 — now builds and serves the central read model that turns the per-tenant write databases into one queryable fleet view.

- **Sync engine** (`internal/central`) — cluster-keyed central schema (`flux_resource` + `cluster_report`); `Apply` mirrors one cluster per transaction (upsert changed rows + prune deletions + cluster_report); the `Engine` discovers `dis_console_*` tenant databases on the shared server and pulls each incrementally (`updated_at > cursor`), tolerant of tenant `schema_version` N and N−1. `dbauth.NewPoolForDatabase` reaches sibling databases on the same server.
- **Fleet API** (`internal/api`, reading only the central DB) — `GET /api/clusters` (per-cluster sweep/sync times, counts, `stale` flag), an optional `?cluster=` filter on `/api/summary` `/api/resources` `/api/kustomizations` `/api/helmreleases`, and detail at `/api/resources/{cluster}/{kind}/{namespace}/{name}`.
- **Staleness** — a cluster is stale when its agent stopped sweeping (`last_sweep_at`) or the console stopped syncing it (`last_synced_at`) beyond `--stale-after` (default 2m).

## Verification
- `make run-checks-ci-cache` — green (fmt/vet/test/lint).
- Central e2e against real Postgres — `Apply`/prune/cursor, `Discover`, and the read methods (`TestCentralReads`).

## Follow-ups (not in this PR)
- Status `history` in the detail endpoint (needs a central `flux_status_event` + event cursor + sync copy) — detail currently returns the resource without it.
- Full two-tenant + role-isolation Kind e2e (run the engine end-to-end across two tenant databases; assert a tenant role cannot cross-connect).
- Admin-syncroot infra: console identity, `Database dis-console-central` (console Owner), console Deployment/Service, `dis-console-readers` Entra group.

## Design note
The `updated_at > cursor` pull can miss an update from a tenant transaction that commits after the console's read but carries an earlier timestamp (bounded and self-healing; within the ~30–60s staleness budget). Deletions are always caught (full key-set prune). A full key+hash reconcile would close the gap if stronger guarantees are ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented cluster-scoped fleet API with `/api/clusters` endpoint and cluster-filtered resource queries
  * Added incremental tenant synchronization with central read model persistence
  * Enabled Azure/Entra authentication for database connections

* **Documentation**
  * Updated service documentation describing fleet synchronization model and API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->