### PR TITLE
feat(dis-console): sweep DIS custom resources and project azureResourceId + parent

### DIFF
--- a/deploy/templates/dis-console-tenant-app-template/rbac.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/rbac.yaml
@@ -29,6 +29,41 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - storage.dis.altinn.cloud
+    resources:
+      - databaseservers
+      - databases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - vault.dis.altinn.cloud
+    resources:
+      - vaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - application.dis.altinn.cloud
+    resources:
+      - applicationidentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apim.dis.altinn.cloud
+    resources:
+      - apis
+      - apiversions
+      - backends
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -2,9 +2,10 @@
 
 ## What this is
 dis-console is a small Go service (plain `net/http`) with two subcommands:
-- `dis-console agent` — runs per cluster: reads Flux custom resources across all
-  namespaces and persists a normalized snapshot into that cluster's own tenant
-  PostgreSQL database. Exposes only `/healthz` and `/readyz` (no JSON API).
+- `dis-console agent` — runs per cluster: reads Flux and DIS custom resources
+  across all namespaces and persists a normalized snapshot into that cluster's
+  own tenant PostgreSQL database. Exposes only `/healthz` and `/readyz` (no
+  JSON API).
 - `dis-console server` — runs centrally: migrates the central read model,
   incrementally syncs every tenant database on the shared server into it, and
   serves the fleet JSON API over it (`/api/clusters`, `?cluster=` filters,
@@ -67,11 +68,14 @@ Do not claim checks passed unless you actually ran them.
 - `cmd/main.go` — subcommand dispatch. `agent` runs the per-cluster sweep loop
   (health probes only); `server` migrates the central schema, runs the tenant
   sync loop, and serves the fleet API. Each wires its own DB pool and flags.
-- `internal/flux` — version-agnostic dynamic-client reader; `normalize.go`
-  decodes the projected status into the typed Flux `api` structs (kustomize/helm/
-  source `api` + `pkg/apis/meta`) via runtime conversion, while keeping the full
-  object for `raw`. `hygiene.go` strips volatile metadata (`managedFields`,
-  `resourceVersion`), computes the `content_hash`, and caps `raw` at `MaxRawBytes`.
+- `internal/flux` — version-agnostic dynamic-client reader for the Flux and DIS
+  kinds; `normalize.go` decodes the projected status into the typed Flux `api`
+  structs (kustomize/helm/source `api` + `pkg/apis/meta`) via runtime
+  conversion — and, for the DIS kinds, into a minimal local struct (never the
+  operator modules) that also projects `azureResourceId` and `parent` — while
+  keeping the full object for `raw`. `hygiene.go` strips volatile metadata
+  (`managedFields`, `resourceVersion`), computes the `content_hash`, and caps
+  `raw` at `MaxRawBytes`.
 - `internal/dbauth` — pgxpool builder; Entra-token `BeforeConnect` hook in the
   cluster, PGPASSWORD/trust fallback when Entra is disabled (Kind/CI/local).
 - `internal/store` — tenant pgxpool store: embedded `schema.sql`, `Migrate`,

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -1,14 +1,11 @@
 # dis-console
 
-**dis-console** is a small Go service that surfaces DIS deployment state. Its
-first job is Flux: it reads the live Flux custom resources across **all
-namespaces** and serves their deployment status as a read-only JSON API, so the
-question *"is everything deployed and healthy, and if not, what failed and
-why?"* can be answered without squinting at `flux get` or raw `kubectl ... -o
-yaml`.
-
-The name is deliberately product-level (not `flux-*`) so the Console can grow
-to cover other DIS state later.
+**dis-console** is a small Go service that surfaces DIS deployment state. It
+reads the live Flux custom resources and the DIS platform custom resources
+(databases, vaults, identities, APIM) across **all namespaces** and serves
+their deployment status as a read-only JSON API, so the question *"is
+everything deployed and healthy, and if not, what failed and why?"* can be
+answered without squinting at `flux get` or raw `kubectl ... -o yaml`.
 
 > Status: moving to a fleet model. The binary has two subcommands:
 > - `dis-console agent` runs in each cluster, sweeps its Flux CRs every interval,
@@ -32,10 +29,25 @@ via a discovery `RESTMapper` (robust to Azure Flux version bumps):
 | `kustomize.toolkit.fluxcd.io` | Kustomization |
 | `helm.toolkit.fluxcd.io` | HelmRelease |
 | `source.toolkit.fluxcd.io` | OCIRepository, HelmRepository, HelmChart |
+| `storage.dis.altinn.cloud` | DatabaseServer, Database |
+| `vault.dis.altinn.cloud` | Vault |
+| `application.dis.altinn.cloud` | ApplicationIdentity |
+| `apim.dis.altinn.cloud` | Api, ApiVersion, Backend |
+
+A DIS kind whose CRD is not installed on a cluster is simply skipped by the
+sweep, so mixed fleets keep working.
 
 For each object it extracts a small normalized shape (`ready`/`reason`/
 `message`/`revision`/`suspended`/`generation`/`observedGeneration`) from the
 `Ready` condition and keeps the full object under `raw` for the detail endpoint.
+The DIS kinds add two fields the UI builds on: `azureResourceId` (the ARM id of
+the provisioned Azure resource, for Portal links — from `status.resourceId`, or
+the APIM ids `status.apiVersionSetID`/`status.backendID`) and `parent`
+(`{kind,name}` — a Database nests under its `spec.server.name` DatabaseServer,
+an ApiVersion under the Api named by its controller owner reference). The DIS
+operators publish the same `Ready` condition; the APIM kinds publish only
+`status.provisioningState`, which is mapped onto ready
+(Succeeded→True, Failed→False, transitional→Unknown).
 
 Each kind is listed from the apiserver watch cache (`resourceVersion=0`, not a
 quorum read from etcd) and the discovery cache is refreshed only periodically,
@@ -51,7 +63,10 @@ the **typed Flux api structs** (`kustomize-controller/api`, `helm-controller/api
 version-pinned typed client, and without giving up the verbatim `raw`. Trade-off:
 those api packages pull `sigs.k8s.io/controller-runtime` in as an *indirect*
 dependency (their scheme builders import it); dis-console uses only the status
-structs, never the framework.
+structs, never the framework. The DIS kinds are decoded the same way but into a
+minimal local struct instead of the operator api packages, which would drag the
+Azure Service Operator dependency tree into this service for a handful of
+fields.
 
 ## Endpoints
 

--- a/services/dis-console/cmd/main.go
+++ b/services/dis-console/cmd/main.go
@@ -59,10 +59,10 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprint(os.Stderr, `dis-console — Flux fleet console
+	fmt.Fprint(os.Stderr, `dis-console — DIS fleet console
 
 Usage:
-  dis-console agent [flags]    Sweep this cluster's Flux resources into its own tenant database.
+  dis-console agent [flags]    Sweep this cluster's Flux and DIS resources into its own tenant database.
   dis-console server [flags]   Sync tenant databases into the central read model and serve the fleet API.
 
 Run "dis-console <subcommand> -h" for that subcommand's flags.
@@ -70,8 +70,8 @@ Run "dis-console <subcommand> -h" for that subcommand's flags.
 }
 
 // runAgent runs the per-cluster sweep-and-store loop: every poll interval it
-// lists the Flux resources and persists a normalized snapshot to this cluster's
-// tenant database. It exposes only liveness/readiness probes — the fleet API
+// lists the Flux and DIS resources and persists a normalized snapshot to this
+// cluster's tenant database. It exposes only liveness/readiness probes — the fleet API
 // lives in the server, reading the central database.
 func runAgent(args []string) {
 	fs := flag.NewFlagSet("agent", flag.ExitOnError)
@@ -260,7 +260,7 @@ func poll(ctx context.Context, client *flux.Client, st *store.Store, h *health.S
 	}
 
 	h.MarkReady()
-	log.Printf("swept %d Flux resources (%d changed, %d pruned)", stats.Upserted, stats.Changed, stats.Pruned)
+	log.Printf("swept %d resources (%d changed, %d pruned)", stats.Upserted, stats.Changed, stats.Pruned)
 }
 
 func gracefulShutdown(srv *http.Server) {

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -112,12 +112,14 @@ INSERT INTO flux_resource (
     cluster, kind, api_version, namespace, name,
     ready, reason, message, revision, suspended,
     generation, observed_generation, last_transition, raw, content_hash,
+    azure_resource_id, parent_kind, parent_name,
     updated_at, synced_at
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15,
-    $16, now()
+    $16, $17, $18,
+    $19, now()
 )
 ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
     api_version         = EXCLUDED.api_version,
@@ -125,6 +127,9 @@ ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
     reason              = EXCLUDED.reason,
     message             = EXCLUDED.message,
     revision            = EXCLUDED.revision,
+    azure_resource_id   = EXCLUDED.azure_resource_id,
+    parent_kind         = EXCLUDED.parent_kind,
+    parent_name         = EXCLUDED.parent_name,
     suspended           = EXCLUDED.suspended,
     generation          = EXCLUDED.generation,
     observed_generation = EXCLUDED.observed_generation,
@@ -195,10 +200,12 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 			if len(raw) == 0 {
 				raw = json.RawMessage("{}")
 			}
+			parentKind, parentName := parentCols(c.Parent)
 			batch.Queue(upsertStmt,
 				st.Cluster, c.Kind, c.APIVersion, c.Namespace, c.Name,
 				c.Ready, c.Reason, c.Message, c.Revision, c.Suspended,
 				c.Generation, c.ObservedGeneration, c.LastTransition, []byte(raw), c.ContentHash,
+				c.AzureResourceID, parentKind, parentName,
 				c.UpdatedAt,
 			)
 		}
@@ -277,6 +284,22 @@ func splitKeys(keys []store.ResourceKey) (kinds, namespaces, names []string) {
 		kinds[i], namespaces[i], names[i] = k.Kind, k.Namespace, k.Name
 	}
 	return kinds, namespaces, names
+}
+
+// parentCols splits an optional parent into its nullable column pair.
+func parentCols(p *flux.ParentRef) (kind, name *string) {
+	if p == nil {
+		return nil, nil
+	}
+	return &p.Kind, &p.Name
+}
+
+// parentRef rebuilds the optional parent from its nullable column pair.
+func parentRef(kind, name *string) *flux.ParentRef {
+	if kind == nil || name == nil {
+		return nil
+	}
+	return &flux.ParentRef{Kind: *kind, Name: *name}
 }
 
 // clusterID strips the tenant-database prefix to get the cluster identifier
@@ -420,7 +443,8 @@ func (s *Store) Summary(ctx context.Context, cluster string) ([]store.KindCount,
 
 const listStmt = `
 SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
-       suspended, generation, observed_generation, last_transition
+       suspended, generation, observed_generation, last_transition,
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name
 FROM flux_resource
 WHERE ($1 = '' OR cluster = $1)
   AND ($2 = '' OR lower(kind) = lower($2))
@@ -441,13 +465,16 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 	out := []Resource{}
 	for rows.Next() {
 		var r Resource
+		var parentKind, parentName *string
 		if err := rows.Scan(
 			&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 			&r.ObservedGeneration, &r.LastTransition,
+			&r.AzureResourceID, &parentKind, &parentName,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
+		r.Parent = parentRef(parentKind, parentName)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -455,7 +482,8 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 
 const getStmt = `
 SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
-       suspended, generation, observed_generation, last_transition, raw
+       suspended, generation, observed_generation, last_transition, raw,
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name
 FROM flux_resource
 WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
 
@@ -464,10 +492,12 @@ WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
 func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) (*Resource, error) {
 	var r Resource
 	var raw []byte
+	var parentKind, parentName *string
 	err := s.pool.QueryRow(ctx, getStmt, cluster, kind, namespace, name).Scan(
 		&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 		&r.ObservedGeneration, &r.LastTransition, &raw,
+		&r.AzureResourceID, &parentKind, &parentName,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -476,6 +506,7 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 		return nil, fmt.Errorf("get query: %w", err)
 	}
 	r.Raw = raw
+	r.Parent = parentRef(parentKind, parentName)
 	return &r, nil
 }
 

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -110,7 +110,10 @@ func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
 	if err != nil {
 		return err
 	}
-	changed, err := ts.ChangedSince(ctx, cursor)
+	// The pull is keyed on the tenant's schema version: a version-1 tenant
+	// (agent not yet migrated) lacks the DIS projection columns, so selecting
+	// them would fail the cluster's sync until its agent rolls out.
+	changed, err := ts.ChangedSince(ctx, cursor, meta.SchemaVersion)
 	if err != nil {
 		return err
 	}

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -8,6 +8,9 @@ CREATE TABLE IF NOT EXISTS flux_resource (
     reason              text,
     message             text,
     revision            text,
+    azure_resource_id   text,
+    parent_kind         text,
+    parent_name         text,
     suspended           boolean     NOT NULL DEFAULT false,
     generation          bigint,
     observed_generation bigint,
@@ -52,3 +55,7 @@ CREATE TABLE IF NOT EXISTS cluster_report (
 );
 
 ALTER TABLE cluster_report ADD COLUMN IF NOT EXISTS event_cursor bigint NOT NULL DEFAULT 0;
+
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS azure_resource_id text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_kind text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_name text;

--- a/services/dis-console/internal/flux/client.go
+++ b/services/dis-console/internal/flux/client.go
@@ -1,12 +1,14 @@
-// Package flux reads Flux custom resources across all namespaces using the
-// dynamic client and a discovery-backed RESTMapper, and normalizes their
+// Package flux reads Flux and DIS custom resources across all namespaces using
+// the dynamic client and a discovery-backed RESTMapper, and normalizes their
 // deployment status into a small, stable shape the API serves.
 //
 // The fetch stays dynamic on purpose (the discovery RESTMapper resolves
 // whichever served version Azure Flux exposes, and the full object is kept
 // verbatim for the raw payload); the projected status fields are then decoded
 // into the typed Flux api structs via runtime conversion — typed access without
-// a version-pinned typed client. See normalize.go and the README.
+// a version-pinned typed client. The DIS kinds are decoded the same way into
+// minimal local structs so the operator modules stay out of the dependency
+// graph. See normalize.go and the README.
 package flux
 
 import (
@@ -38,15 +40,51 @@ const (
 	KindHelmChart      = "HelmChart"
 )
 
-// TargetKinds are the Flux custom resource kinds the Console reads. The served
-// API version of each is resolved at runtime via the discovery RESTMapper, so
-// the same binary keeps working if Azure Flux bumps a version.
+// DIS platform API groups (one per operator) and their kinds. The kind names
+// mirror the CRD spellings (Api, ApiVersion), not Go initialism style.
+const (
+	GroupDISStorage     = "storage.dis.altinn.cloud"
+	GroupDISVault       = "vault.dis.altinn.cloud"
+	GroupDISApplication = "application.dis.altinn.cloud"
+	GroupDISApim        = "apim.dis.altinn.cloud"
+
+	KindDatabaseServer      = "DatabaseServer"
+	KindDatabase            = "Database"
+	KindVault               = "Vault"
+	KindApplicationIdentity = "ApplicationIdentity"
+	KindApi                 = "Api"
+	KindApiVersion          = "ApiVersion"
+	KindBackend             = "Backend"
+)
+
+// isDISGroup reports whether group is one of the DIS platform API groups, which
+// normalize projects via the DIS status shape instead of the typed Flux structs.
+func isDISGroup(group string) bool {
+	switch group {
+	case GroupDISStorage, GroupDISVault, GroupDISApplication, GroupDISApim:
+		return true
+	}
+	return false
+}
+
+// TargetKinds are the custom resource kinds the Console reads: the Flux
+// deployment machinery plus the DIS platform resources. The served API version
+// of each is resolved at runtime via the discovery RESTMapper, so the same
+// binary keeps working if Azure Flux bumps a version; kinds whose CRD is not
+// installed on a cluster are skipped by Sweep.
 var TargetKinds = []schema.GroupKind{
 	{Group: GroupKustomize, Kind: KindKustomization},
 	{Group: GroupHelm, Kind: KindHelmRelease},
 	{Group: GroupSource, Kind: KindOCIRepository},
 	{Group: GroupSource, Kind: KindHelmRepository},
 	{Group: GroupSource, Kind: KindHelmChart},
+	{Group: GroupDISStorage, Kind: KindDatabaseServer},
+	{Group: GroupDISStorage, Kind: KindDatabase},
+	{Group: GroupDISVault, Kind: KindVault},
+	{Group: GroupDISApplication, Kind: KindApplicationIdentity},
+	{Group: GroupDISApim, Kind: KindApi},
+	{Group: GroupDISApim, Kind: KindApiVersion},
+	{Group: GroupDISApim, Kind: KindBackend},
 }
 
 // discoveryTTL bounds how often Sweep refreshes the discovery cache. It is long
@@ -112,7 +150,8 @@ func restConfig(local bool) (*rest.Config, error) {
 // Sweep lists every instance of each target kind across all namespaces and
 // returns them as normalized resources. Kinds that are not installed are
 // skipped (reported as warnings) so the sweep still succeeds when only a
-// subset of Flux controllers is present. Any other discovery/list failure
+// subset of the Flux controllers and DIS operators is present. Any other
+// discovery/list failure
 // (RBAC, auth, apiserver outage) aborts the sweep with an error so the caller
 // keeps the previous snapshot instead of publishing a partial one.
 //
@@ -132,9 +171,10 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 	for _, gk := range TargetKinds {
 		mapping, err := c.mapper.RESTMapping(gk)
 		if err != nil {
-			// A kind that isn't installed is expected (optional source kinds);
-			// skip it. Any other mapping error is a discovery/access failure and
-			// must abort the sweep.
+			// A kind that isn't installed is expected (optional source kinds,
+			// DIS operators not deployed on this cluster); skip it. Any other
+			// mapping error is a discovery/access failure and must abort the
+			// sweep.
 			if apimeta.IsNoMatchError(err) {
 				warnings = append(warnings, fmt.Errorf("skip %s: not installed", gk))
 				continue

--- a/services/dis-console/internal/flux/normalize.go
+++ b/services/dis-console/internal/flux/normalize.go
@@ -3,6 +3,7 @@ package flux
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -22,19 +23,26 @@ const (
 	ReadyUnknown = "Unknown"
 )
 
-// Resource is a normalized view of a Flux custom resource's deployment status.
-// Only the fields needed for the summary and "what's broken" views are pulled
-// out; the full object is preserved verbatim in Raw so the detail endpoint can
-// expose anything else without a schema change.
+// Resource is a normalized view of a Flux or DIS custom resource's deployment
+// status. Only the fields needed for the summary and "what's broken" views are
+// pulled out; the full object is preserved verbatim in Raw so the detail
+// endpoint can expose anything else without a schema change.
 type Resource struct {
-	Kind               string          `json:"kind"`
-	APIVersion         string          `json:"apiVersion"`
-	Namespace          string          `json:"namespace"`
-	Name               string          `json:"name"`
-	Ready              string          `json:"ready"` // True | False | Unknown
-	Reason             string          `json:"reason,omitempty"`
-	Message            string          `json:"message,omitempty"`
-	Revision           string          `json:"revision,omitempty"`
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+	Ready      string `json:"ready"` // True | False | Unknown
+	Reason     string `json:"reason,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Revision   string `json:"revision,omitempty"`
+	// AzureResourceID is the ARM id of the Azure resource a DIS object
+	// provisions (the UI builds Portal links from it). Empty for Flux kinds and
+	// for DIS kinds whose operator has not published it yet.
+	AzureResourceID string `json:"azureResourceId,omitempty"`
+	// Parent names the same-namespace resource this one nests under in the UI
+	// (a Database under its DatabaseServer, an ApiVersion under its Api).
+	Parent             *ParentRef      `json:"parent,omitempty"`
 	Suspended          bool            `json:"suspended"`
 	Generation         int64           `json:"generation,omitempty"`
 	ObservedGeneration int64           `json:"observedGeneration,omitempty"`
@@ -45,6 +53,13 @@ type Resource struct {
 	// this changes, so unchanged objects don't churn the database every sweep.
 	// Internal bookkeeping, not part of the API payload.
 	ContentHash string `json:"-"`
+}
+
+// ParentRef identifies the resource another resource nests under. The JSON
+// shape (kind/name) is part of the UI contract.
+type ParentRef struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
 }
 
 // normalize projects an unstructured Flux object into a Resource. The fetch
@@ -84,8 +99,12 @@ func normalize(u *unstructured.Unstructured) (Resource, error) {
 
 // applyTypedStatus decodes the object into its typed Flux struct and fills the
 // projected status fields. The Ready condition is shared by every Flux kind
-// (meta.fluxcd.io semantics); the revision source differs per kind.
+// (meta.fluxcd.io semantics); the revision source differs per kind. DIS kinds
+// take their own projection path (see applyDISStatus).
 func (r *Resource) applyTypedStatus(u *unstructured.Unstructured) error {
+	if isDISGroup(u.GroupVersionKind().Group) {
+		return r.applyDISStatus(u)
+	}
 	switch u.GetKind() {
 	case KindKustomization:
 		var o kustomizev1.Kustomization
@@ -160,6 +179,95 @@ func artifactRevision(a *fluxmeta.Artifact) string {
 		return ""
 	}
 	return a.Revision
+}
+
+// disObject is the minimal projection of a DIS custom resource — just the
+// fields the console reads, decoded the same runtime-conversion way as the
+// Flux kinds. A local struct instead of the operator api packages keeps the
+// operator modules (and the ASO dependency tree they drag in) out of this
+// service. Fields a kind does not publish simply decode to their zero value.
+type disObject struct {
+	Spec struct {
+		// Server names the same-namespace DatabaseServer a Database runs on.
+		Server struct {
+			Name string `json:"name"`
+		} `json:"server"`
+	} `json:"spec"`
+	Status struct {
+		// ResourceID is the ARM id of the provisioned Azure resource. Vault
+		// publishes it today; DatabaseServer and ApplicationIdentity are
+		// expected to adopt the same field.
+		ResourceID string `json:"resourceId"`
+		// APIVersionSetID and BackendID are the ARM ids the APIM kinds publish.
+		APIVersionSetID string `json:"apiVersionSetID"`
+		BackendID       string `json:"backendID"`
+		// ProvisioningState is the only health signal the APIM kinds publish
+		// (they set no conditions): Succeeded, Failed, Updating, Deleting or
+		// Deleted.
+		ProvisioningState  string             `json:"provisioningState"`
+		ObservedGeneration int64              `json:"observedGeneration"`
+		Conditions         []metav1.Condition `json:"conditions"`
+	} `json:"status"`
+}
+
+// applyDISStatus fills the projected fields for a DIS custom resource. The
+// storage/vault/application operators publish a Ready condition with the same
+// semantics as Flux; the APIM kinds publish only status.provisioningState, so
+// health is mapped from that when no Ready condition exists.
+func (r *Resource) applyDISStatus(u *unstructured.Unstructured) error {
+	var o disObject
+	if err := fromUnstructured(u, &o); err != nil {
+		return err
+	}
+	st := o.Status
+
+	r.applyStatus(false, st.ObservedGeneration, st.Conditions, "")
+	if apimeta.FindStatusCondition(st.Conditions, fluxmeta.ReadyCondition) == nil && st.ProvisioningState != "" {
+		r.Ready = readyFromProvisioningState(st.ProvisioningState)
+		r.Reason = st.ProvisioningState
+	}
+
+	// The ARM id behind the Portal link, from whichever status field the
+	// kind's operator publishes. Database and ApiVersion have none.
+	switch u.GetKind() {
+	case KindVault, KindDatabaseServer, KindApplicationIdentity:
+		r.AzureResourceID = st.ResourceID
+	case KindApi:
+		r.AzureResourceID = st.APIVersionSetID
+	case KindBackend:
+		r.AzureResourceID = st.BackendID
+	}
+
+	switch u.GetKind() {
+	case KindDatabase:
+		if name := o.Spec.Server.Name; name != "" {
+			r.Parent = &ParentRef{Kind: KindDatabaseServer, Name: name}
+		}
+	case KindApiVersion:
+		// The Api controller creates ApiVersions with a controller owner
+		// reference; a user-created ApiVersion has none and stays top-level.
+		for _, ref := range u.GetOwnerReferences() {
+			if ref.Kind == KindApi && strings.HasPrefix(ref.APIVersion, GroupDISApim+"/") {
+				r.Parent = &ParentRef{Kind: KindApi, Name: ref.Name}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// readyFromProvisioningState maps the APIM operator's provisioningState onto
+// the console's ready values: Succeeded is healthy, Failed is broken, and the
+// transitional states (Updating, Deleting, Deleted) stay Unknown.
+func readyFromProvisioningState(state string) string {
+	switch state {
+	case "Succeeded":
+		return ReadyTrue
+	case "Failed":
+		return ReadyFalse
+	default:
+		return ReadyUnknown
+	}
 }
 
 // fromUnstructured decodes the (version-agnostically fetched) object into a

--- a/services/dis-console/internal/flux/normalize_test.go
+++ b/services/dis-console/internal/flux/normalize_test.go
@@ -106,6 +106,162 @@ func TestNormalizeHelmReleaseRevisionFromHistory(t *testing.T) {
 	}
 }
 
+func TestNormalizeVaultResourceIDAndReady(t *testing.T) {
+	armID := "/subscriptions/s1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv-app"
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "vault.dis.altinn.cloud/v1alpha1",
+		"kind":       "Vault",
+		"metadata":   map[string]any{"namespace": "team-a", "name": "kv-app"},
+		"status": map[string]any{
+			"resourceId": armID,
+			"conditions": []any{
+				map[string]any{
+					"type":               "Ready",
+					"status":             "True",
+					"reason":             "Provisioned",
+					"lastTransitionTime": "2026-06-02T10:00:00Z",
+				},
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.Ready != ReadyTrue || r.Reason != "Provisioned" {
+		t.Fatalf("unexpected ready condition: %+v", r)
+	}
+	if r.AzureResourceID != armID {
+		t.Fatalf("azureResourceId: got %q, want %q", r.AzureResourceID, armID)
+	}
+	if r.Parent != nil {
+		t.Fatalf("expected no parent for a Vault, got %+v", r.Parent)
+	}
+	if r.LastTransition == nil {
+		t.Fatalf("expected lastTransition parsed")
+	}
+}
+
+func TestNormalizeDatabaseParentFromServerRef(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "storage.dis.altinn.cloud/v1alpha1",
+		"kind":       "Database",
+		"metadata":   map[string]any{"namespace": "team-a", "name": "appdb"},
+		"spec": map[string]any{
+			"name":   "appdb",
+			"server": map[string]any{"name": "pg-main"},
+		},
+		"status": map[string]any{
+			"observedGeneration": int64(1),
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "False", "reason": "Provisioning"},
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.Ready != ReadyFalse || r.Reason != "Provisioning" {
+		t.Fatalf("unexpected ready condition: %+v", r)
+	}
+	if r.Parent == nil || r.Parent.Kind != KindDatabaseServer || r.Parent.Name != "pg-main" {
+		t.Fatalf("unexpected parent: %+v", r.Parent)
+	}
+	if r.AzureResourceID != "" {
+		t.Fatalf("expected no azureResourceId for a Database, got %q", r.AzureResourceID)
+	}
+}
+
+func TestNormalizeApiVersionParentFromOwnerReference(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apim.dis.altinn.cloud/v1alpha1",
+		"kind":       "ApiVersion",
+		"metadata": map[string]any{
+			"namespace": "team-a",
+			"name":      "orders-v1",
+			"ownerReferences": []any{
+				map[string]any{
+					"apiVersion": "apim.dis.altinn.cloud/v1alpha1",
+					"kind":       "Api",
+					"name":       "orders",
+					"uid":        "u1",
+					"controller": true,
+				},
+			},
+		},
+		"status": map[string]any{"provisioningState": "Succeeded"},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.Parent == nil || r.Parent.Kind != KindApi || r.Parent.Name != "orders" {
+		t.Fatalf("unexpected parent: %+v", r.Parent)
+	}
+	if r.Ready != ReadyTrue || r.Reason != "Succeeded" {
+		t.Fatalf("expected Succeeded mapped to ready True, got %+v", r)
+	}
+}
+
+func TestNormalizeApimProvisioningState(t *testing.T) {
+	cases := []struct {
+		name      string
+		kind      string
+		status    map[string]any
+		wantReady string
+		wantARM   string
+	}{
+		{
+			name:      "api succeeded with version set id",
+			kind:      "Api",
+			status:    map[string]any{"provisioningState": "Succeeded", "apiVersionSetID": "/subscriptions/s1/apiVersionSets/orders"},
+			wantReady: ReadyTrue,
+			wantARM:   "/subscriptions/s1/apiVersionSets/orders",
+		},
+		{
+			name:      "backend failed with backend id",
+			kind:      "Backend",
+			status:    map[string]any{"provisioningState": "Failed", "backendID": "/subscriptions/s1/backends/orders-be"},
+			wantReady: ReadyFalse,
+			wantARM:   "/subscriptions/s1/backends/orders-be",
+		},
+		{
+			name:      "transitional state stays unknown",
+			kind:      "Api",
+			status:    map[string]any{"provisioningState": "Updating"},
+			wantReady: ReadyUnknown,
+			wantARM:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "apim.dis.altinn.cloud/v1alpha1",
+				"kind":       tc.kind,
+				"metadata":   map[string]any{"namespace": "team-a", "name": "orders"},
+				"status":     tc.status,
+			}}
+			r, err := normalize(u)
+			if err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if r.Ready != tc.wantReady {
+				t.Fatalf("ready: got %q, want %q", r.Ready, tc.wantReady)
+			}
+			if state, _ := tc.status["provisioningState"].(string); r.Reason != state {
+				t.Fatalf("reason: got %q, want the provisioning state %q", r.Reason, state)
+			}
+			if r.AzureResourceID != tc.wantARM {
+				t.Fatalf("azureResourceId: got %q, want %q", r.AzureResourceID, tc.wantARM)
+			}
+		})
+	}
+}
+
 func TestNormalizeOCIRepositoryRevisionFromArtifact(t *testing.T) {
 	u := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "source.toolkit.fluxcd.io/v1",

--- a/services/dis-console/internal/store/schema.sql
+++ b/services/dis-console/internal/store/schema.sql
@@ -7,6 +7,9 @@ CREATE TABLE IF NOT EXISTS flux_resource (
     reason              text,
     message             text,
     revision            text,
+    azure_resource_id   text,
+    parent_kind         text,
+    parent_name         text,
     suspended           boolean     NOT NULL DEFAULT false,
     generation          bigint,
     observed_generation bigint,
@@ -20,6 +23,9 @@ CREATE TABLE IF NOT EXISTS flux_resource (
 );
 
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS content_hash text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS azure_resource_id text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_kind text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_name text;
 
 CREATE INDEX IF NOT EXISTS idx_flux_resource_ready ON flux_resource (lower(ready));
 CREATE INDEX IF NOT EXISTS idx_flux_resource_kind  ON flux_resource (lower(kind));

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -54,7 +54,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 // SchemaVersion is the version of this tenant database's schema, stamped into
 // the meta row at startup. The central console reads it to stay tolerant of
 // agents rolling out across the fleet at different times.
-const SchemaVersion = 1
+//
+// Version 2 added the DIS projection columns (azure_resource_id, parent_kind,
+// parent_name); ChangedSince selects per version so the server can still pull
+// version-1 tenants whose agents have not migrated yet.
+const SchemaVersion = 2
 
 // Meta is the single bookkeeping row each agent maintains in its tenant DB.
 type Meta struct {
@@ -108,6 +112,22 @@ type SyncStats struct {
 	Pruned   int64 // rows deleted because their object disappeared from the cluster
 }
 
+// parentCols splits an optional parent into its nullable column pair.
+func parentCols(p *flux.ParentRef) (kind, name *string) {
+	if p == nil {
+		return nil, nil
+	}
+	return &p.Kind, &p.Name
+}
+
+// parentRef rebuilds the optional parent from its nullable column pair.
+func parentRef(kind, name *string) *flux.ParentRef {
+	if kind == nil || name == nil {
+		return nil
+	}
+	return &flux.ParentRef{Kind: *kind, Name: *name}
+}
+
 // upsertStmt upserts one resource and, in the same statement, writes a history
 // event when the row is new or its ready/reason/revision changed. The `prev`
 // CTE reads the pre-upsert row (CTEs see the snapshot from the start of the
@@ -132,11 +152,13 @@ up AS (
         kind, api_version, namespace, name,
         ready, reason, message, revision, suspended,
         generation, observed_generation, last_transition, raw, content_hash,
+        azure_resource_id, parent_kind, parent_name,
         first_seen, last_seen, updated_at
     ) VALUES (
         $1, $2, $3, $4,
         $5, $6, $7, $8, $9,
         $10, $11, $12, $13, $14,
+        $15, $16, $17,
         now(), now(), now()
     )
     ON CONFLICT (kind, namespace, name) DO UPDATE SET
@@ -145,6 +167,9 @@ up AS (
         reason              = EXCLUDED.reason,
         message             = EXCLUDED.message,
         revision            = EXCLUDED.revision,
+        azure_resource_id   = EXCLUDED.azure_resource_id,
+        parent_kind         = EXCLUDED.parent_kind,
+        parent_name         = EXCLUDED.parent_name,
         suspended           = EXCLUDED.suspended,
         generation          = EXCLUDED.generation,
         observed_generation = EXCLUDED.observed_generation,
@@ -193,10 +218,12 @@ func (s *Store) Sync(ctx context.Context, resources []flux.Resource) (SyncStats,
 			if len(raw) == 0 {
 				raw = json.RawMessage("{}")
 			}
+			parentKind, parentName := parentCols(r.Parent)
 			batch.Queue(upsertStmt,
 				r.Kind, r.APIVersion, r.Namespace, r.Name,
 				r.Ready, r.Reason, r.Message, r.Revision, r.Suspended,
 				r.Generation, r.ObservedGeneration, r.LastTransition, []byte(raw), r.ContentHash,
+				r.AzureResourceID, parentKind, parentName,
 			)
 		}
 		br := tx.SendBatch(ctx, batch)
@@ -311,7 +338,8 @@ func (s *Store) Summary(ctx context.Context) ([]KindCount, error) {
 
 const listStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
-       suspended, generation, observed_generation, last_transition
+       suspended, generation, observed_generation, last_transition,
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name
 FROM flux_resource
 WHERE ($1 = '' OR lower(kind) = lower($1))
   AND ($2 = '' OR namespace = $2)
@@ -330,13 +358,16 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 	out := []flux.Resource{}
 	for rows.Next() {
 		var r flux.Resource
+		var parentKind, parentName *string
 		if err := rows.Scan(
 			&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 			&r.ObservedGeneration, &r.LastTransition,
+			&r.AzureResourceID, &parentKind, &parentName,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
+		r.Parent = parentRef(parentKind, parentName)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -344,7 +375,8 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 
 const getStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
-       suspended, generation, observed_generation, last_transition, raw
+       suspended, generation, observed_generation, last_transition, raw,
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name
 FROM flux_resource
 WHERE lower(kind) = lower($1) AND namespace = $2 AND name = $3`
 
@@ -368,10 +400,12 @@ type Event struct {
 func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Resource, []Event, error) {
 	var r flux.Resource
 	var raw []byte
+	var parentKind, parentName *string
 	err := s.pool.QueryRow(ctx, getStmt, kind, namespace, name).Scan(
 		&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 		&r.ObservedGeneration, &r.LastTransition, &raw,
+		&r.AzureResourceID, &parentKind, &parentName,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, ErrNotFound
@@ -380,6 +414,7 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 		return nil, nil, fmt.Errorf("get query: %w", err)
 	}
 	r.Raw = raw
+	r.Parent = parentRef(parentKind, parentName)
 
 	rows, err := s.pool.Query(ctx, historyStmt, r.Kind, r.Namespace, r.Name, historyLimit)
 	if err != nil {
@@ -419,6 +454,16 @@ type ChangedResource struct {
 
 const changedSinceStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
+       suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at,
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+FROM flux_resource
+WHERE updated_at > $1
+ORDER BY updated_at`
+
+// changedSinceStmtV1 is the pull for tenants still at schema version 1, whose
+// databases predate the DIS projection columns; those fields stay zero.
+const changedSinceStmtV1 = `
+SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at
 FROM flux_resource
 WHERE updated_at > $1
@@ -428,8 +473,17 @@ ORDER BY updated_at`
 // server's per-cluster high-water), including the raw payload. Because the
 // agent only advances updated_at on a real content change, an idle cluster
 // returns no rows and transfers no payloads.
-func (s *Store) ChangedSince(ctx context.Context, cursor time.Time) ([]ChangedResource, error) {
-	rows, err := s.pool.Query(ctx, changedSinceStmt, cursor)
+//
+// schemaVersion is the tenant's meta.schema_version: the SELECT is keyed on it
+// so the server can pull tenants whose agents have not migrated to the current
+// schema yet (the server rolls out first, then the agents).
+func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersion int) ([]ChangedResource, error) {
+	stmt := changedSinceStmt
+	withDIS := schemaVersion >= 2
+	if !withDIS {
+		stmt = changedSinceStmtV1
+	}
+	rows, err := s.pool.Query(ctx, stmt, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("changed-since query: %w", err)
 	}
@@ -440,17 +494,23 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time) ([]ChangedRe
 		var c ChangedResource
 		var raw []byte
 		var hash *string
-		if err := rows.Scan(
+		var parentKind, parentName *string
+		dest := []any{
 			&c.Kind, &c.APIVersion, &c.Namespace, &c.Name, &c.Ready, &c.Reason,
 			&c.Message, &c.Revision, &c.Suspended, &c.Generation,
 			&c.ObservedGeneration, &c.LastTransition, &raw, &hash, &c.UpdatedAt,
-		); err != nil {
+		}
+		if withDIS {
+			dest = append(dest, &c.AzureResourceID, &parentKind, &parentName)
+		}
+		if err := rows.Scan(dest...); err != nil {
 			return nil, fmt.Errorf("scan changed row: %w", err)
 		}
 		c.Raw = raw
 		if hash != nil {
 			c.ContentHash = *hash
 		}
+		c.Parent = parentRef(parentKind, parentName)
 		out = append(out, c)
 	}
 	return out, rows.Err()

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -262,6 +262,144 @@ func TestCentralReads(t *testing.T) {
 	}
 }
 
+// TestCentralDISFieldsEndToEnd walks a DIS resource through the full pipeline
+// against real PostgreSQL: agent Sync into the tenant database, server pull
+// (ChangedSince at the current schema) and Apply, then the fleet-API reads —
+// asserting the azure id and the parent pair survive every hop.
+func TestCentralDISFieldsEndToEnd(t *testing.T) {
+	cs, _ := newCentral(t)
+	ctx := context.Background()
+	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
+
+	tpool, err := dbauth.NewPoolForDatabase(ctx, uri, "dis_console_ttd_at23", nil)
+	if err != nil {
+		t.Fatalf("tenant pool: %v", err)
+	}
+	defer tpool.Close()
+	ts := store.New(tpool)
+	if err := ts.Migrate(ctx); err != nil {
+		t.Fatalf("migrate tenant: %v", err)
+	}
+	if err := ts.InitMeta(ctx, "e2e"); err != nil {
+		t.Fatalf("init tenant meta: %v", err)
+	}
+
+	armID := "/subscriptions/s1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv-app"
+	if _, err := ts.Sync(ctx, []flux.Resource{
+		{
+			Kind: "Vault", APIVersion: "vault.dis.altinn.cloud/v1alpha1",
+			Namespace: "team-a", Name: "kv-app",
+			Ready: flux.ReadyTrue, AzureResourceID: armID,
+			Raw: json.RawMessage(`{"kind":"Vault"}`), ContentHash: "vault-1",
+		},
+		{
+			Kind: "Database", APIVersion: "storage.dis.altinn.cloud/v1alpha1",
+			Namespace: "team-a", Name: "appdb",
+			Ready: flux.ReadyFalse, Parent: &flux.ParentRef{Kind: "DatabaseServer", Name: "pg-main"},
+			Raw: json.RawMessage(`{"kind":"Database"}`), ContentHash: "db-1",
+		},
+	}); err != nil {
+		t.Fatalf("tenant sync: %v", err)
+	}
+
+	pullAndApply(t, cs, ts, "ttd_at23")
+
+	vault, err := cs.Get(ctx, "ttd_at23", "Vault", "team-a", "kv-app")
+	if err != nil {
+		t.Fatalf("central get vault: %v", err)
+	}
+	if vault.AzureResourceID != armID || vault.Parent != nil {
+		t.Fatalf("vault lost its projection in central: %+v", vault)
+	}
+
+	dbs, err := cs.List(ctx, "ttd_at23", "Database", "", "")
+	if err != nil || len(dbs) != 1 {
+		t.Fatalf("central list databases: %+v err=%v", dbs, err)
+	}
+	if dbs[0].Parent == nil || dbs[0].Parent.Kind != "DatabaseServer" || dbs[0].Parent.Name != "pg-main" {
+		t.Fatalf("database lost its parent in central: %+v", dbs[0])
+	}
+	if dbs[0].AzureResourceID != "" {
+		t.Fatalf("expected empty azure id on the database, got %q", dbs[0].AzureResourceID)
+	}
+}
+
+// TestCentralSyncSchemaV1Tenant proves the rollout order the schema gate
+// promises: a server at schema 2 can still pull a tenant whose agent is at
+// schema 1 (its database lacks the DIS columns entirely). The tenant is built
+// by hand — migrate, then drop the v2 columns and stamp schema_version 1 —
+// because a v2 agent binary can no longer write the v1 shape.
+func TestCentralSyncSchemaV1Tenant(t *testing.T) {
+	cs, _ := newCentral(t)
+	ctx := context.Background()
+	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
+
+	tpool, err := dbauth.NewPoolForDatabase(ctx, uri, "dis_console_ttd_at23", nil)
+	if err != nil {
+		t.Fatalf("tenant pool: %v", err)
+	}
+	defer tpool.Close()
+	ts := store.New(tpool)
+	if err := ts.Migrate(ctx); err != nil {
+		t.Fatalf("migrate tenant: %v", err)
+	}
+	if _, err := tpool.Exec(ctx, `ALTER TABLE flux_resource
+		DROP COLUMN azure_resource_id, DROP COLUMN parent_kind, DROP COLUMN parent_name`); err != nil {
+		t.Fatalf("shape tenant as v1: %v", err)
+	}
+	if _, err := tpool.Exec(ctx,
+		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 1, 'v1-agent')"); err != nil {
+		t.Fatalf("stamp v1 meta: %v", err)
+	}
+	// The full column set a v1 agent writes: its upsert always passes the Go
+	// zero values, so reason/message/revision land as '' (never NULL).
+	if _, err := tpool.Exec(ctx, `INSERT INTO flux_resource
+		(kind, api_version, namespace, name, ready, reason, message, revision,
+		 suspended, generation, observed_generation, raw, content_hash)
+		VALUES ('Kustomization', 'kustomize.toolkit.fluxcd.io/v1', 'flux-system', 'apps', 'True', '', '', '',
+		 false, 0, 0, '{}', 'h1')`); err != nil {
+		t.Fatalf("insert v1 row: %v", err)
+	}
+
+	meta, err := ts.GetMeta(ctx)
+	if err != nil || meta.SchemaVersion != 1 {
+		t.Fatalf("tenant meta: %+v err=%v", meta, err)
+	}
+
+	// The version-keyed pull must succeed against the columnless table.
+	changed, err := ts.ChangedSince(ctx, time.Time{}, meta.SchemaVersion)
+	if err != nil {
+		t.Fatalf("changed-since on a v1 tenant: %v", err)
+	}
+	if len(changed) != 1 || changed[0].AzureResourceID != "" || changed[0].Parent != nil {
+		t.Fatalf("unexpected v1 pull: %+v", changed)
+	}
+	keys, err := ts.Keys(ctx)
+	if err != nil {
+		t.Fatalf("keys: %v", err)
+	}
+
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:       "ttd_at23",
+		Environment:   "at23",
+		Changed:       changed,
+		Keys:          keys,
+		Cursor:        changed[0].UpdatedAt,
+		SchemaVersion: meta.SchemaVersion,
+		AgentVersion:  meta.AgentVersion,
+	}); err != nil {
+		t.Fatalf("apply v1 tenant: %v", err)
+	}
+
+	rows, err := cs.List(ctx, "ttd_at23", "", "", "")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("central list after v1 sync: %+v err=%v", rows, err)
+	}
+	if rows[0].AzureResourceID != "" || rows[0].Parent != nil {
+		t.Fatalf("v1 row should have empty DIS fields, got %+v", rows[0])
+	}
+}
+
 // TestCentralEventCopyAndHistory drives the status-history pipeline against real
 // PostgreSQL: an agent writes status events into its tenant database, the server
 // copies them into the cluster-keyed central event log (incremental, id-cursored),
@@ -347,7 +485,7 @@ func pullAndApply(t *testing.T, cs *central.Store, ts *store.Store, cluster stri
 	if err != nil {
 		t.Fatalf("cursor: %v", err)
 	}
-	changed, err := ts.ChangedSince(ctx, cur)
+	changed, err := ts.ChangedSince(ctx, cur, store.SchemaVersion)
 	if err != nil {
 		t.Fatalf("changed-since: %v", err)
 	}

--- a/services/dis-console/test/e2e/store_test.go
+++ b/services/dis-console/test/e2e/store_test.go
@@ -174,6 +174,77 @@ func TestSyncUpsertHistoryAndPrune(t *testing.T) {
 	}
 }
 
+// TestSyncRoundTripsDISColumns checks the schema-v2 columns against real
+// PostgreSQL: a swept DIS resource's azure_resource_id and parent pair survive
+// Sync and come back out of List, Get and ChangedSince.
+func TestSyncRoundTripsDISColumns(t *testing.T) {
+	s, _ := newStore(t)
+	ctx := context.Background()
+
+	armID := "/subscriptions/s1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv-app"
+	vault := flux.Resource{
+		Kind:            "Vault",
+		APIVersion:      "vault.dis.altinn.cloud/v1alpha1",
+		Namespace:       "team-a",
+		Name:            "kv-app",
+		Ready:           flux.ReadyTrue,
+		Reason:          "Provisioned",
+		AzureResourceID: armID,
+		Raw:             json.RawMessage(`{"kind":"Vault"}`),
+		ContentHash:     "vault-1",
+	}
+	database := flux.Resource{
+		Kind:        "Database",
+		APIVersion:  "storage.dis.altinn.cloud/v1alpha1",
+		Namespace:   "team-a",
+		Name:        "appdb",
+		Ready:       flux.ReadyFalse,
+		Reason:      "Provisioning",
+		Parent:      &flux.ParentRef{Kind: "DatabaseServer", Name: "pg-main"},
+		Raw:         json.RawMessage(`{"kind":"Database"}`),
+		ContentHash: "db-1",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{vault, database}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	rows, err := s.List(ctx, "Vault", "", "")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("list vaults: %+v err=%v", rows, err)
+	}
+	if rows[0].AzureResourceID != armID || rows[0].Parent != nil {
+		t.Fatalf("unexpected vault projection: %+v", rows[0])
+	}
+
+	got, _, err := s.Get(ctx, "Database", "team-a", "appdb")
+	if err != nil {
+		t.Fatalf("get database: %v", err)
+	}
+	if got.Parent == nil || got.Parent.Kind != "DatabaseServer" || got.Parent.Name != "pg-main" {
+		t.Fatalf("unexpected database parent: %+v", got.Parent)
+	}
+	if got.AzureResourceID != "" {
+		t.Fatalf("expected empty azure id on the database, got %q", got.AzureResourceID)
+	}
+
+	changed, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion)
+	if err != nil || len(changed) != 2 {
+		t.Fatalf("changed-since: %d rows err=%v", len(changed), err)
+	}
+	for _, c := range changed {
+		switch c.Kind {
+		case "Vault":
+			if c.AzureResourceID != armID {
+				t.Fatalf("changed vault lost azure id: %+v", c.Resource)
+			}
+		case "Database":
+			if c.Parent == nil || c.Parent.Name != "pg-main" {
+				t.Fatalf("changed database lost parent: %+v", c.Resource)
+			}
+		}
+	}
+}
+
 // TestSyncContentHashSkipsUnchangedRewrite asserts the write-hygiene contract:
 // an unchanged sweep leaves updated_at alone (no row/raw rewrite), while a
 // content change advances it. The central sync loop pulls on updated_at, so


### PR DESCRIPTION
## Problem

The fleet API sweeps only Flux CRs, but the console UI's DIS resources view needs two live fields: `azureResourceId` (Azure Portal links) and `parent {kind,name}` (nest Databases under their DatabaseServer, ApiVersions under their Api). The UI already models both and runs on mock.

## Fix

- **Sweep**: add the DIS kinds to `TargetKinds` — `storage` (DatabaseServer, Database), `vault` (Vault), `application` (ApplicationIdentity), `apim` (Api, ApiVersion, Backend). A cluster without a CRD skips that kind (existing `NoKindMatch` tolerance).
- **Projection**: DIS objects decode into a minimal local struct (same `FromUnstructured` approach as the Flux kinds) so the operator modules and their ASO dependency tree stay out of this service. `azureResourceId` ← `status.resourceId` / `status.apiVersionSetID` / `status.backendID`; `parent` ← `spec.server.name` (Database) / controller ownerReference (ApiVersion). The APIM kinds publish no conditions, so ready maps from `status.provisioningState` (Succeeded→True, Failed→False, transitional→Unknown) when no Ready condition exists.
- **Persistence**: nullable `azure_resource_id`/`parent_kind`/`parent_name` columns threaded agent store → central → `/api/resources` + detail endpoint. Content-hash change detection already covers them (they derive from spec/status).
- **RBAC**: tenant-agent ClusterRole gains get/list/watch on the four DIS groups.

Only Vault publishes `status.resourceId` today; DatabaseServer/ApplicationIdentity adopt it in pending operator work and the console picks it up with no further changes.

## Rollout

Tenant `SchemaVersion` bumps 1→2; the server's tenant pull is version-keyed and accepts schema {1,2}, so **deploy the server first, then the agents** — a lagging server never rejects an upgraded tenant, and an upgraded server still syncs v1 tenants (new fields empty).

## Verification

- `make run-checks-ci-cache` — fmt, vet, unit tests, golangci-lint all green (new normalize tests: Vault ARM id, Database parent, ApiVersion ownerRef parent, provisioningState mapping).
- `make test-e2e-kind-ci` — all 10 tests green on Kind postgres:16, including new coverage: v2 columns round-trip tenant→central end-to-end, and a simulated schema-v1 tenant (columns dropped, meta stamped 1) syncs cleanly through the version-keyed pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)