### PR TITLE
feat(grafana): let Viewer role use Explore and query data sources

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/grafana.tf
@@ -20,6 +20,30 @@ resource "azurerm_dashboard_grafana" "grafana" {
   }
 }
 
+# Let members of the Grafana "Viewer" role use Explore and run ad-hoc queries against
+# data sources (temporary, in-session panel edits that cannot be saved). Without this,
+# viewers can only look at existing dashboards — they cannot open Explore or query data
+# sources. The azurerm_dashboard_grafana resource does not expose this toggle (it only
+# maps grafanaConfigurations.smtp), so we set grafanaConfigurations.users.viewersCanEdit
+# directly via azapi.
+#
+# NOTE: azurerm only rebuilds grafanaConfigurations when an `smtp` block changes on the
+# grafana resource above (none is configured today). If an `smtp` block is ever added,
+# re-apply this resource to restore the setting.
+resource "azapi_update_resource" "grafana_viewers_can_edit" {
+  type        = "Microsoft.Dashboard/grafana@2024-10-01"
+  resource_id = azurerm_dashboard_grafana.grafana.id
+  body = {
+    properties = {
+      grafanaConfigurations = {
+        users = {
+          viewersCanEdit = true
+        }
+      }
+    }
+  }
+}
+
 resource "azurerm_role_assignment" "tf_grafana_admin" {
   scope                            = azurerm_dashboard_grafana.grafana.id
   role_definition_name             = "Grafana Admin"

--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/providers.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/providers.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 2.3.0"
+    }
   }
   backend "azurerm" {
     use_azuread_auth = true
@@ -20,6 +24,8 @@ provider "azurerm" {
     "Microsoft.KubernetesConfiguration"
   ]
 }
+
+provider "azapi" {}
 
 # Dialogporten
 provider "azurerm" {


### PR DESCRIPTION
Grafana Viewer-role members could previously only view existing dashboards — they could not open **Explore** or run ad-hoc queries against data sources. This sets `grafanaConfigurations.users.viewersCanEdit = true` on the `altinn-grafana-test` Azure Managed Grafana instance so viewers can use Explore and make temporary, non-persisted panel edits (they still cannot save dashboards or edit data source configs). Because `azurerm_dashboard_grafana` does not expose this setting (it only maps the `smtp` config), it is patched via `azapi`, which is added to the `altinn-monitor-test-rg` stack's required providers. Takes effect on `terraform apply` of that stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grafana viewers can now use Explore and run ad-hoc queries, giving read-only users more flexibility when investigating dashboards and data.
* **Bug Fixes**
  * Applied a configuration update so the Grafana permission change takes effect reliably in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->