### PR TITLE
fix(dis-pgsql-operator): decouple Private DNS zone CR name from Azure FQDN

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -555,12 +555,13 @@ var _ = Describe("DatabaseServer controller", func() {
 
 		Expect(k8sClient.Create(ctx, db)).To(Succeed())
 
-		expectedZoneName := fmt.Sprintf("%s.private.postgres.database.azure.com", db.Name)
+		expectedZoneCRName := zoneCRNameForDatabaseServer(db)
+		expectedZoneAzureName := fmt.Sprintf("%s.private.postgres.database.azure.com", db.Name)
 
 		Eventually(func(g Gomega) error {
 			var zone networkv1.PrivateDnsZone
 			key := types.NamespacedName{
-				Name:      expectedZoneName,
+				Name:      expectedZoneCRName,
 				Namespace: ns,
 			}
 			err := k8sClient.Get(ctx, key, &zone)
@@ -571,13 +572,16 @@ var _ = Describe("DatabaseServer controller", func() {
 		// Inspect metadata of created Private DNS zone
 		var zone networkv1.PrivateDnsZone
 		key := types.NamespacedName{
-			Name:      expectedZoneName,
+			Name:      expectedZoneCRName,
 			Namespace: ns,
 		}
 		Expect(k8sClient.Get(ctx, key, &zone)).To(Succeed())
 
-		// Miminal expectations about the created zone
-		Expect(zone.Name).To(Equal(expectedZoneName))
+		// The zone CR name is the short DatabaseServer name so ASO's owner-name
+		// label on child vnet links stays a valid <=63-char label; the Azure-side
+		// name (Spec.AzureName) remains the FQDN PostgreSQL requires.
+		Expect(zone.Name).To(Equal(expectedZoneCRName))
+		Expect(zone.Spec.AzureName).To(Equal(expectedZoneAzureName))
 		Expect(zone.Namespace).To(Equal(ns))
 	})
 
@@ -601,13 +605,13 @@ var _ = Describe("DatabaseServer controller", func() {
 		}
 		Expect(k8sClient.Create(ctx, db)).To(Succeed())
 
-		zoneName := fmt.Sprintf("%s.private.postgres.database.azure.com", db.Name)
+		zoneCRName := zoneCRNameForDatabaseServer(db)
 
 		// Wait for the zone
 		Eventually(func(g Gomega) error {
 			var zone networkv1.PrivateDnsZone
 			key := types.NamespacedName{
-				Name:      zoneName,
+				Name:      zoneCRName,
 				Namespace: ns,
 			}
 			return k8sClient.Get(ctx, key, &zone)
@@ -938,7 +942,7 @@ var _ = Describe("DatabaseServer controller", func() {
 		Consistently(func() bool {
 			var zone networkv1.PrivateDnsZone
 			err := k8sClient.Get(ctx, types.NamespacedName{
-				Name:      zoneNameForDatabaseServer(db),
+				Name:      zoneCRNameForDatabaseServer(db),
 				Namespace: db.Namespace,
 			}, &zone)
 			return apierrors.IsNotFound(err)
@@ -2442,7 +2446,7 @@ var _ = Describe("DatabaseServer controller", func() {
 		))
 		Expect(k8sClient.Create(ctx, db)).To(Succeed())
 
-		zoneName := zoneNameForDatabaseServer(db)
+		zoneName := zoneCRNameForDatabaseServer(db)
 		dbLinkName := dbVNetLinkNameForDatabaseServer(db)
 		aksLinkName := aksVNetLinkNameForDatabaseServer(db)
 

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
@@ -196,7 +196,7 @@ func (r *DatabaseServerReconciler) deleteDedicatedNetworkChildren(
 	}
 
 	// Second wave: the zone, now that nothing nested under it remains.
-	zoneGone, err := r.ensureChildDeleted(ctx, logger, db.Namespace, zoneNameForDatabaseServer(db), &networkv1.PrivateDnsZone{})
+	zoneGone, err := r.ensureChildDeleted(ctx, logger, db.Namespace, zoneCRNameForDatabaseServer(db), &networkv1.PrivateDnsZone{})
 	if err != nil {
 		return false, err
 	}
@@ -303,7 +303,7 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 	// DB VNet link
 	if err := r.ensurePrivateDNSVNetLink(
 		ctx, logger, db,
-		zoneNameForDatabaseServer(db),
+		zoneCRNameForDatabaseServer(db),
 		dbVNetLinkNameForDatabaseServer(db),
 		r.Config.DBVNetName,
 		dbVnetID,
@@ -315,7 +315,7 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 	// AKS VNet link
 	if err := r.ensurePrivateDNSVNetLink(
 		ctx, logger, db,
-		zoneNameForDatabaseServer(db),
+		zoneCRNameForDatabaseServer(db),
 		aksVNetLinkNameForDatabaseServer(db),
 		r.Config.AKSVNetName,
 		aksVnetID,
@@ -324,7 +324,7 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 		return ctrl.Result{}, err
 	}
 
-	networkConfig, err := r.dedicatedPostgresNetworkConfig(db, zoneNameForDatabaseServer(db))
+	networkConfig, err := r.dedicatedPostgresNetworkConfig(db, zoneCRNameForDatabaseServer(db))
 	if err != nil {
 		logger.Error(err, "failed to build dedicated PostgreSQL network config")
 		return ctrl.Result{}, err

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller_dns.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller_dns.go
@@ -19,8 +19,21 @@ import (
 // The suffix we use for per-database-server private DNS zones.
 const postgresPrivateZoneSuffix = "private.postgres.database.azure.com"
 
-// zoneNameForDatabaseServer computes the Private DNS zone name for a server.
-func zoneNameForDatabaseServer(db *storagev1alpha1.DatabaseServer) string {
+// zoneCRNameForDatabaseServer is the Kubernetes object name of the server's
+// Private DNS zone CR. It stays equal to the DatabaseServer CR name (which is a
+// valid flexible-server name, so <=63 chars) rather than the FQDN. ASO stamps a
+// serviceoperator.azure.com/owner-name=<owner CR name> label on child resources
+// (the vnet links), truncated to the 63-char label limit. Using the FQDN as the
+// owner name made that label exceed 63 chars for longer server names, ending in
+// a '.' and failing label validation, which blocked the vnet links entirely.
+func zoneCRNameForDatabaseServer(db *storagev1alpha1.DatabaseServer) string {
+	return db.Name
+}
+
+// zoneAzureNameForDatabaseServer is the Azure-side name of the server's Private
+// DNS zone (used only for Spec.AzureName) — the FQDN PostgreSQL Flexible Server
+// requires.
+func zoneAzureNameForDatabaseServer(db *storagev1alpha1.DatabaseServer) string {
 	return fmt.Sprintf("%s.%s", db.Name, postgresPrivateZoneSuffix)
 }
 
@@ -42,9 +55,10 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSZone(
 		return fmt.Errorf("ResourceGroup is not configured on DatabaseServerReconciler")
 	}
 	ns := db.Namespace
-	zoneName := zoneNameForDatabaseServer(db)
+	zoneCRName := zoneCRNameForDatabaseServer(db)
+	zoneAzureName := zoneAzureNameForDatabaseServer(db)
 	key := types.NamespacedName{
-		Name:      zoneName,
+		Name:      zoneCRName,
 		Namespace: ns,
 	}
 
@@ -52,7 +66,8 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSZone(
 	err := r.Get(ctx, key, &existing)
 	if err == nil {
 		logger.Info("private DNS zone already exists for database server",
-			"zoneName", zoneName,
+			"zoneCRName", zoneCRName,
+			"azureName", zoneAzureName,
 			"asoNamespace", ns)
 		return nil
 	}
@@ -61,21 +76,22 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSZone(
 	}
 
 	logger.Info("creating private DNS zone for database server",
-		"zoneName", zoneName,
+		"zoneCRName", zoneCRName,
+		"azureName", zoneAzureName,
 		"asoNamespace", ns)
 
 	loc := "global" // Private DNS zones use 'global' for Location in Azure.
 
 	zone := &networkv1.PrivateDnsZone{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      zoneName,
+			Name:      zoneCRName,
 			Namespace: ns,
 			Labels: map[string]string{
 				databaseServerNameLabelKey: db.Name,
 			},
 		},
 		Spec: networkv1.PrivateDnsZone_Spec{
-			AzureName: zoneName,
+			AzureName: zoneAzureName,
 			Location:  &loc,
 			Owner: &genruntime.KnownResourceReference{
 				ARMID: fmt.Sprintf(
@@ -97,7 +113,8 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSZone(
 	if err := r.Create(ctx, zone); err != nil {
 		if errors.IsAlreadyExists(err) {
 			logger.Info("private DNS zone already created by another reconcile",
-				"zoneName", zoneName,
+				"zoneCRName", zoneCRName,
+				"azureName", zoneAzureName,
 				"asoNamespace", ns)
 			return nil
 		}
@@ -113,7 +130,7 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSVNetLink(
 	ctx context.Context,
 	logger logr.Logger,
 	db *storagev1alpha1.DatabaseServer,
-	zoneName string,
+	zoneCRName string,
 	linkName string,
 	targetVNetName string,
 	vnetID string,
@@ -130,7 +147,7 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSVNetLink(
 
 		// REQUIRED: owner is the PrivateDnsZone CR
 		Owner: &genruntime.KnownResourceReference{
-			Name: zoneName,
+			Name: zoneCRName,
 		},
 
 		RegistrationEnabled: &regFalse,
@@ -163,7 +180,7 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSVNetLink(
 		if updated {
 			logger.Info("updating private DNS VNet link",
 				"linkName", existing.Name,
-				"zoneName", zoneName,
+				"zoneCRName", zoneCRName,
 				"vnetName", targetVNetName,
 				"vnetID", vnetID,
 			)
@@ -187,7 +204,7 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSVNetLink(
 
 	logger.Info("creating private DNS VNet link",
 		"linkName", linkName,
-		"zoneName", zoneName,
+		"zoneCRName", zoneCRName,
 		"vnetName", targetVNetName,
 		"vnetID", vnetID,
 	)
@@ -206,11 +223,13 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSVNetLink(
 	return nil
 }
 
-// privateZoneARMIDResourceReference builds the resource reference for the server's Private DNS zone.
-func (r *DatabaseServerReconciler) privateZoneARMIDResourceReference(zoneName string) *genruntime.ResourceReference {
+// privateZoneARMIDResourceReference builds the resource reference for the server's
+// Private DNS zone. Name is a Kubernetes cross-resource reference (the zone CR
+// name), not the Azure FQDN.
+func (r *DatabaseServerReconciler) privateZoneARMIDResourceReference(zoneCRName string) *genruntime.ResourceReference {
 	return &genruntime.ResourceReference{
 		Group: "network.azure.com",
 		Kind:  "PrivateDnsZone",
-		Name:  zoneName,
+		Name:  zoneCRName,
 	}
 }

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller_postgres.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller_postgres.go
@@ -129,7 +129,7 @@ func (r *DatabaseServerReconciler) subnetARMIDResourceReference(subnetName strin
 
 func (r *DatabaseServerReconciler) dedicatedPostgresNetworkConfig(
 	db *storagev1alpha1.DatabaseServer,
-	zoneName string,
+	zoneCRName string,
 ) (postgresNetworkConfig, error) {
 	// Use the subnet allocated to this database server from the status.
 	if db.Status.SubnetCIDR == "" {
@@ -143,7 +143,7 @@ func (r *DatabaseServerReconciler) dedicatedPostgresNetworkConfig(
 	}
 
 	subnetID := r.subnetARMIDResourceReference(subnetInfo.Name)
-	zoneID := r.privateZoneARMIDResourceReference(zoneName)
+	zoneID := r.privateZoneARMIDResourceReference(zoneCRName)
 
 	publicNetworkAccess := dbforpostgresqlv1.ServerPublicNetworkAccessState_Disabled
 	return postgresNetworkConfig{


### PR DESCRIPTION
## Problem
When a DatabaseServer name is long, the operator-created Private DNS vnet-link CRs are rejected by the API server and never reconcile (admin-AKS link never created → provisioner can't resolve the server → tenant AAD role never created → app gets `28P01`).

Root cause: the Private DNS zone CR's `metadata.name` was the FQDN `<db.Name>.private.postgres.database.azure.com`. ASO stamps `serviceoperator.azure.com/owner-name=<owner CR name>` on child resources (the vnet links), truncated to the 63-char label limit. For longer server names the FQDN truncates to a trailing `.` → invalid label → the link CRs can't persist.

## Fix
Decouple the zone CR's Kubernetes name from its Azure name (mirroring the existing FlexibleServer name/AzureName split):
- zone CR `metadata.name` = `db.Name` (also the vnet-link `Owner.Name` and the FlexibleServer's private-zone reference) — always a valid ≤63-char owner-name label
- `Spec.AzureName` = FQDN — unchanged

Removes the previous ≤27-char server-name constraint entirely.

## Rollout
⚠️ Existing servers have FQDN-named zone CRs; after this ships the operator looks for a `db.Name`-named CR and creates a new one pointing at the same Azure zone. Migrate per env (at23: clean-slate; prod: ASO adopt path). Deploy admin-test → at23 verify → admin-prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private DNS zone handling so the Kubernetes resource name and the Azure DNS zone name are tracked separately.
  * Private DNS links and cleanup now use the correct zone identifier, helping prevent reconciliation and teardown issues.
  * Updated tests to validate DNS zone creation, lookup, and deletion with the expected names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->