### PR TITLE
Add a generation timestamp to configmaps

### DIFF
--- a/actions/generate-k6-manifests/cmd/expected_generated_files/smoke/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/smoke/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/smoke/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/smoke/yt01/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v1/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/at22/testrun.json.tmpl
@@ -94,7 +94,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/prod/testrun.json.tmpl
@@ -94,7 +94,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/tt02/testrun.json.tmpl
@@ -94,7 +94,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v10/yt01/testrun.json.tmpl
@@ -94,7 +94,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v11/at22/testrun.json.tmpl
@@ -82,7 +82,7 @@
                }
             }
          ],
-         "image": "grafana/k6:1.7.1-with-browser",
+         "image": "grafana/k6:2.0.0-with-browser",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v12/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v13/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v13/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at23/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v14/at23/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v2/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v3/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v4/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v5/yt01/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/at22/testrun.json.tmpl
@@ -78,7 +78,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v6/yt01/testrun.json.tmpl
@@ -86,7 +86,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-daemonsets",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v7/at22/testrun.json.tmpl
@@ -94,7 +94,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v8/at22/testrun.json.tmpl
@@ -88,7 +88,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
+++ b/actions/generate-k6-manifests/cmd/expected_generated_files/v9/at22/testrun.json.tmpl
@@ -90,7 +90,7 @@
                }
             }
          ],
-         "image": "ghcr.io/altinn/altinn-platform/k6-image:latest",
+         "image": "ghcr.io/altinn/altinn-platform/k6-image:v2.0.0",
          "metadata": {
             "annotations": {
                "k6-action-image/test_name": "get-deployments",

--- a/actions/generate-k6-manifests/cmd/generator.go
+++ b/actions/generate-k6-manifests/cmd/generator.go
@@ -430,9 +430,13 @@ func (r K8sManifestGenerator) CallKubectl(dirName string, configMapName string, 
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	generationTimestamp := strings.Split(uniqName, "-")[1]
+
 	temp.SetLabels(map[string]string{
-		"generated-by": "k6-action-image",
-		"uniq_name":    uniqName,
+		"generated-by":         "k6-action-image",
+		"uniq_name":            uniqName,
+		"generation_timestamp": generationTimestamp,
 	})
 	temp.SetAnnotations(map[string]string{
 		"k6-action-image/test_name":    testName,


### PR DESCRIPTION
Adding a generation timestamp so I can see which ConfigMaps are no longer being used and therefore can be cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned container image version to v2.0.0 across multiple test configurations to ensure consistent deployments.
  * Added generation timestamp tracking to generated configuration maps for improved auditability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->