### PR TITLE
fix(dis-console): grant the console Reader on every tenant database

### DIFF
--- a/deploy/templates/dis-console-tenant-db-template/database.yaml
+++ b/deploy/templates/dis-console-tenant-db-template/database.yaml
@@ -13,4 +13,7 @@ spec:
         servicePrincipal:
           name: ${DISDB_GRANTEE_NAME}
           principalId: "${DISDB_GRANTEE_OID}"
+      - role: Reader
+        identityRef:
+          name: dis-console
   deletionPolicy: Retain


### PR DESCRIPTION
## Problem

The central console server syncs every per-tenant database on `dis-console-central` into its read model, connecting as its own identity (`product-dis-dis-console`). The tenant `Database`s grant only the per-cluster agent, so the console is denied CONNECT (`SQLSTATE 42501`) — found during deploy verification.

## Fix

Grant the console **Reader** on every tenant database stamped from `dis-console-tenant-db-template`. The tenant `Database` CRs live in `product-dis`, the same namespace as the `dis-console` `ApplicationIdentity`, so a direct `identityRef` resolves — no Entra group needed (the agent uses `servicePrincipal` only because it's cross-cluster). Supersedes the deferred `dis-console-readers` group.

## Rollout

The existing tenant `Database`s pick up the `Reader` principal on their next reconcile/apply (ttd-side stamping); the operator then grants CONNECT + SELECT and the sync loop self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
