### PR TITLE
chore: Add token rotation for grafana-operator service account

### DIFF
--- a/infrastructure/modules/grafana/README.md
+++ b/infrastructure/modules/grafana/README.md
@@ -13,6 +13,7 @@
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.0.0 |
 | <a name="provider_grafana"></a> [grafana](#provider\_grafana) | >= 3.0.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Modules
 
@@ -31,6 +32,7 @@ No modules.
 | [azurerm_role_assignment.grafana_permission](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [grafana_service_account.admin](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/service_account) | resource |
 | [grafana_service_account_token.grafana_operator](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/service_account_token) | resource |
+| [time_rotating.grafana_operator_token](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
 
 ## Inputs
 
@@ -42,8 +44,10 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment for resources | `string` | n/a | yes |
 | <a name="input_grafana_admin_access"></a> [grafana\_admin\_access](#input\_grafana\_admin\_access) | List of user groups to grant admin access to grafana. | `list(string)` | `[]` | no |
 | <a name="input_grafana_editor_access"></a> [grafana\_editor\_access](#input\_grafana\_editor\_access) | List of user groups to grant editor access to grafana. | `list(string)` | `[]` | no |
-| <a name="input_grafana_major_version"></a> [grafana\_major\_version](#input\_grafana\_major\_version) | Managed Grafana major version. | `number` | `11` | no |
+| <a name="input_grafana_major_version"></a> [grafana\_major\_version](#input\_grafana\_major\_version) | Managed Grafana major version. | `number` | `12` | no |
 | <a name="input_grafana_monitor_reader_subscription_id"></a> [grafana\_monitor\_reader\_subscription\_id](#input\_grafana\_monitor\_reader\_subscription\_id) | List of subscription ids to grant reader access to grafana. | `list(string)` | `[]` | no |
+| <a name="input_grafana_operator_token_expiration_days"></a> [grafana\_operator\_token\_expiration\_days](#input\_grafana\_operator\_token\_expiration\_days) | Lifetime in days for the grafana-operator service account token. Must be less than or equal to the Grafana instance's service\_accounts.token\_expiration\_day\_limit. | `number` | `360` | no |
+| <a name="input_grafana_operator_token_rotation_days"></a> [grafana\_operator\_token\_rotation\_days](#input\_grafana\_operator\_token\_rotation\_days) | Number of days after which the grafana-operator service account token is rotated. Must be less than grafana\_operator\_token\_expiration\_days so the token is recreated before it expires. | `number` | `180` | no |
 | <a name="input_localtags"></a> [localtags](#input\_localtags) | A map of tags to assign to the created resources. | `map(string)` | `{}` | no |
 | <a name="input_location"></a> [location](#input\_location) | Default region for resources | `string` | `"norwayeast"` | no |
 | <a name="input_monitor_workspace_ids"></a> [monitor\_workspace\_ids](#input\_monitor\_workspace\_ids) | List of azure monitor workspaces to connect grafana. | `map(string)` | `{}` | no |

--- a/infrastructure/modules/grafana/grafana.tf
+++ b/infrastructure/modules/grafana/grafana.tf
@@ -44,7 +44,19 @@ resource "grafana_service_account" "admin" {
   role       = "Admin"
 }
 
+# Rotate the grafana-operator token before it expires so grafana-operator
+# always has a valid token. The instance enforces
+# service_accounts.token_expiration_day_limit, so the token must have an expiry.
+resource "time_rotating" "grafana_operator_token" {
+  rotation_days = var.grafana_operator_token_rotation_days
+}
+
 resource "grafana_service_account_token" "grafana_operator" {
   name               = "grafana-operator"
   service_account_id = grafana_service_account.admin.id
+  seconds_to_live    = var.grafana_operator_token_expiration_days * 24 * 60 * 60
+
+  lifecycle {
+    replace_triggered_by = [time_rotating.grafana_operator_token.id]
+  }
 }

--- a/infrastructure/modules/grafana/variables.tf
+++ b/infrastructure/modules/grafana/variables.tf
@@ -84,6 +84,23 @@ variable "prefix" {
   }
 }
 
+variable "grafana_operator_token_expiration_days" {
+  type        = number
+  default     = 360
+  description = "Lifetime in days for the grafana-operator service account token. Must be less than or equal to the Grafana instance's service_accounts.token_expiration_day_limit."
+}
+
+variable "grafana_operator_token_rotation_days" {
+  type        = number
+  default     = 180
+  description = "Number of days after which the grafana-operator service account token is rotated. Must be less than grafana_operator_token_expiration_days so the token is recreated before it expires."
+
+  validation {
+    condition     = var.grafana_operator_token_rotation_days < var.grafana_operator_token_expiration_days
+    error_message = "grafana_operator_token_rotation_days must be less than grafana_operator_token_expiration_days so the token is rotated before it expires."
+  }
+}
+
 variable "localtags" {
   type        = map(string)
   description = "A map of tags to assign to the created resources."

--- a/infrastructure/modules/grafana/variables.tf
+++ b/infrastructure/modules/grafana/variables.tf
@@ -88,12 +88,22 @@ variable "grafana_operator_token_expiration_days" {
   type        = number
   default     = 360
   description = "Lifetime in days for the grafana-operator service account token. Must be less than or equal to the Grafana instance's service_accounts.token_expiration_day_limit."
+
+  validation {
+    condition     = var.grafana_operator_token_expiration_days > 0 && floor(var.grafana_operator_token_expiration_days) == var.grafana_operator_token_expiration_days
+    error_message = "grafana_operator_token_expiration_days must be a positive whole number of days."
+  }
 }
 
 variable "grafana_operator_token_rotation_days" {
   type        = number
   default     = 180
   description = "Number of days after which the grafana-operator service account token is rotated. Must be less than grafana_operator_token_expiration_days so the token is recreated before it expires."
+
+  validation {
+    condition     = var.grafana_operator_token_rotation_days > 0 && floor(var.grafana_operator_token_rotation_days) == var.grafana_operator_token_rotation_days
+    error_message = "grafana_operator_token_rotation_days must be a positive whole number of days."
+  }
 
   validation {
     condition     = var.grafana_operator_token_rotation_days < var.grafana_operator_token_expiration_days


### PR DESCRIPTION
Add automatic rotation of the grafana-operator service account token before it expires. Uses the time provider to trigger token regeneration every 180 days by default, preventing service disruption. Also upgrades the default Grafana version from 11 to 12.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Grafana operator service account tokens now rotate automatically using a configurable schedule (default: 180-day rotation with 360-day expiration) to reduce authentication failures.

* **Improvements**
  * Added input validation for the new token lifecycle settings, including whole-number and rotation-before-expiration rules.

* **Chores**
  * Updated the module’s documented defaults, including moving the Grafana major version default to 12.
  * Expanded module documentation to reflect the new token rotation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->