### PR TITLE
chore(dis-console): roll out v1.4.0 server to admin clusters

### DIFF
--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
           args:
             - server
           ports:


### PR DESCRIPTION
Rolls the central dis-console server (admin clusters) to v1.4.0.

#3785 bumped the tenant schema to v2; the v1.4.0 server syncs both v1 and v2 tenants, so it must be live before any agent moves to v1.4.0. This PR bumps only the server — agents follow in a separate PR.

Rollout: merge, dispatch "Publish DIS Admin Syncroot Artifacts" (test), verify tenants keep syncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)