### PR TITLE
feat(dis-console): admin-cluster agent + at22/at23 agent-arg fix

### DIFF
--- a/deploy/admin/base/dis-console-agent-database.yaml
+++ b/deploy/admin/base/dis-console-agent-database.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.dis.altinn.cloud/v1alpha1
+kind: Database
+metadata:
+  name: dis-console-admin
+  namespace: product-dis
+spec:
+  name: dis_console_admin
+  server:
+    name: dis-console-central
+  access:
+    principals:
+      - role: Owner
+        identityRef:
+          name: dis-console-agent
+      - role: Reader
+        identityRef:
+          name: dis-console
+  deletionPolicy: Retain

--- a/deploy/admin/base/dis-console-agent-deployment.yaml
+++ b/deploy/admin/base/dis-console-agent-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dis-console-agent
+  namespace: product-dis
+  labels:
+    app: dis-console-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dis-console-agent
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: dis-console-agent
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: dis-console-agent
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dis-console
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          args:
+            - agent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DB_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: dis-console-admin-dis-console-agent-dis-pgsql
+                  key: uri
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/deploy/admin/base/dis-console-agent-rbac.yaml
+++ b/deploy/admin/base/dis-console-agent-rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dis-console-flux-reader
+rules:
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dis-console-flux-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dis-console-flux-reader
+subjects:
+  - kind: ServiceAccount
+    name: dis-console-agent
+    namespace: product-dis

--- a/deploy/admin/base/dis-console-agent.yaml
+++ b/deploy/admin/base/dis-console-agent.yaml
@@ -1,0 +1,6 @@
+apiVersion: application.dis.altinn.cloud/v1alpha1
+kind: ApplicationIdentity
+metadata:
+  name: dis-console-agent
+  namespace: product-dis
+spec: {}

--- a/deploy/admin/base/kustomization.yaml
+++ b/deploy/admin/base/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
   - dis-console-databaseserver.yaml
   - dis-console-database.yaml
   - dis-console-deployment.yaml
+  - dis-console-agent.yaml
+  - dis-console-agent-database.yaml
+  - dis-console-agent-rbac.yaml
+  - dis-console-agent-deployment.yaml

--- a/deploy/admin/test/kustomization.yaml
+++ b/deploy/admin/test/kustomization.yaml
@@ -2,3 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - patch: |
+      apiVersion: storage.dis.altinn.cloud/v1alpha1
+      kind: Database
+      metadata:
+        name: dis-console-admin
+        namespace: product-dis
+      spec:
+        name: dis_console_admin_test

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -29,6 +29,8 @@ spec:
       containers:
         - name: dis-console
           image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          args:
+            - agent
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -29,6 +29,8 @@ spec:
       containers:
         - name: dis-console
           image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          args:
+            - agent
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Two related dis-console deploy changes, split into two commits.

## fix: at22/at23 agent subcommand (latent CrashLoop)
at22/at23 run the agent with no subcommand. Since the agent/server split, `cmd/main.go` requires `agent`/`server` and the Dockerfile sets no default `CMD`, so a no-arg container exits 2 and CrashLoops. #3756 bumped these to v1.3.1 without the subcommand — this adds `args: [agent]` (image unchanged at v1.3.1).

## feat: agent in the admin cluster
Run a co-located agent in admin so the admin cluster's own Flux deploys appear in the fleet console (today admin runs only the central server). The agent sweeps admin Flux CRs (`dis-console-flux-reader`) into a new tenant DB `dis_console_admin_test` on the existing `dis-console-central` server; the server discovers it by the `dis_console_` prefix and serves it as cluster `admin_test`. The DB grants `Owner` to a new `dis-console-agent` identity and `Reader` to `dis-console` (the server syncs each tenant DB as its own identity). Rides the existing `dis/syncroot-admin` artifact — no adminservices change.

Verified with `kustomize build` on `deploy/admin/{base,test}` and `deploy/common/{at22,at23}`. `test` overlay only — prod admin isn't wired in the syncroot release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new admin agent deployment, including its identity, database access, and runtime configuration.
  * Updated the console deployment to run in agent mode in both environments.

* **Bug Fixes**
  * Improved workload health checks and security hardening for the new deployment.
  * Added read-only access for the agent to relevant platform resources.

* **Chores**
  * Included the new resources in the admin and test environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->