### PR TITLE
fix(dis-pgsql-operator): grant Owner CREATE on its database

### DIFF
--- a/rfcs/0013-multitenant-dis-databases.md
+++ b/rfcs/0013-multitenant-dis-databases.md
@@ -221,8 +221,12 @@ reader, writer, and owner. It grants access by role membership:
   and sequences.
 - `Writer`: Reader plus `INSERT`, `UPDATE`, `DELETE`, and sequence write access.
   It does not get DDL.
-- `Owner`: Writer plus schema ownership/DDL capability for migrations and
-  maintainers.
+- `Owner`: Writer plus ownership of the managed schema and `CREATE` on the
+  database, so migrations and maintainers can run DDL and create their own
+  schemas (e.g. an app that puts its tables in a dedicated `engine` schema).
+  Because each database is dedicated to its app, this mirrors CloudNativePG's
+  model where the application role owns its database; `Reader`/`Writer` stay
+  scoped to the managed schema.
 
 `identityRef` entries are provisioned as PostgreSQL AAD `service` principals.
 `group` entries are provisioned as PostgreSQL AAD `group` principals.

--- a/services/dis-pgsql-operator/internal/database/user_provisioner.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner.go
@@ -380,6 +380,7 @@ func ensureManagedRoleGrants(
 		{name: "grant writer sequence write", sql: grantAllSequencesWriteSQL(opts.SchemaName, roles.Writer)},
 		{name: "grant owner schema usage", sql: grantSchemaUsageSQL(opts.SchemaName, roles.Owner)},
 		{name: "grant owner schema create", sql: grantSchemaCreateSQL(opts.SchemaName, roles.Owner)},
+		{name: "grant owner database create", sql: grantDatabaseCreateSQL(opts.DatabaseName, roles.Owner)},
 	}
 
 	for _, statement := range statements {
@@ -535,6 +536,17 @@ func grantConnectSQL(dbName, user string) string {
 	return fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s;",
 		pgx.Identifier{dbName}.Sanitize(),
 		pgx.Identifier{user}.Sanitize(),
+	)
+}
+
+// grantDatabaseCreateSQL grants CREATE on the database to a role, allowing it to
+// create new schemas. The Owner managed role gets this so apps that manage their
+// own schemas (e.g. EF Core's CREATE SCHEMA) work in their dedicated database,
+// mirroring how CloudNativePG makes the application role own its database.
+func grantDatabaseCreateSQL(dbName, role string) string {
+	return fmt.Sprintf("GRANT CREATE ON DATABASE %s TO %s;",
+		pgx.Identifier{dbName}.Sanitize(),
+		pgx.Identifier{role}.Sanitize(),
 	)
 }
 

--- a/services/dis-pgsql-operator/internal/database/user_provisioner_test.go
+++ b/services/dis-pgsql-operator/internal/database/user_provisioner_test.go
@@ -61,6 +61,11 @@ func TestUserProvisionSQL(t *testing.T) {
 			want: `GRANT CONNECT ON DATABASE "app-db" TO "app-user";`,
 		},
 		{
+			name: "grant database create",
+			got:  grantDatabaseCreateSQL(dbName, "owner-role"),
+			want: `GRANT CREATE ON DATABASE "app-db" TO "owner-role";`,
+		},
+		{
 			name: "create schema",
 			got:  createSchemaSQL(schema, user),
 			want: `CREATE SCHEMA IF NOT EXISTS "app-db" AUTHORIZATION "app-user";`,
@@ -263,6 +268,7 @@ func TestEnsureAccessCreatesManagedRolesAndPrincipalMemberships(t *testing.T) {
 	requireExec(t, conn, grantSchemaUsageSQL(appDBName, roles.Reader))
 	requireExec(t, conn, grantAllTablesReadSQL(appDBName, roles.Reader))
 	requireExec(t, conn, grantAllTablesWriteSQL(appDBName, roles.Writer))
+	requireExec(t, conn, grantDatabaseCreateSQL(appDBName, roles.Owner))
 	requireExec(t, conn, grantRoleSQL(roles.Reader, roles.Writer))
 	requireExec(t, conn, grantRoleSQL(roles.Writer, roles.Owner))
 	requireExec(t, conn, grantRoleSQL(roles.Writer, "app-user"))


### PR DESCRIPTION
## Problem
workflow-engine (and any app that manages its own schema) fails its EF migration on a freshly provisioned shared-dis-pgsql database:

```
42501: permission denied for database workflow_engine_ttd_at23
Where: SQL statement "CREATE SCHEMA engine"
```

## Root cause
The operator grants the `Owner` managed role `CREATE` on the **operator-managed schema** (named after the DB), but never `CREATE ON DATABASE`. So an `Owner` principal can do DDL inside that one schema but cannot create a new schema (e.g. `engine`), which needs database-level CREATE.

## Fix
Grant the `Owner` role `CREATE ON DATABASE <db>` in `ensureManagedRoleGrants`. Since each DIS database is dedicated to its app, letting `Owner` manage schemas in its own database is safe and mirrors CloudNativePG's "the app role owns its database" model. `Reader`/`Writer` stay schema-scoped — only `Owner` gains schema-creation.

## Rollout
After release + redeploy, the access job re-runs on reconcile and applies the new grant to existing databases — no app change, no CR change. Apps recover on next pod restart.

Verified: `make run-checks-ci-cache` (fmt/generate/manifests/test-ci/lint — 0 issues), incl. a new `grantDatabaseCreateSQL` unit test + an `ensureAccess` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed owner roles now receive database-level `CREATE` access, allowing authorized users to create objects directly in the database.
* **Bug Fixes**
  * Improved permission provisioning so role setup includes the full set of required grants.
* **Tests**
  * Expanded coverage to verify the new database create privilege is applied during role provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->