### PR TITLE
chore(dis-console): roll out v1.4.0 agents + DIS sweep RBAC

### DIFF
--- a/deploy/admin/base/dis-console-agent-deployment.yaml
+++ b/deploy/admin/base/dis-console-agent-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
           args:
             - agent
           ports:

--- a/deploy/admin/base/dis-console-agent-rbac.yaml
+++ b/deploy/admin/base/dis-console-agent-rbac.yaml
@@ -29,6 +29,41 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - storage.dis.altinn.cloud
+    resources:
+      - databaseservers
+      - databases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - vault.dis.altinn.cloud
+    resources:
+      - vaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - application.dis.altinn.cloud
+    resources:
+      - applicationidentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apim.dis.altinn.cloud
+    resources:
+      - apis
+      - apiversions
+      - backends
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
           args:
             - agent
           ports:

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
           args:
             - agent
           ports:

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.3.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
           args:
             - agent
           ports:


### PR DESCRIPTION
⚠️ **Do not merge until the v1.4.0 server (#3790) is deployed** — v1.4.0 agents stamp tenant schema v2, which the v1.3.1 server refuses to sync.

Rolls all dis-console agents to v1.4.0 (admin, at22/at23 inline, tenant app template) so they sweep DIS resources and project `azureResourceId`/`parent`.

Also adds the four DIS API groups to the **admin agent** ClusterRole — #3785 only updated the tenant-app-template copy. The sweep aborts on a Forbidden list (only missing CRDs are tolerated), and admin clusters have DIS CRDs installed, so without this the v1.4.0 admin agent stops reporting entirely.

Rollout (after #3790 is live): dispatch "Publish DIS Admin Syncroot Artifacts" (test) + "Publish DIS Syncroot Artifact" (at22, at23). Before the TE dispatch, confirm the TE clusters' `dis-console-flux-reader` ClusterRole carries the DIS groups (that RBAC is not delivered from `deploy/common`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)