### PR TITLE
chore(dis-console): bump deployed image to v1.3.1

### DIFF
--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.2.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
           args:
             - server
           ports:

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.1.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.1.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.2.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
           args:
             - agent
           ports:


### PR DESCRIPTION
**⛔ DO NOT MERGE until the dis-console v1.3.1 image has published to ghcr** (release-please release PR merged + its build green). Merging earlier = ImagePullBackOff across the fleet.

**What**: bump all dis-console deployments to v1.3.1 — agents (at22, at23, tenant template) and the central server.

**Why**: v1.3.1 carries the Flux-sweep watch-cache/discovery-TTL fix (relieves the API server the agents were hammering) and the `x/crypto` HIGH-CVE fix.

**Rollout note**: agents are currently scaled to 0 / Flux suspended as incident mitigation; after this merges, resuming Flux deploys v1.3.1 at replicas:1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `dis-console` application image to version `v1.3.1` across deployment environments and templates.
  * No other deployment settings, service configuration, or runtime behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->