### PR TITLE
feat(dis-pgsql): suffix Flexible Server AzureName with --cluster-id

### DIFF
--- a/services/dis-pgsql-operator/api/v1alpha1/databaseserver_types.go
+++ b/services/dis-pgsql-operator/api/v1alpha1/databaseserver_types.go
@@ -195,6 +195,23 @@ type DatabaseServerStatus struct {
 	// +optional
 	SubnetCIDR string `json:"subnetCIDR,omitempty"`
 
+	// serverName is the Azure PostgreSQL Flexible Server name (the AzureName
+	// of the owned FlexibleServer). It is the authoritative server identity
+	// for consumers and may differ from metadata.name because the operator
+	// appends the cluster-id ("<metadata.name>-<cluster-id>") to keep the
+	// Azure name globally unique across clusters. Existing servers keep
+	// their original AzureName so this can be rolled out without
+	// recreating Azure resources.
+	// +optional
+	ServerName string `json:"serverName,omitempty"`
+
+	// host is the fully qualified DNS name of the PostgreSQL Flexible Server
+	// (server.Status.FullyQualifiedDomainName). It is populated once Azure
+	// has provisioned the server. Consumers should read this instead of
+	// deriving "<metadata.name>.postgres.database.azure.com".
+	// +optional
+	Host string `json:"host,omitempty"`
+
 	// conditions represent the current state of the DatabaseServer resource.
 	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
 	//

--- a/services/dis-pgsql-operator/cmd/main.go
+++ b/services/dis-pgsql-operator/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 	var aksResourceGroup string
 	var tenantID string
 	var userProvisionImage string
+	var clusterID string
 	var provisionUser bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -153,6 +154,14 @@ func main() {
 		"user-provision-image",
 		os.Getenv("DISPG_USER_PROVISION_IMAGE"),
 		"Image used for user provisioning Jobs (required)",
+	)
+	flag.StringVar(
+		&clusterID,
+		"cluster-id",
+		os.Getenv("DISPG_CLUSTER_ID"),
+		"Stable, human-readable cluster identifier (e.g. 'admin-test'); appended to new "+
+			"Flexible Server AzureNames to keep them globally unique across clusters and "+
+			"derivable by out-of-cluster consumers (required)",
 	)
 
 	opts := zap.Options{
@@ -291,6 +300,7 @@ func main() {
 		tenantID,
 		aksResourceGroup,
 		userProvisionImage,
+		clusterID,
 		useFakes,
 	)
 	if err != nil {

--- a/services/dis-pgsql-operator/config/crd/bases/storage.dis.altinn.cloud_databaseservers.yaml
+++ b/services/dis-pgsql-operator/config/crd/bases/storage.dis.altinn.cloud_databaseservers.yaml
@@ -332,6 +332,23 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              host:
+                description: |-
+                  host is the fully qualified DNS name of the PostgreSQL Flexible Server
+                  (server.Status.FullyQualifiedDomainName). It is populated once Azure
+                  has provisioned the server. Consumers should read this instead of
+                  deriving "<metadata.name>.postgres.database.azure.com".
+                type: string
+              serverName:
+                description: |-
+                  serverName is the Azure PostgreSQL Flexible Server name (the AzureName
+                  of the owned FlexibleServer). It is the authoritative server identity
+                  for consumers and may differ from metadata.name because the operator
+                  appends the cluster-id ("<metadata.name>-<cluster-id>") to keep the
+                  Azure name globally unique across clusters. Existing servers keep
+                  their original AzureName so this can be rolled out without
+                  recreating Azure resources.
+                type: string
               serverParameterErrors:
                 description: |-
                   serverParameterErrors contains per-parameter reconciliation failures reported

--- a/services/dis-pgsql-operator/config/default/deploy_vars_patch.yaml
+++ b/services/dis-pgsql-operator/config/default/deploy_vars_patch.yaml
@@ -15,6 +15,8 @@
       value: ${DISPG_AKS_RESOURCE_GROUP}
     - name: DISPG_USER_PROVISION_IMAGE
       value: ${DISPG_USER_PROVISION_IMAGE}
+    - name: DISPG_CLUSTER_ID
+      value: ${DISPG_CLUSTER_ID}
 - op: add
   path: /spec/template/metadata/labels/azure.workload.identity~1use
   value: "true"

--- a/services/dis-pgsql-operator/config/kind/manager_kind_patch.yaml
+++ b/services/dis-pgsql-operator/config/kind/manager_kind_patch.yaml
@@ -24,6 +24,8 @@ spec:
               value: "fake-tenant"
             - name: DISPG_AKS_RESOURCE_GROUP
               value: "fake-aks-rg"
+            - name: DISPG_CLUSTER_ID
+              value: "kind"
           resources:
             requests:
               cpu: 50m

--- a/services/dis-pgsql-operator/internal/config/config.go
+++ b/services/dis-pgsql-operator/internal/config/config.go
@@ -15,6 +15,14 @@ type OperatorConfig struct {
 	SubscriptionId   string
 	TenantId         string
 
+	// ClusterId is the deterministic, human-readable identifier of the cluster
+	// this operator runs in (e.g. "admin-test", "admin-prod"). It is appended
+	// to new Azure PostgreSQL Flexible Server names ("<db.Name>-<ClusterId>")
+	// to keep them globally unique across clusters, and is the same value
+	// out-of-cluster consumers (service-owner Terraform) use to derive the
+	// server name without needing to read DatabaseServer.status.
+	ClusterId string
+
 	// UserProvisionImage is the image used for user provisioning Jobs.
 	UserProvisionImage string
 
@@ -24,7 +32,7 @@ type OperatorConfig struct {
 
 // NewOperatorConfig builds and validates the OperatorConfig from already-parsed
 // flag values. It does NOT read environment variables itself.
-func NewOperatorConfig(resourceGroup, dbVnetName, aksVnetName, subscriptionId, tenantId, aksRG, userProvisionImage string, useAzFakes bool) (*OperatorConfig, error) {
+func NewOperatorConfig(resourceGroup, dbVnetName, aksVnetName, subscriptionId, tenantId, aksRG, userProvisionImage, clusterId string, useAzFakes bool) (*OperatorConfig, error) {
 	var missing []string
 
 	subscriptionId = strings.TrimSpace(subscriptionId)
@@ -33,6 +41,7 @@ func NewOperatorConfig(resourceGroup, dbVnetName, aksVnetName, subscriptionId, t
 	aksVnetName = strings.TrimSpace(aksVnetName)
 	aksRG = strings.TrimSpace(aksRG)
 	userProvisionImage = strings.TrimSpace(userProvisionImage)
+	clusterId = strings.TrimSpace(clusterId)
 
 	tenantId = strings.TrimSpace(tenantId)
 
@@ -57,6 +66,9 @@ func NewOperatorConfig(resourceGroup, dbVnetName, aksVnetName, subscriptionId, t
 	if userProvisionImage == "" {
 		missing = append(missing, "user-provision-image")
 	}
+	if clusterId == "" {
+		missing = append(missing, "cluster-id")
+	}
 
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("missing required configuration: %s", strings.Join(missing, ", "))
@@ -68,6 +80,7 @@ func NewOperatorConfig(resourceGroup, dbVnetName, aksVnetName, subscriptionId, t
 		AKSVNetName:        aksVnetName,
 		AKSResourceGroup:   aksRG,
 		TenantId:           tenantId,
+		ClusterId:          clusterId,
 		UserProvisionImage: userProvisionImage,
 		UseAzFakes:         useAzFakes,
 	}, nil

--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -741,6 +741,31 @@ var _ = Describe("DatabaseServer controller", func() {
 		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
 			Should(Equal(db.Name))
 
+		// The Azure-side server name carries the cluster-id suffix so it stays
+		// globally unique across clusters; the suite config sets ClusterId="envtest".
+		Eventually(func(g Gomega) string {
+			var server dbforpostgresqlv1.FlexibleServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &server)).To(Succeed())
+			return server.Spec.AzureName
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(db.Name + "-envtest"))
+
+		// DatabaseServer.status.serverName mirrors that AzureName so downstream
+		// consumers can read the authoritative identity from K8s without
+		// re-implementing the naming convention.
+		Eventually(func(g Gomega) string {
+			var updated storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &updated)).To(Succeed())
+			return updated.Status.ServerName
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(db.Name + "-envtest"))
+
 		Consistently(func(g Gomega) int {
 			var jobs batchv1.JobList
 			g.Expect(k8sClient.List(ctx, &jobs,
@@ -753,6 +778,59 @@ var _ = Describe("DatabaseServer controller", func() {
 			return len(jobs.Items)
 		}).WithTimeout(3 * time.Second).WithPolling(250 * time.Millisecond).
 			Should(Equal(0))
+	})
+
+	It("preserves a pre-existing FlexibleServer AzureName instead of recreating it", func() {
+		// Backward-compat guarantee: if a FlexibleServer for this DatabaseServer
+		// already exists with a hand-picked AzureName (e.g. the pre-cluster-id
+		// per-env-name mitigation), the operator must keep that AzureName so
+		// rolling out cluster-id-based naming does not orphan or recreate the
+		// underlying Azure resource.
+		const dbCRName = "preserve-existing-azurename"
+		const legacyAzureName = "preserve-existing-azurename-test"
+
+		db := newDedicatedDatabaseServer(dbCRName, adminAuth(
+			adminManagedIdentity,
+			adminManagedIdentityID,
+			adminManagedIdentity,
+		))
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+
+		// Wait for the operator to create the FlexibleServer, then overwrite its
+		// AzureName with a value that doesn't follow the cluster-id convention.
+		Eventually(func(g Gomega) {
+			var server dbforpostgresqlv1.FlexibleServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &server)).To(Succeed())
+			server.Spec.AzureName = legacyAzureName
+			g.Expect(k8sClient.Update(ctx, &server)).To(Succeed())
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		// Trigger a re-reconcile by mutating the DatabaseServer spec.
+		Eventually(func(g Gomega) {
+			var current storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &current)).To(Succeed())
+			retention := 21
+			current.Spec.BackupRetentionDays = &retention
+			g.Expect(k8sClient.Update(ctx, &current)).To(Succeed())
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		Consistently(func(g Gomega) string {
+			var server dbforpostgresqlv1.FlexibleServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &server)).To(Succeed())
+			return server.Spec.AzureName
+		}).WithTimeout(5 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(legacyAzureName))
 	})
 
 	It("rejects dedicated database servers with shared network config", func() {

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
@@ -507,6 +507,15 @@ func (r *DatabaseServerReconciler) asoResourcesReady(
 		return false, fmt.Errorf("get FlexibleServer %s/%s: %w", ns, serverName, err)
 	}
 
+	// Publish the Azure-side identity on the DatabaseServer status as soon as ASO
+	// has filled it in. setDatabaseServerReadyCondition flushes the status, so
+	// this only needs to mutate the in-memory object.
+	if server.Status.FullyQualifiedDomainName != nil {
+		if host := strings.TrimSpace(*server.Status.FullyQualifiedDomainName); host != "" {
+			db.Status.Host = host
+		}
+	}
+
 	serverStatus, serverReason, serverMessage, serverReady := readyConditionInfo(server.Status.Conditions)
 	if !serverReady || serverStatus != metav1.ConditionTrue {
 		logger.Info("FlexibleServer not ready yet",

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller_postgres.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller_postgres.go
@@ -16,6 +16,7 @@ import (
 	storagev1alpha1 "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/api/v1alpha1"
 	dbUtil "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/database"
 	k8sutil "github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/k8s"
+	"github.com/Altinn/altinn-platform/services/dis-pgsql-operator/internal/naming"
 	to "github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	dbforpostgresqlv1 "github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v20250801"
 	genruntime "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
@@ -34,6 +35,16 @@ const (
 	defaultMaintenanceStartHour          = 3
 	defaultMaintenanceStartMinute        = 0
 	maintenanceCustomWindowEnabled       = "Enabled"
+
+	// flexibleServerNameMaxLen is Azure's upper bound on a PostgreSQL Flexible
+	// Server name (3-63 chars, lowercase letters/digits/hyphens, starts with a
+	// letter). New AzureNames must respect it even after the uniqueness suffix.
+	flexibleServerNameMaxLen = 63
+
+	// flexibleServerNameFallback is used when db.Name is empty or sanitizes to
+	// nothing usable; the helper requires a non-empty fallback to stay inside
+	// Azure's naming rules.
+	flexibleServerNameFallback = "dispg-srv"
 )
 
 type postgresNetworkConfig struct {
@@ -221,6 +232,31 @@ func resourceReferenceLogValue(ref *genruntime.ResourceReference) string {
 	return ref.Name
 }
 
+// flexibleServerAzureName resolves the globally-unique Azure name for the
+// FlexibleServer that backs this DatabaseServer.
+//
+// When a FlexibleServer already exists with a non-empty Spec.AzureName, that
+// value is reused so existing servers keep their Azure identity (changing
+// AzureName triggers a destructive recreate in ASO). When the FlexibleServer
+// does not exist yet, a new name "<db.Name>-<cluster-id>" is derived from the
+// operator's --cluster-id flag, which is the same per-cluster suffix
+// out-of-cluster consumers (service-owner Terraform that cannot read K8s
+// status) use to compute the server name. Two DatabaseServers with the same
+// CR name in different clusters get distinct AzureNames because each cluster
+// has its own cluster-id.
+func (r *DatabaseServerReconciler) flexibleServerAzureName(
+	db *storagev1alpha1.DatabaseServer,
+	existing *dbforpostgresqlv1.FlexibleServer,
+) string {
+	if existing != nil {
+		if name := strings.TrimSpace(existing.Spec.AzureName); name != "" {
+			return name
+		}
+	}
+	suffix := naming.SanitizeLowerHyphen(r.Config.ClusterId)
+	return naming.WithRequiredSuffix(db.Name, "-"+suffix, flexibleServerNameMaxLen, flexibleServerNameFallback)
+}
+
 // ensurePostgresServer ensures a PostgreSQL Flexible Server ASO resource exists
 // for the given database server.
 func (r *DatabaseServerReconciler) ensurePostgresServer(
@@ -231,12 +267,15 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 ) error {
 	ns := db.Namespace
 
-	// The current DatabaseServer CR represents a PostgreSQL server, so the FlexibleServer
-	// uses the CR name.
-	serverName := db.Name
+	// The FlexibleServer's Kubernetes object name stays equal to the DatabaseServer
+	// CR name (used as a stable identifier across watches, owner refs, status
+	// lookups). The Azure-side server name (Spec.AzureName) is the globally unique
+	// identifier in Azure's PostgreSQL namespace and is resolved separately below
+	// after we know whether the resource already exists.
+	k8sName := db.Name
 
 	key := types.NamespacedName{
-		Name:      serverName,
+		Name:      k8sName,
 		Namespace: ns,
 	}
 
@@ -246,9 +285,16 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 		if apierrors.IsNotFound(err) {
 			found = false
 		} else {
-			return fmt.Errorf("get FlexibleServer %s/%s: %w", ns, serverName, err)
+			return fmt.Errorf("get FlexibleServer %s/%s: %w", ns, k8sName, err)
 		}
 	}
+
+	var existingPtr *dbforpostgresqlv1.FlexibleServer
+	if found {
+		existingPtr = &existing
+	}
+	serverAzureName := r.flexibleServerAzureName(db, existingPtr)
+	db.Status.ServerName = serverAzureName
 
 	// define if dev/prod profile
 	profile := dbUtil.GetProfile(db.Spec.ServerType)
@@ -278,7 +324,7 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 
 	// 5) Build server
 	desiredSpec := dbforpostgresqlv1.FlexibleServer_Spec{
-		AzureName: serverName,
+		AzureName: serverAzureName,
 		Location:  to.Ptr(loc),
 
 		Owner: &genruntime.KnownResourceReference{
@@ -312,7 +358,7 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 	if !found {
 		server := &dbforpostgresqlv1.FlexibleServer{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serverName,
+				Name:      k8sName,
 				Namespace: ns,
 				Labels:    desiredLabels,
 			},
@@ -324,7 +370,8 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 		}
 
 		logger.Info("creating PostgreSQL FlexibleServer for database server",
-			"serverName", serverName,
+			"k8sName", k8sName,
+			"azureName", serverAzureName,
 			"namespace", ns,
 			"location", loc,
 			"version", versionStr,
@@ -338,7 +385,7 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 			if apierrors.IsAlreadyExists(err) {
 				return nil
 			}
-			return fmt.Errorf("create FlexibleServer %s/%s: %w", ns, serverName, err)
+			return fmt.Errorf("create FlexibleServer %s/%s: %w", ns, k8sName, err)
 		}
 		return nil
 	}
@@ -347,11 +394,12 @@ func (r *DatabaseServerReconciler) ensurePostgresServer(
 	existing.Labels, updated = k8sutil.SyncSpecAndLabels(&existing.Spec, desiredSpec, existing.Labels, desiredLabels)
 	if updated {
 		logger.Info("updating PostgreSQL FlexibleServer to match database server",
-			"serverName", serverName,
+			"k8sName", k8sName,
+			"azureName", serverAzureName,
 			"namespace", ns,
 		)
 		if err := r.Update(ctx, &existing); err != nil {
-			return fmt.Errorf("update FlexibleServer %s/%s: %w", ns, serverName, err)
+			return fmt.Errorf("update FlexibleServer %s/%s: %w", ns, k8sName, err)
 		}
 	}
 

--- a/services/dis-pgsql-operator/internal/controller/suite_test.go
+++ b/services/dis-pgsql-operator/internal/controller/suite_test.go
@@ -118,6 +118,7 @@ var _ = BeforeSuite(func() {
 		SubscriptionId:     "my-subscription-id",
 		TenantId:           "my-tenant-id",
 		AKSResourceGroup:   "aks-vnet-rg",
+		ClusterId:          "envtest",
 		UserProvisionImage: "controller:latest",
 	}
 	err = (&DatabaseServerReconciler{

--- a/services/dis-pgsql-operator/internal/database/user_provisioner.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner.go
@@ -53,7 +53,11 @@ func RunUserProvisioner(ctx context.Context) error {
 		if disableAAD {
 			host = "postgres.default.svc"
 		} else {
-			host = fmt.Sprintf("%s.postgres.database.azure.com", serverName)
+			// In Azure mode the controller publishes the real Flexible Server FQDN
+			// from DatabaseServer.Status.Host (server.Status.FullyQualifiedDomainName).
+			// Deriving "<serverName>.postgres.database.azure.com" is no longer correct
+			// because AzureName now carries a stable uniqueness suffix.
+			return fmt.Errorf("%s must be set when AAD is enabled", DBHostEnv)
 		}
 	}
 	dbName := strings.TrimSpace(os.Getenv(DBNameEnv))

--- a/services/dis-pgsql-operator/test/e2e/user_provision_test.go
+++ b/services/dis-pgsql-operator/test/e2e/user_provision_test.go
@@ -500,6 +500,44 @@ var _ = Describe("User provisioning", Ordered, func() {
 			Should(Equal("14"))
 	})
 
+	It("appends the cluster-id to the FlexibleServer AzureName for global uniqueness", func() {
+		// The Kind manager patch sets DISPG_CLUSTER_ID=kind; the operator must
+		// suffix every new FlexibleServer's Spec.AzureName with that value so
+		// two clusters can host a DatabaseServer of the same CR name without
+		// colliding on Azure's global PostgreSQL server-name registry. The
+		// DatabaseServer.status.serverName field mirrors the AzureName for
+		// out-of-cluster consumers.
+		By("verifying the FlexibleServer Spec.AzureName carries the cluster-id suffix")
+		Eventually(func(g Gomega) string {
+			cmd := exec.Command(
+				"kubectl", "get",
+				"flexibleservers.dbforpostgresql.azure.com",
+				dbName,
+				"-n", namespace,
+				"-o", "jsonpath={.spec.azureName}",
+			)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.TrimSpace(output)
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).
+			Should(Equal(dbName + "-kind"))
+
+		By("verifying DatabaseServer.status.serverName mirrors the AzureName")
+		Eventually(func(g Gomega) string {
+			cmd := exec.Command(
+				"kubectl", "get",
+				"databaseservers.storage.dis.altinn.cloud",
+				dbName,
+				"-n", namespace,
+				"-o", "jsonpath={.status.serverName}",
+			)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.TrimSpace(output)
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).
+			Should(Equal(dbName + "-kind"))
+	})
+
 	It("applies explicit backupRetentionDays when set on DatabaseServer", func() {
 		manifestPath := writeTestManifestWithBackupRetention(
 			explicitRetentionDBName,


### PR DESCRIPTION
## Problem

`FlexibleServer.Spec.AzureName` was set verbatim to `DatabaseServer.metadata.name`. PostgreSQL Flexible Server names are globally unique in Azure, so two clusters with same-named `DatabaseServer` CRs collide on `ServerNameAlreadyExists`, and generic names risk colliding with unrelated Azure tenants.

## Fix

- Append `--cluster-id` to new `Spec.AzureName`: `<db.Name>-<sanitize(--cluster-id)>`.
- Preserve any pre-existing `Spec.AzureName` so rolling out this change does not recreate live Azure servers.
- Expose `DatabaseServer.status.serverName` (the AzureName) and `status.host` (FQDN from `FullyQualifiedDomainName`) for consumers.
- Drop the `<serverName>.postgres.database.azure.com` fallback in `user_provisioner.go`; rely on `DISPG_DB_HOST` (which the controller always sets from `status.host`).

## Rollout

`--cluster-id` (env `DISPG_CLUSTER_ID`) is **required**. The deploy overlay templates it; the deploying TF must set it per cluster before this image lands. Kind overlay sets it to `kind`.

## Test plan

- [x] Integration (`make test` envtest): new dedicated-server It asserts `Spec.AzureName == <db.Name>-envtest` and `status.serverName` mirrors it; new "preserves a pre-existing AzureName" It overwrites AzureName mid-reconcile and confirms it stays.
- [x] E2E (`make test-e2e` in Kind): asserts `Spec.AzureName == <db.Name>-kind` and `status.serverName` matches.
- [x] `make run-checks-ci-cache` green (fmt, generate, manifests, test-ci, lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)