### PR TITLE
feat(dis-console): status history on the resource detail endpoint

### DIFF
--- a/services/dis-console/internal/api/server.go
+++ b/services/dis-console/internal/api/server.go
@@ -27,6 +27,7 @@ type Store interface {
 	Summary(ctx context.Context, cluster string) ([]store.KindCount, error)
 	List(ctx context.Context, cluster, kind, namespace, ready string) ([]central.Resource, error)
 	Get(ctx context.Context, cluster, kind, namespace, name string) (*central.Resource, error)
+	History(ctx context.Context, cluster, kind, namespace, name string) ([]store.Event, error)
 	Ping(ctx context.Context) error
 }
 
@@ -164,9 +165,17 @@ func (s *Server) writeFiltered(w http.ResponseWriter, r *http.Request, cluster, 
 	writeJSON(w, http.StatusOK, listResponse{Count: len(rows), Resources: rows})
 }
 
+// resourceDetail is the detail-endpoint payload: the resource (flattened) plus
+// its recent status history, newest first.
+type resourceDetail struct {
+	*central.Resource
+	History []store.Event `json:"history"`
+}
+
 func (s *Server) handleResourceDetail(w http.ResponseWriter, r *http.Request) {
+	cluster := r.PathValue("cluster")
 	res, err := s.store.Get(r.Context(),
-		r.PathValue("cluster"), r.PathValue("kind"), r.PathValue("namespace"), r.PathValue("name"))
+		cluster, r.PathValue("kind"), r.PathValue("namespace"), r.PathValue("name"))
 	if errors.Is(err, central.ErrNotFound) {
 		writeJSON(w, http.StatusNotFound, errorBody("resource not found"))
 		return
@@ -175,7 +184,12 @@ func (s *Server) handleResourceDetail(w http.ResponseWriter, r *http.Request) {
 		s.fail(w, "get", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, res)
+	history, err := s.store.History(r.Context(), cluster, res.Kind, res.Namespace, res.Name)
+	if err != nil {
+		s.fail(w, "history", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resourceDetail{Resource: res, History: history})
 }
 
 // fail logs the underlying error and returns a generic 500 to the client.

--- a/services/dis-console/internal/api/server_test.go
+++ b/services/dis-console/internal/api/server_test.go
@@ -20,6 +20,7 @@ import (
 type fakeStore struct {
 	resources []central.Resource
 	clusters  []central.Cluster
+	history   map[string][]store.Event
 	pingErr   error
 }
 
@@ -93,6 +94,14 @@ func (f *fakeStore) Get(_ context.Context, cluster, kind, namespace, name string
 	return nil, central.ErrNotFound
 }
 
+func histKey(cluster, kind, namespace, name string) string {
+	return cluster + "|" + strings.ToLower(kind) + "|" + namespace + "|" + name
+}
+
+func (f *fakeStore) History(_ context.Context, cluster, kind, namespace, name string) ([]store.Event, error) {
+	return f.history[histKey(cluster, kind, namespace, name)], nil
+}
+
 func res(cluster, kind, namespace, name, ready, reason string, suspended bool) central.Resource {
 	return central.Resource{
 		Cluster: cluster,
@@ -112,6 +121,12 @@ func testServer() *Server {
 		clusters: []central.Cluster{
 			{Cluster: "ttd_at23", Environment: "at23", ResourceCount: 2, Stale: false},
 			{Cluster: "skd_at23", Environment: "at23", ResourceCount: 1, Stale: true},
+		},
+		history: map[string][]store.Event{
+			histKey("ttd_at23", "Kustomization", "apps", "broken"): {
+				{Ready: flux.ReadyFalse, Reason: "ReconciliationFailed", ObservedAt: time.Now()},
+				{Ready: flux.ReadyTrue, ObservedAt: time.Now().Add(-time.Hour)},
+			},
 		},
 	}, time.Minute)
 	s.MarkSynced()
@@ -243,5 +258,24 @@ func TestResourceDetailNotFound(t *testing.T) {
 	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources/ttd_at23/Kustomization/apps/missing", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestResourceDetailHistory(t *testing.T) {
+	s := testServer()
+	rec := httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/resources/ttd_at23/Kustomization/apps/broken", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var resp resourceDetail
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Resource == nil || resp.Name != "broken" {
+		t.Fatalf("unexpected detail: %+v", resp)
+	}
+	if len(resp.History) != 2 || resp.History[0].Ready != flux.ReadyFalse {
+		t.Fatalf("expected 2 history events newest-first, got %+v", resp.History)
 	}
 }

--- a/services/dis-console/internal/api/server_test.go
+++ b/services/dis-console/internal/api/server_test.go
@@ -99,7 +99,10 @@ func histKey(cluster, kind, namespace, name string) string {
 }
 
 func (f *fakeStore) History(_ context.Context, cluster, kind, namespace, name string) ([]store.Event, error) {
-	return f.history[histKey(cluster, kind, namespace, name)], nil
+	if h, ok := f.history[histKey(cluster, kind, namespace, name)]; ok {
+		return h, nil
+	}
+	return []store.Event{}, nil
 }
 
 func res(cluster, kind, namespace, name, ready, reason string, suspended bool) central.Resource {

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -499,7 +499,7 @@ func (s *Store) EventCursor(ctx context.Context, cluster string) (int64, error) 
 const historyLimit = 50
 
 const historyStmt = `
-SELECT ready, reason, revision, observed_at
+SELECT ready, COALESCE(reason, ''), COALESCE(revision, ''), observed_at
 FROM flux_status_event
 WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4
 ORDER BY observed_at DESC, tenant_id DESC

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -99,7 +99,9 @@ type ClusterState struct {
 	Environment   string
 	Changed       []store.ChangedResource // rows to upsert (content changed since the cursor)
 	Keys          []store.ResourceKey     // the tenant's full current key set (prune basis)
-	Cursor        time.Time               // new high-water
+	Cursor        time.Time               // new resource high-water
+	Events        []store.HistoryEvent    // status events newer than the event cursor (append-only copy)
+	EventCursor   int64                   // new event high-water (largest tenant event id copied)
 	SchemaVersion int
 	AgentVersion  string
 	LastSweepAt   time.Time // agent's last sweep (data freshness), from tenant meta
@@ -145,16 +147,35 @@ WHERE c.cluster = $1
 
 const reportStmt = `
 INSERT INTO cluster_report (
-    cluster, environment, sync_cursor, last_synced_at, last_sweep_at, agent_version, schema_version, resource_count
-) VALUES ($1, $2, $3, now(), $4, $5, $6, $7)
+    cluster, environment, sync_cursor, event_cursor,
+    last_synced_at, last_sweep_at, agent_version, schema_version, resource_count
+) VALUES ($1, $2, $3, $4, now(), $5, $6, $7, $8)
 ON CONFLICT (cluster) DO UPDATE SET
     environment    = EXCLUDED.environment,
     sync_cursor    = EXCLUDED.sync_cursor,
+    event_cursor   = EXCLUDED.event_cursor,
     last_synced_at = now(),
     last_sweep_at  = EXCLUDED.last_sweep_at,
     agent_version  = EXCLUDED.agent_version,
     schema_version = EXCLUDED.schema_version,
     resource_count = EXCLUDED.resource_count`
+
+const eventInsertStmt = `
+INSERT INTO flux_status_event (
+    cluster, tenant_id, kind, namespace, name, ready, reason, message, revision, observed_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (cluster, tenant_id) DO NOTHING`
+
+// pruneEventsStmt removes a cluster's history rows whose resource no longer
+// exists in the central mirror. Run only after the resource prune removed rows.
+const pruneEventsStmt = `
+DELETE FROM flux_status_event e
+WHERE e.cluster = $1
+  AND NOT EXISTS (
+    SELECT 1 FROM flux_resource r
+    WHERE r.cluster = e.cluster AND r.kind = e.kind
+      AND r.namespace = e.namespace AND r.name = e.name
+  )`
 
 // Apply mirrors one cluster's state into the central DB in a single transaction
 // — upsert the changed rows, prune the ones that disappeared, and record the
@@ -193,9 +214,38 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 		}
 	}
 
+	if len(st.Events) > 0 {
+		batch := &pgx.Batch{}
+		for i := range st.Events {
+			e := &st.Events[i]
+			batch.Queue(eventInsertStmt,
+				st.Cluster, e.ID, e.Kind, e.Namespace, e.Name,
+				e.Ready, e.Reason, e.Message, e.Revision, e.ObservedAt,
+			)
+		}
+		br := tx.SendBatch(ctx, batch)
+		for range st.Events {
+			if _, err := br.Exec(); err != nil {
+				_ = br.Close()
+				return fmt.Errorf("copy events cluster %s: %w", st.Cluster, err)
+			}
+		}
+		if err := br.Close(); err != nil {
+			return fmt.Errorf("close event batch: %w", err)
+		}
+	}
+
 	kinds, namespaces, names := splitKeys(st.Keys)
-	if _, err := tx.Exec(ctx, pruneStmt, st.Cluster, kinds, namespaces, names); err != nil {
+	pruned, err := tx.Exec(ctx, pruneStmt, st.Cluster, kinds, namespaces, names)
+	if err != nil {
 		return fmt.Errorf("prune cluster %s: %w", st.Cluster, err)
+	}
+	// Drop history for resources that disappeared, mirroring the resource prune
+	// so orphaned events don't accumulate — only when the prune removed rows.
+	if pruned.RowsAffected() > 0 {
+		if _, err := tx.Exec(ctx, pruneEventsStmt, st.Cluster); err != nil {
+			return fmt.Errorf("prune events cluster %s: %w", st.Cluster, err)
+		}
 	}
 
 	var cursor, lastSweep *time.Time
@@ -208,7 +258,7 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 		lastSweep = &ls
 	}
 	if _, err := tx.Exec(ctx, reportStmt,
-		st.Cluster, st.Environment, cursor, lastSweep, st.AgentVersion, st.SchemaVersion, len(st.Keys),
+		st.Cluster, st.Environment, cursor, st.EventCursor, lastSweep, st.AgentVersion, st.SchemaVersion, len(st.Keys),
 	); err != nil {
 		return fmt.Errorf("cluster_report %s: %w", st.Cluster, err)
 	}
@@ -256,6 +306,18 @@ func advanceCursor(old time.Time, changed []store.ChangedResource) time.Time {
 	for i := range changed {
 		if changed[i].UpdatedAt.After(next) {
 			next = changed[i].UpdatedAt
+		}
+	}
+	return next
+}
+
+// advanceEventCursor returns the new event high-water: the largest tenant event
+// id among the copied events, or the old cursor when none (never regresses).
+func advanceEventCursor(old int64, events []store.HistoryEvent) int64 {
+	next := old
+	for i := range events {
+		if events[i].ID > next {
+			next = events[i].ID
 		}
 	}
 	return next
@@ -415,4 +477,50 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 	}
 	r.Raw = raw
 	return &r, nil
+}
+
+const eventCursorStmt = `SELECT event_cursor FROM cluster_report WHERE cluster = $1`
+
+// EventCursor returns a cluster's event high-water — the largest tenant event
+// id copied so far. Zero means none copied yet (or the cluster is unknown).
+func (s *Store) EventCursor(ctx context.Context, cluster string) (int64, error) {
+	var c int64
+	err := s.pool.QueryRow(ctx, eventCursorStmt, cluster).Scan(&c)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("event cursor query: %w", err)
+	}
+	return c, nil
+}
+
+// historyLimit caps how many recent status events the detail endpoint returns.
+const historyLimit = 50
+
+const historyStmt = `
+SELECT ready, reason, revision, observed_at
+FROM flux_status_event
+WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4
+ORDER BY observed_at DESC, tenant_id DESC
+LIMIT $5`
+
+// History returns a resource's recent status transitions in this cluster,
+// newest first, capped at historyLimit. An unknown resource yields no rows.
+func (s *Store) History(ctx context.Context, cluster, kind, namespace, name string) ([]store.Event, error) {
+	rows, err := s.pool.Query(ctx, historyStmt, cluster, kind, namespace, name, historyLimit)
+	if err != nil {
+		return nil, fmt.Errorf("history query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.Event{}
+	for rows.Next() {
+		var e store.Event
+		if err := rows.Scan(&e.Ready, &e.Reason, &e.Revision, &e.ObservedAt); err != nil {
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
 }

--- a/services/dis-console/internal/central/central_test.go
+++ b/services/dis-console/internal/central/central_test.go
@@ -73,6 +73,21 @@ func TestAdvanceCursor(t *testing.T) {
 	}
 }
 
+func TestAdvanceEventCursor(t *testing.T) {
+	// No events: cursor must not move.
+	if got := advanceEventCursor(7, nil); got != 7 {
+		t.Fatalf("empty events should keep cursor, got %d", got)
+	}
+	events := []store.HistoryEvent{{ID: 3}, {ID: 9}, {ID: 5}}
+	if got := advanceEventCursor(7, events); got != 9 {
+		t.Fatalf("advanceEventCursor should pick the largest id 9, got %d", got)
+	}
+	// All ids at/below the cursor: must never regress.
+	if got := advanceEventCursor(20, events); got != 20 {
+		t.Fatalf("advanceEventCursor must not regress, got %d", got)
+	}
+}
+
 func TestStaleSince(t *testing.T) {
 	d := time.Minute
 	if !staleSince(time.Time{}, d) {

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -118,6 +118,14 @@ func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
 	if err != nil {
 		return err
 	}
+	eventCursor, err := e.central.EventCursor(ctx, cluster)
+	if err != nil {
+		return err
+	}
+	events, err := ts.EventsSince(ctx, eventCursor)
+	if err != nil {
+		return err
+	}
 
 	return e.central.Apply(ctx, ClusterState{
 		Cluster:       cluster,
@@ -125,6 +133,8 @@ func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
 		Changed:       changed,
 		Keys:          keys,
 		Cursor:        advanceCursor(cursor, changed),
+		Events:        events,
+		EventCursor:   advanceEventCursor(eventCursor, events),
 		SchemaVersion: meta.SchemaVersion,
 		AgentVersion:  meta.AgentVersion,
 		LastSweepAt:   meta.LastSweepAt,

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS flux_status_event (
     PRIMARY KEY (cluster, tenant_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_central_event_obj ON flux_status_event (cluster, kind, namespace, name, observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_central_event_obj ON flux_status_event (cluster, lower(kind), namespace, name, observed_at DESC, tenant_id DESC);
 
 CREATE TABLE IF NOT EXISTS cluster_report (
     cluster        text        PRIMARY KEY,

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -23,13 +23,32 @@ CREATE INDEX IF NOT EXISTS idx_central_resource_ready   ON flux_resource (lower(
 CREATE INDEX IF NOT EXISTS idx_central_resource_kind    ON flux_resource (lower(kind));
 CREATE INDEX IF NOT EXISTS idx_central_resource_cluster ON flux_resource (cluster);
 
+CREATE TABLE IF NOT EXISTS flux_status_event (
+    cluster     text        NOT NULL,
+    tenant_id   bigint      NOT NULL,
+    kind        text        NOT NULL,
+    namespace   text        NOT NULL,
+    name        text        NOT NULL,
+    ready       text        NOT NULL,
+    reason      text,
+    message     text,
+    revision    text,
+    observed_at timestamptz NOT NULL,
+    PRIMARY KEY (cluster, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_central_event_obj ON flux_status_event (cluster, kind, namespace, name, observed_at DESC);
+
 CREATE TABLE IF NOT EXISTS cluster_report (
     cluster        text        PRIMARY KEY,
     environment    text        NOT NULL DEFAULT '',
     sync_cursor    timestamptz,
+    event_cursor   bigint      NOT NULL DEFAULT 0,
     last_synced_at timestamptz NOT NULL DEFAULT now(),
     last_sweep_at  timestamptz,
     agent_version  text        NOT NULL DEFAULT '',
     schema_version integer     NOT NULL DEFAULT 0,
     resource_count integer     NOT NULL DEFAULT 0
 );
+
+ALTER TABLE cluster_report ADD COLUMN IF NOT EXISTS event_cursor bigint NOT NULL DEFAULT 0;

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -477,3 +477,48 @@ func (s *Store) Keys(ctx context.Context) ([]ResourceKey, error) {
 	}
 	return out, rows.Err()
 }
+
+// HistoryEvent is one status transition the server copies from a tenant into
+// the central event log. ID is the tenant-local flux_status_event id, used as
+// the server's per-cluster copy high-water.
+type HistoryEvent struct {
+	ID         int64
+	Kind       string
+	Namespace  string
+	Name       string
+	Ready      string
+	Reason     string
+	Message    string
+	Revision   string
+	ObservedAt time.Time
+}
+
+const eventsSinceStmt = `
+SELECT id, kind, namespace, name, ready, reason, message, revision, observed_at
+FROM flux_status_event
+WHERE id > $1
+ORDER BY id`
+
+// EventsSince returns status events with a tenant id greater than cursorID
+// (the server's per-cluster event high-water), oldest first. The agent writes
+// events one sweep at a time, so ids land in commit order with no visibility
+// gaps — a high-water id cursor never skips an event the way an updated_at
+// cursor could.
+func (s *Store) EventsSince(ctx context.Context, cursorID int64) ([]HistoryEvent, error) {
+	rows, err := s.pool.Query(ctx, eventsSinceStmt, cursorID)
+	if err != nil {
+		return nil, fmt.Errorf("events-since query: %w", err)
+	}
+	defer rows.Close()
+
+	out := []HistoryEvent{}
+	for rows.Next() {
+		var e HistoryEvent
+		if err := rows.Scan(&e.ID, &e.Kind, &e.Namespace, &e.Name, &e.Ready,
+			&e.Reason, &e.Message, &e.Revision, &e.ObservedAt); err != nil {
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -349,7 +349,7 @@ FROM flux_resource
 WHERE lower(kind) = lower($1) AND namespace = $2 AND name = $3`
 
 const historyStmt = `
-SELECT ready, reason, revision, observed_at
+SELECT ready, COALESCE(reason, ''), COALESCE(revision, ''), observed_at
 FROM flux_status_event
 WHERE kind = $1 AND namespace = $2 AND name = $3
 ORDER BY observed_at DESC
@@ -494,7 +494,8 @@ type HistoryEvent struct {
 }
 
 const eventsSinceStmt = `
-SELECT id, kind, namespace, name, ready, reason, message, revision, observed_at
+SELECT id, kind, namespace, name, ready,
+       COALESCE(reason, ''), COALESCE(message, ''), COALESCE(revision, ''), observed_at
 FROM flux_status_event
 WHERE id > $1
 ORDER BY id`

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -261,3 +261,131 @@ func TestCentralReads(t *testing.T) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
+
+// TestCentralEventCopyAndHistory drives the status-history pipeline against real
+// PostgreSQL: an agent writes status events into its tenant database, the server
+// copies them into the cluster-keyed central event log (incremental, id-cursored),
+// History serves them newest-first, a redundant sync doesn't duplicate, and a
+// pruned resource loses its events.
+func TestCentralEventCopyAndHistory(t *testing.T) {
+	cs, cpool := newCentral(t)
+	ctx := context.Background()
+	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
+
+	// Agent side: a tenant store on the tenant database newCentral created.
+	tpool, err := dbauth.NewPoolForDatabase(ctx, uri, "dis_console_ttd_at23", nil)
+	if err != nil {
+		t.Fatalf("tenant pool: %v", err)
+	}
+	defer tpool.Close()
+	ts := store.New(tpool)
+	if err := ts.Migrate(ctx); err != nil {
+		t.Fatalf("migrate tenant: %v", err)
+	}
+	if err := ts.InitMeta(ctx, "e2e"); err != nil {
+		t.Fatalf("init tenant meta: %v", err)
+	}
+
+	// Sweep 1: two resources => two status events in the tenant.
+	if _, err := ts.Sync(ctx, []flux.Resource{
+		res("apps", flux.ReadyTrue, "ReconciliationSucceeded", "sha-1"),
+		res("infra", flux.ReadyFalse, "BuildFailed", "sha-1"),
+	}); err != nil {
+		t.Fatalf("tenant sync 1: %v", err)
+	}
+
+	// Server pulls resources + events from the cursors and applies to central.
+	pullAndApply(t, cs, ts, "ttd_at23")
+
+	if ec, err := cs.EventCursor(ctx, "ttd_at23"); err != nil || ec == 0 {
+		t.Fatalf("event cursor should have advanced past 0, got %d err %v", ec, err)
+	}
+	if h, err := cs.History(ctx, "ttd_at23", "Kustomization", "flux-system", "infra"); err != nil ||
+		len(h) != 1 || h[0].Ready != flux.ReadyFalse {
+		t.Fatalf("infra history after sweep 1: %+v err=%v", h, err)
+	}
+
+	// Sweep 2: infra recovers (new event); apps disappears (pruned in the tenant).
+	if _, err := ts.Sync(ctx, []flux.Resource{
+		res("infra", flux.ReadyTrue, "ReconciliationSucceeded", "sha-2"),
+	}); err != nil {
+		t.Fatalf("tenant sync 2: %v", err)
+	}
+	pullAndApply(t, cs, ts, "ttd_at23")
+
+	// infra now has two events, newest first (case-insensitive kind lookup).
+	h, err := cs.History(ctx, "ttd_at23", "kustomization", "flux-system", "infra")
+	if err != nil || len(h) != 2 || h[0].Ready != flux.ReadyTrue || h[1].Ready != flux.ReadyFalse {
+		t.Fatalf("infra history after sweep 2: %+v err=%v", h, err)
+	}
+
+	// apps was pruned, so its central events were pruned too (no orphans).
+	var appsEvents int
+	if err := cpool.QueryRow(ctx,
+		"SELECT count(*) FROM flux_status_event WHERE cluster=$1 AND name=$2", "ttd_at23", "apps",
+	).Scan(&appsEvents); err != nil {
+		t.Fatalf("count apps events: %v", err)
+	}
+	if appsEvents != 0 {
+		t.Fatalf("expected apps history pruned in central, got %d orphaned events", appsEvents)
+	}
+
+	// A redundant sync (nothing new) must not duplicate events.
+	pullAndApply(t, cs, ts, "ttd_at23")
+	if h, err := cs.History(ctx, "ttd_at23", "Kustomization", "flux-system", "infra"); err != nil || len(h) != 2 {
+		t.Fatalf("redundant sync changed history: %+v err=%v", h, err)
+	}
+}
+
+// pullAndApply mirrors the engine's per-cluster sync against a tenant store: pull
+// the rows + events newer than the central cursors, then apply both (with the
+// advanced cursors) to the central store in one transaction.
+func pullAndApply(t *testing.T, cs *central.Store, ts *store.Store, cluster string) {
+	t.Helper()
+	ctx := context.Background()
+	cur, err := cs.Cursor(ctx, cluster)
+	if err != nil {
+		t.Fatalf("cursor: %v", err)
+	}
+	changed, err := ts.ChangedSince(ctx, cur)
+	if err != nil {
+		t.Fatalf("changed-since: %v", err)
+	}
+	keys, err := ts.Keys(ctx)
+	if err != nil {
+		t.Fatalf("keys: %v", err)
+	}
+	ec, err := cs.EventCursor(ctx, cluster)
+	if err != nil {
+		t.Fatalf("event cursor: %v", err)
+	}
+	events, err := ts.EventsSince(ctx, ec)
+	if err != nil {
+		t.Fatalf("events-since: %v", err)
+	}
+	newCur := cur
+	for _, c := range changed {
+		if c.UpdatedAt.After(newCur) {
+			newCur = c.UpdatedAt
+		}
+	}
+	newEC := ec
+	for _, e := range events {
+		if e.ID > newEC {
+			newEC = e.ID
+		}
+	}
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:       cluster,
+		Environment:   "at23",
+		Changed:       changed,
+		Keys:          keys,
+		Cursor:        newCur,
+		Events:        events,
+		EventCursor:   newEC,
+		SchemaVersion: store.SchemaVersion,
+		AgentVersion:  "e2e",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The resource detail endpoint returned the current resource but an empty `history` — the agent records status events per tenant, but the central read model never copied them.

## Fix

Copy each tenant's status events into a cluster-keyed central `flux_status_event` log: incremental (per-cluster `event_cursor`), idempotent (`ON CONFLICT DO NOTHING`), and pruned alongside the resource. `/api/resources/{cluster}/{kind}/{namespace}/{name}` now returns a `history` array, newest-first (capped at 50).

## Verification

gofmt/vet/build, unit tests, golangci-lint v2.12.2 (0 issues), and e2e against real Postgres (a new test drives agent → central copy → History → prune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource detail endpoint now includes recent status history for enhanced visibility into state transitions.
  * System can track and retrieve recent status events for monitored resources.

* **Tests**
  * Added comprehensive tests validating status history retrieval and event synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->