### PR TITLE
feat(dis-console): central read-model server deploy + agent v1.2.0 rollout

### DIFF
--- a/deploy/admin/base/dis-console-database.yaml
+++ b/deploy/admin/base/dis-console-database.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: Database
+metadata:
+  name: dis-console-central
+  namespace: product-dis
+spec:
+  name: dis_console_central
+  server:
+    name: dis-console-central
+  access:
+    principals:
+      - role: Owner
+        identityRef:
+          name: dis-console
+  deletionPolicy: Retain

--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dis-console
+  namespace: product-dis
+  labels:
+    app: dis-console
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dis-console
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: dis-console
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: dis-console
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dis-console
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.2.0
+          args:
+            - server
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DB_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: dis-console-central-dis-console-dis-pgsql
+                  key: uri
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dis-console
+  namespace: product-dis
+  labels:
+    app: dis-console
+spec:
+  selector:
+    app: dis-console
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/admin/base/dis-console.yaml
+++ b/deploy/admin/base/dis-console.yaml
@@ -1,0 +1,6 @@
+apiVersion: application.dis.altinn.cloud/v1alpha1
+kind: ApplicationIdentity
+metadata:
+  name: dis-console
+  namespace: product-dis
+spec: {}

--- a/deploy/admin/base/kustomization.yaml
+++ b/deploy/admin/base/kustomization.yaml
@@ -3,4 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - dis-console-db-admin.yaml
+  - dis-console.yaml
   - dis-console-databaseserver.yaml
+  - dis-console-database.yaml
+  - dis-console-deployment.yaml

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,9 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.1.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.2.0
+          args:
+            - agent
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## What

Slice 3 of the dis-console fleet: deploy the central read-model **server** and roll the per-cluster **agent** to v1.2.0.

### Central server — `dis/syncroot-admin`, ns `product-dis`
- `ApplicationIdentity dis-console` — the server's workload identity.
- `Database dis-console-central` (`dis_console_central`) on the existing `DatabaseServer dis-console-central`; `dis-console` granted **Owner** via `identityRef`, `deletionPolicy: Retain`.
- `Deployment` + `Service` running the `server` subcommand at **v1.2.0**, reading `DB_URI` from the operator-published connection ConfigMap `dis-console-central-dis-console-dis-pgsql`. No Flux RBAC — the server only syncs tenant DBs into the central read model and serves the fleet API.

### Agent
- `dis-console-tenant-app-template` bumped to **v1.2.0** + `args: [agent]` — the split binary now requires an explicit subcommand. Image released by #3731.

## Validation
- `kustomize build deploy/admin/base` assembles all resources; cross-resource wiring verified (Database → server, access principal → identity, ConfigMap name/key → server env).

## Follow-ups (intentionally not in this PR)
- `deploy/common/at22|at23` are the legacy standalone PoC consoles (their own DatabaseServer/Database/identity), superseded by the fleet model. Left on v1.1.0 (safe — that binary needs no subcommand) pending a decommission-vs-convert decision.
- `dis-console-readers` Entra group + a `Reader` principal on the central Database — deferred until the dedicated reader instance lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed DIS Console service (v1.2.0) with integrated database backend, health checks, and HTTP endpoint exposure.

* **Chores**
  * Updated deployment infrastructure with security configurations and service registrations for the DIS Console component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->