### PR TITLE
feat(dis-console): project the owning Kustomization (appliedBy) into normalized resources

### DIFF
--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -40,6 +40,10 @@ sweep, so mixed fleets keep working.
 For each object it extracts a small normalized shape (`ready`/`reason`/
 `message`/`revision`/`suspended`/`generation`/`observedGeneration`) from the
 `Ready` condition and keeps the full object under `raw` for the detail endpoint.
+Every object also projects `appliedBy` (`{name,namespace}`) from the
+`kustomize.toolkit.fluxcd.io/{name,namespace}` labels — the Kustomization that
+applied it — so the list endpoint can group child HelmReleases under their
+parent app without fetching detail; roots and Arc-managed objects have none.
 The DIS kinds add two fields the UI builds on: `azureResourceId` (the ARM id of
 the provisioned Azure resource, for Portal links — from `status.resourceId`, or
 the APIM ids `status.apiVersionSetID`/`status.backendID`) and `parent`

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -113,31 +113,35 @@ INSERT INTO flux_resource (
     ready, reason, message, revision, suspended,
     generation, observed_generation, last_transition, raw, content_hash,
     azure_resource_id, parent_kind, parent_name,
+    applied_by_name, applied_by_namespace,
     updated_at, synced_at
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15,
     $16, $17, $18,
-    $19, now()
+    $19, $20,
+    $21, now()
 )
 ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
-    api_version         = EXCLUDED.api_version,
-    ready               = EXCLUDED.ready,
-    reason              = EXCLUDED.reason,
-    message             = EXCLUDED.message,
-    revision            = EXCLUDED.revision,
-    azure_resource_id   = EXCLUDED.azure_resource_id,
-    parent_kind         = EXCLUDED.parent_kind,
-    parent_name         = EXCLUDED.parent_name,
-    suspended           = EXCLUDED.suspended,
-    generation          = EXCLUDED.generation,
-    observed_generation = EXCLUDED.observed_generation,
-    last_transition     = EXCLUDED.last_transition,
-    raw                 = EXCLUDED.raw,
-    content_hash        = EXCLUDED.content_hash,
-    updated_at          = EXCLUDED.updated_at,
-    synced_at           = now()`
+    api_version          = EXCLUDED.api_version,
+    ready                = EXCLUDED.ready,
+    reason               = EXCLUDED.reason,
+    message              = EXCLUDED.message,
+    revision             = EXCLUDED.revision,
+    azure_resource_id    = EXCLUDED.azure_resource_id,
+    parent_kind          = EXCLUDED.parent_kind,
+    parent_name          = EXCLUDED.parent_name,
+    applied_by_name      = EXCLUDED.applied_by_name,
+    applied_by_namespace = EXCLUDED.applied_by_namespace,
+    suspended            = EXCLUDED.suspended,
+    generation           = EXCLUDED.generation,
+    observed_generation  = EXCLUDED.observed_generation,
+    last_transition      = EXCLUDED.last_transition,
+    raw                  = EXCLUDED.raw,
+    content_hash         = EXCLUDED.content_hash,
+    updated_at           = EXCLUDED.updated_at,
+    synced_at            = now()`
 
 // pruneStmt deletes the cluster's mirrored rows whose identity is not in the
 // tenant's current key set (passed as parallel arrays). An empty key set drops
@@ -201,11 +205,13 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 				raw = json.RawMessage("{}")
 			}
 			parentKind, parentName := parentCols(c.Parent)
+			appliedByName, appliedByNamespace := appliedByCols(c.AppliedBy)
 			batch.Queue(upsertStmt,
 				st.Cluster, c.Kind, c.APIVersion, c.Namespace, c.Name,
 				c.Ready, c.Reason, c.Message, c.Revision, c.Suspended,
 				c.Generation, c.ObservedGeneration, c.LastTransition, []byte(raw), c.ContentHash,
 				c.AzureResourceID, parentKind, parentName,
+				appliedByName, appliedByNamespace,
 				c.UpdatedAt,
 			)
 		}
@@ -300,6 +306,22 @@ func parentRef(kind, name *string) *flux.ParentRef {
 		return nil
 	}
 	return &flux.ParentRef{Kind: *kind, Name: *name}
+}
+
+// appliedByCols splits an optional applied-by into its nullable column pair.
+func appliedByCols(a *flux.AppliedBy) (name, namespace *string) {
+	if a == nil {
+		return nil, nil
+	}
+	return &a.Name, &a.Namespace
+}
+
+// appliedByRef rebuilds the optional applied-by from its nullable column pair.
+func appliedByRef(name, namespace *string) *flux.AppliedBy {
+	if name == nil || namespace == nil {
+		return nil
+	}
+	return &flux.AppliedBy{Name: *name, Namespace: *namespace}
 }
 
 // clusterID strips the tenant-database prefix to get the cluster identifier
@@ -444,7 +466,8 @@ func (s *Store) Summary(ctx context.Context, cluster string) ([]store.KindCount,
 const listStmt = `
 SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition,
-       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name,
+       applied_by_name, applied_by_namespace
 FROM flux_resource
 WHERE ($1 = '' OR cluster = $1)
   AND ($2 = '' OR lower(kind) = lower($2))
@@ -454,7 +477,8 @@ ORDER BY cluster, kind, namespace, name`
 
 // List returns matching resources (without the raw payload) across the fleet,
 // or for one cluster when cluster is non-empty. An empty kind/namespace/ready
-// means "any".
+// means "any". appliedBy rides in the list payload so the UI can group child
+// HelmReleases under their parent Kustomization without fetching detail.
 func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string) ([]Resource, error) {
 	rows, err := s.pool.Query(ctx, listStmt, cluster, kind, namespace, ready)
 	if err != nil {
@@ -466,15 +490,18 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 	for rows.Next() {
 		var r Resource
 		var parentKind, parentName *string
+		var appliedByName, appliedByNamespace *string
 		if err := rows.Scan(
 			&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 			&r.ObservedGeneration, &r.LastTransition,
 			&r.AzureResourceID, &parentKind, &parentName,
+			&appliedByName, &appliedByNamespace,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		r.Parent = parentRef(parentKind, parentName)
+		r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -483,7 +510,8 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 const getStmt = `
 SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw,
-       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name,
+       applied_by_name, applied_by_namespace
 FROM flux_resource
 WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
 
@@ -493,11 +521,13 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 	var r Resource
 	var raw []byte
 	var parentKind, parentName *string
+	var appliedByName, appliedByNamespace *string
 	err := s.pool.QueryRow(ctx, getStmt, cluster, kind, namespace, name).Scan(
 		&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 		&r.ObservedGeneration, &r.LastTransition, &raw,
 		&r.AzureResourceID, &parentKind, &parentName,
+		&appliedByName, &appliedByNamespace,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -507,6 +537,7 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 	}
 	r.Raw = raw
 	r.Parent = parentRef(parentKind, parentName)
+	r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 	return &r, nil
 }
 

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -110,8 +110,8 @@ func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
 	if err != nil {
 		return err
 	}
-	// The pull is keyed on the tenant's schema version: a version-1 tenant
-	// (agent not yet migrated) lacks the DIS projection columns, so selecting
+	// The pull is keyed on the tenant's schema version: a version-2 tenant
+	// (agent not yet migrated) lacks the applied-by columns, so selecting
 	// them would fail the cluster's sync until its agent rolls out.
 	changed, err := ts.ChangedSince(ctx, cursor, meta.SchemaVersion)
 	if err != nil {

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -1,24 +1,26 @@
 CREATE TABLE IF NOT EXISTS flux_resource (
-    cluster             text        NOT NULL,
-    kind                text        NOT NULL,
-    api_version         text        NOT NULL,
-    namespace           text        NOT NULL,
-    name                text        NOT NULL,
-    ready               text        NOT NULL DEFAULT 'Unknown',
-    reason              text,
-    message             text,
-    revision            text,
-    azure_resource_id   text,
-    parent_kind         text,
-    parent_name         text,
-    suspended           boolean     NOT NULL DEFAULT false,
-    generation          bigint,
-    observed_generation bigint,
-    last_transition     timestamptz,
-    raw                 jsonb       NOT NULL,
-    content_hash        text,
-    updated_at          timestamptz NOT NULL,
-    synced_at           timestamptz NOT NULL DEFAULT now(),
+    cluster              text        NOT NULL,
+    kind                 text        NOT NULL,
+    api_version          text        NOT NULL,
+    namespace            text        NOT NULL,
+    name                 text        NOT NULL,
+    ready                text        NOT NULL DEFAULT 'Unknown',
+    reason               text,
+    message              text,
+    revision             text,
+    azure_resource_id    text,
+    parent_kind          text,
+    parent_name          text,
+    applied_by_name      text,
+    applied_by_namespace text,
+    suspended            boolean     NOT NULL DEFAULT false,
+    generation           bigint,
+    observed_generation  bigint,
+    last_transition      timestamptz,
+    raw                  jsonb       NOT NULL,
+    content_hash         text,
+    updated_at           timestamptz NOT NULL,
+    synced_at            timestamptz NOT NULL DEFAULT now(),
     PRIMARY KEY (cluster, kind, namespace, name)
 );
 
@@ -59,3 +61,5 @@ ALTER TABLE cluster_report ADD COLUMN IF NOT EXISTS event_cursor bigint NOT NULL
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS azure_resource_id text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_kind text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_name text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_name text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_namespace text;

--- a/services/dis-console/internal/flux/normalize.go
+++ b/services/dis-console/internal/flux/normalize.go
@@ -42,7 +42,13 @@ type Resource struct {
 	AzureResourceID string `json:"azureResourceId,omitempty"`
 	// Parent names the same-namespace resource this one nests under in the UI
 	// (a Database under its DatabaseServer, an ApiVersion under its Api).
-	Parent             *ParentRef      `json:"parent,omitempty"`
+	Parent *ParentRef `json:"parent,omitempty"`
+	// AppliedBy is the Kustomization that applied this object, projected from
+	// the kustomize.toolkit.fluxcd.io/{name,namespace} labels the kustomize
+	// controller stamps on everything it applies, so the list endpoint (which
+	// omits Raw) can group child resources under their parent app. Empty for
+	// roots and Arc-managed objects, which carry no such labels.
+	AppliedBy          *AppliedBy      `json:"appliedBy,omitempty"`
 	Suspended          bool            `json:"suspended"`
 	Generation         int64           `json:"generation,omitempty"`
 	ObservedGeneration int64           `json:"observedGeneration,omitempty"`
@@ -62,6 +68,21 @@ type ParentRef struct {
 	Name string `json:"name"`
 }
 
+// Labels the kustomize controller stamps on every object it applies, naming
+// the owning Kustomization. HelmReleases applied by a Kustomization carry
+// them too, which is how the UI groups child HelmReleases under their app.
+const (
+	LabelAppliedByName      = "kustomize.toolkit.fluxcd.io/name"
+	LabelAppliedByNamespace = "kustomize.toolkit.fluxcd.io/namespace"
+)
+
+// AppliedBy identifies the Kustomization that applied a resource. The JSON
+// shape (name/namespace) is part of the UI contract.
+type AppliedBy struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
 // normalize projects an unstructured Flux object into a Resource. The fetch
 // stays dynamic (discovery-resolved, version-agnostic) and the full object is
 // preserved for Raw; only the projected status fields are decoded into the
@@ -74,6 +95,7 @@ func normalize(u *unstructured.Unstructured) (Resource, error) {
 		Name:       u.GetName(),
 		Generation: u.GetGeneration(),
 		Ready:      ReadyUnknown,
+		AppliedBy:  appliedByFrom(u.GetLabels()),
 	}
 
 	if err := r.applyTypedStatus(u); err != nil {
@@ -179,6 +201,17 @@ func artifactRevision(a *fluxmeta.Artifact) string {
 		return ""
 	}
 	return a.Revision
+}
+
+// appliedByFrom projects the kustomize-controller ownership labels into an
+// AppliedBy. Returns nil when the labels are absent (roots, Arc-managed
+// objects) so the JSON field is omitted.
+func appliedByFrom(labels map[string]string) *AppliedBy {
+	name, ns := labels[LabelAppliedByName], labels[LabelAppliedByNamespace]
+	if name == "" && ns == "" {
+		return nil
+	}
+	return &AppliedBy{Name: name, Namespace: ns}
 }
 
 // disObject is the minimal projection of a DIS custom resource — just the

--- a/services/dis-console/internal/flux/normalize_test.go
+++ b/services/dis-console/internal/flux/normalize_test.go
@@ -262,6 +262,53 @@ func TestNormalizeApimProvisioningState(t *testing.T) {
 	}
 }
 
+// HelmReleases applied by a Kustomization carry the kustomize-controller
+// ownership labels; the projected AppliedBy is what lets the list endpoint
+// group child HelmReleases under their parent app (raw is detail-only).
+func TestNormalizeHelmReleaseAppliedByFromLabels(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"namespace": "grafana",
+			"name":      "grafana-operator",
+			"labels": map[string]any{
+				"kustomize.toolkit.fluxcd.io/name":      "grafana-operator-grafana-operator",
+				"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.AppliedBy == nil {
+		t.Fatalf("expected AppliedBy populated from labels")
+	}
+	if r.AppliedBy.Name != "grafana-operator-grafana-operator" || r.AppliedBy.Namespace != "flux-system" {
+		t.Fatalf("unexpected AppliedBy: %+v", r.AppliedBy)
+	}
+}
+
+// A root Kustomization (or an Arc-managed object) carries no kustomize-controller
+// labels; AppliedBy must stay nil so the JSON omits the field.
+func TestNormalizeAppliedByEmptyWithoutLabels(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"namespace": "flux-system", "name": "root"},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.AppliedBy != nil {
+		t.Fatalf("expected nil AppliedBy without labels, got %+v", r.AppliedBy)
+	}
+}
+
 func TestNormalizeOCIRepositoryRevisionFromArtifact(t *testing.T) {
 	u := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "source.toolkit.fluxcd.io/v1",

--- a/services/dis-console/internal/store/schema.sql
+++ b/services/dis-console/internal/store/schema.sql
@@ -1,24 +1,26 @@
 CREATE TABLE IF NOT EXISTS flux_resource (
-    kind                text        NOT NULL,
-    api_version         text        NOT NULL,
-    namespace           text        NOT NULL,
-    name                text        NOT NULL,
-    ready               text        NOT NULL DEFAULT 'Unknown',
-    reason              text,
-    message             text,
-    revision            text,
-    azure_resource_id   text,
-    parent_kind         text,
-    parent_name         text,
-    suspended           boolean     NOT NULL DEFAULT false,
-    generation          bigint,
-    observed_generation bigint,
-    last_transition     timestamptz,
-    raw                 jsonb       NOT NULL,
-    content_hash        text,
-    first_seen          timestamptz NOT NULL DEFAULT now(),
-    last_seen           timestamptz NOT NULL DEFAULT now(),
-    updated_at          timestamptz NOT NULL DEFAULT now(),
+    kind                 text        NOT NULL,
+    api_version          text        NOT NULL,
+    namespace            text        NOT NULL,
+    name                 text        NOT NULL,
+    ready                text        NOT NULL DEFAULT 'Unknown',
+    reason               text,
+    message              text,
+    revision             text,
+    azure_resource_id    text,
+    parent_kind          text,
+    parent_name          text,
+    applied_by_name      text,
+    applied_by_namespace text,
+    suspended            boolean     NOT NULL DEFAULT false,
+    generation           bigint,
+    observed_generation  bigint,
+    last_transition      timestamptz,
+    raw                  jsonb       NOT NULL,
+    content_hash         text,
+    first_seen           timestamptz NOT NULL DEFAULT now(),
+    last_seen            timestamptz NOT NULL DEFAULT now(),
+    updated_at           timestamptz NOT NULL DEFAULT now(),
     PRIMARY KEY (kind, namespace, name)
 );
 
@@ -26,6 +28,8 @@ ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS content_hash text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS azure_resource_id text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_kind text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_name text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_name text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_namespace text;
 
 CREATE INDEX IF NOT EXISTS idx_flux_resource_ready ON flux_resource (lower(ready));
 CREATE INDEX IF NOT EXISTS idx_flux_resource_kind  ON flux_resource (lower(kind));

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -56,9 +56,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 // agents rolling out across the fleet at different times.
 //
 // Version 2 added the DIS projection columns (azure_resource_id, parent_kind,
-// parent_name); ChangedSince selects per version so the server can still pull
-// version-1 tenants whose agents have not migrated yet.
-const SchemaVersion = 2
+// parent_name). Version 3 added the applied-by columns (applied_by_name,
+// applied_by_namespace — the owning Kustomization). ChangedSince selects per
+// version so the server can still pull version-2 tenants whose agents have not
+// migrated yet; version 1 fell out of the supported window (schemaSupported
+// covers the current version and the previous one).
+const SchemaVersion = 3
 
 // Meta is the single bookkeeping row each agent maintains in its tenant DB.
 type Meta struct {
@@ -128,6 +131,22 @@ func parentRef(kind, name *string) *flux.ParentRef {
 	return &flux.ParentRef{Kind: *kind, Name: *name}
 }
 
+// appliedByCols splits an optional applied-by into its nullable column pair.
+func appliedByCols(a *flux.AppliedBy) (name, namespace *string) {
+	if a == nil {
+		return nil, nil
+	}
+	return &a.Name, &a.Namespace
+}
+
+// appliedByRef rebuilds the optional applied-by from its nullable column pair.
+func appliedByRef(name, namespace *string) *flux.AppliedBy {
+	if name == nil || namespace == nil {
+		return nil
+	}
+	return &flux.AppliedBy{Name: *name, Namespace: *namespace}
+}
+
 // upsertStmt upserts one resource and, in the same statement, writes a history
 // event when the row is new or its ready/reason/revision changed. The `prev`
 // CTE reads the pre-upsert row (CTEs see the snapshot from the start of the
@@ -153,33 +172,37 @@ up AS (
         ready, reason, message, revision, suspended,
         generation, observed_generation, last_transition, raw, content_hash,
         azure_resource_id, parent_kind, parent_name,
+        applied_by_name, applied_by_namespace,
         first_seen, last_seen, updated_at
     ) VALUES (
         $1, $2, $3, $4,
         $5, $6, $7, $8, $9,
         $10, $11, $12, $13, $14,
         $15, $16, $17,
+        $18, $19,
         now(), now(), now()
     )
     ON CONFLICT (kind, namespace, name) DO UPDATE SET
-        api_version         = EXCLUDED.api_version,
-        ready               = EXCLUDED.ready,
-        reason              = EXCLUDED.reason,
-        message             = EXCLUDED.message,
-        revision            = EXCLUDED.revision,
-        azure_resource_id   = EXCLUDED.azure_resource_id,
-        parent_kind         = EXCLUDED.parent_kind,
-        parent_name         = EXCLUDED.parent_name,
-        suspended           = EXCLUDED.suspended,
-        generation          = EXCLUDED.generation,
-        observed_generation = EXCLUDED.observed_generation,
-        last_transition     = EXCLUDED.last_transition,
-        raw                 = CASE
+        api_version          = EXCLUDED.api_version,
+        ready                = EXCLUDED.ready,
+        reason               = EXCLUDED.reason,
+        message              = EXCLUDED.message,
+        revision             = EXCLUDED.revision,
+        azure_resource_id    = EXCLUDED.azure_resource_id,
+        parent_kind          = EXCLUDED.parent_kind,
+        parent_name          = EXCLUDED.parent_name,
+        applied_by_name      = EXCLUDED.applied_by_name,
+        applied_by_namespace = EXCLUDED.applied_by_namespace,
+        suspended            = EXCLUDED.suspended,
+        generation           = EXCLUDED.generation,
+        observed_generation  = EXCLUDED.observed_generation,
+        last_transition      = EXCLUDED.last_transition,
+        raw                  = CASE
             WHEN r.content_hash IS DISTINCT FROM EXCLUDED.content_hash
             THEN EXCLUDED.raw ELSE r.raw END,
-        content_hash        = EXCLUDED.content_hash,
-        last_seen           = now(),
-        updated_at          = CASE
+        content_hash         = EXCLUDED.content_hash,
+        last_seen            = now(),
+        updated_at           = CASE
             WHEN r.content_hash IS DISTINCT FROM EXCLUDED.content_hash
             THEN now() ELSE r.updated_at END
     RETURNING ready, reason, message, revision
@@ -219,11 +242,13 @@ func (s *Store) Sync(ctx context.Context, resources []flux.Resource) (SyncStats,
 				raw = json.RawMessage("{}")
 			}
 			parentKind, parentName := parentCols(r.Parent)
+			appliedByName, appliedByNamespace := appliedByCols(r.AppliedBy)
 			batch.Queue(upsertStmt,
 				r.Kind, r.APIVersion, r.Namespace, r.Name,
 				r.Ready, r.Reason, r.Message, r.Revision, r.Suspended,
 				r.Generation, r.ObservedGeneration, r.LastTransition, []byte(raw), r.ContentHash,
 				r.AzureResourceID, parentKind, parentName,
+				appliedByName, appliedByNamespace,
 			)
 		}
 		br := tx.SendBatch(ctx, batch)
@@ -339,7 +364,8 @@ func (s *Store) Summary(ctx context.Context) ([]KindCount, error) {
 const listStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition,
-       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name,
+       applied_by_name, applied_by_namespace
 FROM flux_resource
 WHERE ($1 = '' OR lower(kind) = lower($1))
   AND ($2 = '' OR namespace = $2)
@@ -359,15 +385,18 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 	for rows.Next() {
 		var r flux.Resource
 		var parentKind, parentName *string
+		var appliedByName, appliedByNamespace *string
 		if err := rows.Scan(
 			&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 			&r.ObservedGeneration, &r.LastTransition,
 			&r.AzureResourceID, &parentKind, &parentName,
+			&appliedByName, &appliedByNamespace,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		r.Parent = parentRef(parentKind, parentName)
+		r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -376,7 +405,8 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 const getStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw,
-       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name,
+       applied_by_name, applied_by_namespace
 FROM flux_resource
 WHERE lower(kind) = lower($1) AND namespace = $2 AND name = $3`
 
@@ -401,11 +431,13 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 	var r flux.Resource
 	var raw []byte
 	var parentKind, parentName *string
+	var appliedByName, appliedByNamespace *string
 	err := s.pool.QueryRow(ctx, getStmt, kind, namespace, name).Scan(
 		&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 		&r.ObservedGeneration, &r.LastTransition, &raw,
 		&r.AzureResourceID, &parentKind, &parentName,
+		&appliedByName, &appliedByNamespace,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, ErrNotFound
@@ -415,6 +447,7 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 	}
 	r.Raw = raw
 	r.Parent = parentRef(parentKind, parentName)
+	r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 
 	rows, err := s.pool.Query(ctx, historyStmt, r.Kind, r.Namespace, r.Name, historyLimit)
 	if err != nil {
@@ -455,16 +488,18 @@ type ChangedResource struct {
 const changedSinceStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at,
-       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name,
+       applied_by_name, applied_by_namespace
 FROM flux_resource
 WHERE updated_at > $1
 ORDER BY updated_at`
 
-// changedSinceStmtV1 is the pull for tenants still at schema version 1, whose
-// databases predate the DIS projection columns; those fields stay zero.
-const changedSinceStmtV1 = `
+// changedSinceStmtV2 is the pull for tenants still at schema version 2, whose
+// databases predate the applied-by columns; that field stays nil.
+const changedSinceStmtV2 = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
-       suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at
+       suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at,
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name
 FROM flux_resource
 WHERE updated_at > $1
 ORDER BY updated_at`
@@ -476,12 +511,13 @@ ORDER BY updated_at`
 //
 // schemaVersion is the tenant's meta.schema_version: the SELECT is keyed on it
 // so the server can pull tenants whose agents have not migrated to the current
-// schema yet (the server rolls out first, then the agents).
+// schema yet (the server rolls out first, then the agents). Versions outside
+// the schemaSupported window are the caller's job to skip.
 func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersion int) ([]ChangedResource, error) {
 	stmt := changedSinceStmt
-	withDIS := schemaVersion >= 2
-	if !withDIS {
-		stmt = changedSinceStmtV1
+	withAppliedBy := schemaVersion >= 3
+	if !withAppliedBy {
+		stmt = changedSinceStmtV2
 	}
 	rows, err := s.pool.Query(ctx, stmt, cursor)
 	if err != nil {
@@ -495,13 +531,15 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 		var raw []byte
 		var hash *string
 		var parentKind, parentName *string
+		var appliedByName, appliedByNamespace *string
 		dest := []any{
 			&c.Kind, &c.APIVersion, &c.Namespace, &c.Name, &c.Ready, &c.Reason,
 			&c.Message, &c.Revision, &c.Suspended, &c.Generation,
 			&c.ObservedGeneration, &c.LastTransition, &raw, &hash, &c.UpdatedAt,
+			&c.AzureResourceID, &parentKind, &parentName,
 		}
-		if withDIS {
-			dest = append(dest, &c.AzureResourceID, &parentKind, &parentName)
+		if withAppliedBy {
+			dest = append(dest, &appliedByName, &appliedByNamespace)
 		}
 		if err := rows.Scan(dest...); err != nil {
 			return nil, fmt.Errorf("scan changed row: %w", err)
@@ -511,6 +549,7 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 			c.ContentHash = *hash
 		}
 		c.Parent = parentRef(parentKind, parentName)
+		c.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 		out = append(out, c)
 	}
 	return out, rows.Err()

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -262,6 +262,67 @@ func TestCentralReads(t *testing.T) {
 	}
 }
 
+// TestCentralAppliedByRoundTrip checks the projected owning Kustomization is
+// carried end-to-end into the central read model: List (no raw) and Get both
+// surface appliedBy, while an unowned root stays nil. The list carrying it is
+// what lets the UI group child HelmReleases under their app without detail
+// fetches.
+func TestCentralAppliedByRoundTrip(t *testing.T) {
+	cs, _ := newCentral(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	child := changed("grafana-operator", "HelmRelease", flux.ReadyTrue, "h1", now)
+	child.AppliedBy = &flux.AppliedBy{Name: "grafana-operator-grafana-operator", Namespace: "flux-system"}
+	root := changed("apps", "Kustomization", flux.ReadyTrue, "h2", now)
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:     "ttd_at23",
+		Environment: "at23",
+		Changed:     []store.ChangedResource{child, root},
+		Keys: []store.ResourceKey{
+			{Kind: "HelmRelease", Namespace: "flux-system", Name: "grafana-operator"},
+			{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"},
+		},
+		Cursor:        now,
+		SchemaVersion: store.SchemaVersion,
+		AgentVersion:  "test",
+		LastSweepAt:   now,
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	rows, err := cs.List(ctx, "ttd_at23", "", "", "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var seenChild, seenRoot bool
+	for _, r := range rows {
+		switch r.Name {
+		case "grafana-operator":
+			seenChild = true
+			if r.AppliedBy == nil || r.AppliedBy.Name != "grafana-operator-grafana-operator" || r.AppliedBy.Namespace != "flux-system" {
+				t.Fatalf("child HelmRelease List should carry AppliedBy: %+v", r.AppliedBy)
+			}
+		case "apps":
+			seenRoot = true
+			if r.AppliedBy != nil {
+				t.Fatalf("root Kustomization List should have nil AppliedBy: %+v", r.AppliedBy)
+			}
+		}
+	}
+	if !seenChild || !seenRoot {
+		t.Fatalf("list missing rows: child=%v root=%v rows=%+v", seenChild, seenRoot, rows)
+	}
+
+	got, err := cs.Get(ctx, "ttd_at23", "HelmRelease", "flux-system", "grafana-operator")
+	if err != nil {
+		t.Fatalf("get child: %v", err)
+	}
+	if got.AppliedBy == nil || got.AppliedBy.Name != "grafana-operator-grafana-operator" {
+		t.Fatalf("child Get should carry AppliedBy: %+v", got.AppliedBy)
+	}
+}
+
 // TestCentralDISFieldsEndToEnd walks a DIS resource through the full pipeline
 // against real PostgreSQL: agent Sync into the tenant database, server pull
 // (ChangedSince at the current schema) and Apply, then the fleet-API reads —
@@ -324,12 +385,12 @@ func TestCentralDISFieldsEndToEnd(t *testing.T) {
 	}
 }
 
-// TestCentralSyncSchemaV1Tenant proves the rollout order the schema gate
-// promises: a server at schema 2 can still pull a tenant whose agent is at
-// schema 1 (its database lacks the DIS columns entirely). The tenant is built
-// by hand — migrate, then drop the v2 columns and stamp schema_version 1 —
-// because a v2 agent binary can no longer write the v1 shape.
-func TestCentralSyncSchemaV1Tenant(t *testing.T) {
+// TestCentralSyncSchemaV2Tenant proves the rollout order the schema gate
+// promises: a server at schema 3 can still pull a tenant whose agent is at
+// schema 2 (its database lacks the applied-by columns entirely). The tenant is
+// built by hand — migrate, then drop the v3 columns and stamp schema_version 2
+// — because a v3 agent binary can no longer write the v2 shape.
+func TestCentralSyncSchemaV2Tenant(t *testing.T) {
 	cs, _ := newCentral(t)
 	ctx := context.Background()
 	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
@@ -344,35 +405,36 @@ func TestCentralSyncSchemaV1Tenant(t *testing.T) {
 		t.Fatalf("migrate tenant: %v", err)
 	}
 	if _, err := tpool.Exec(ctx, `ALTER TABLE flux_resource
-		DROP COLUMN azure_resource_id, DROP COLUMN parent_kind, DROP COLUMN parent_name`); err != nil {
-		t.Fatalf("shape tenant as v1: %v", err)
+		DROP COLUMN applied_by_name, DROP COLUMN applied_by_namespace`); err != nil {
+		t.Fatalf("shape tenant as v2: %v", err)
 	}
 	if _, err := tpool.Exec(ctx,
-		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 1, 'v1-agent')"); err != nil {
-		t.Fatalf("stamp v1 meta: %v", err)
+		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 2, 'v2-agent')"); err != nil {
+		t.Fatalf("stamp v2 meta: %v", err)
 	}
-	// The full column set a v1 agent writes: its upsert always passes the Go
-	// zero values, so reason/message/revision land as '' (never NULL).
+	// The full column set a v2 agent writes: its upsert always passes the Go
+	// zero values, so reason/message/revision land as '' (never NULL) and the
+	// DIS pair as NULL for a plain Flux object.
 	if _, err := tpool.Exec(ctx, `INSERT INTO flux_resource
 		(kind, api_version, namespace, name, ready, reason, message, revision,
-		 suspended, generation, observed_generation, raw, content_hash)
+		 azure_resource_id, suspended, generation, observed_generation, raw, content_hash)
 		VALUES ('Kustomization', 'kustomize.toolkit.fluxcd.io/v1', 'flux-system', 'apps', 'True', '', '', '',
-		 false, 0, 0, '{}', 'h1')`); err != nil {
-		t.Fatalf("insert v1 row: %v", err)
+		 '', false, 0, 0, '{}', 'h1')`); err != nil {
+		t.Fatalf("insert v2 row: %v", err)
 	}
 
 	meta, err := ts.GetMeta(ctx)
-	if err != nil || meta.SchemaVersion != 1 {
+	if err != nil || meta.SchemaVersion != 2 {
 		t.Fatalf("tenant meta: %+v err=%v", meta, err)
 	}
 
 	// The version-keyed pull must succeed against the columnless table.
 	changed, err := ts.ChangedSince(ctx, time.Time{}, meta.SchemaVersion)
 	if err != nil {
-		t.Fatalf("changed-since on a v1 tenant: %v", err)
+		t.Fatalf("changed-since on a v2 tenant: %v", err)
 	}
-	if len(changed) != 1 || changed[0].AzureResourceID != "" || changed[0].Parent != nil {
-		t.Fatalf("unexpected v1 pull: %+v", changed)
+	if len(changed) != 1 || changed[0].AppliedBy != nil {
+		t.Fatalf("unexpected v2 pull: %+v", changed)
 	}
 	keys, err := ts.Keys(ctx)
 	if err != nil {
@@ -388,15 +450,15 @@ func TestCentralSyncSchemaV1Tenant(t *testing.T) {
 		SchemaVersion: meta.SchemaVersion,
 		AgentVersion:  meta.AgentVersion,
 	}); err != nil {
-		t.Fatalf("apply v1 tenant: %v", err)
+		t.Fatalf("apply v2 tenant: %v", err)
 	}
 
 	rows, err := cs.List(ctx, "ttd_at23", "", "", "")
 	if err != nil || len(rows) != 1 {
-		t.Fatalf("central list after v1 sync: %+v err=%v", rows, err)
+		t.Fatalf("central list after v2 sync: %+v err=%v", rows, err)
 	}
-	if rows[0].AzureResourceID != "" || rows[0].Parent != nil {
-		t.Fatalf("v1 row should have empty DIS fields, got %+v", rows[0])
+	if rows[0].AppliedBy != nil {
+		t.Fatalf("v2 row should have nil appliedBy, got %+v", rows[0])
 	}
 }
 

--- a/services/dis-console/test/e2e/store_test.go
+++ b/services/dis-console/test/e2e/store_test.go
@@ -245,6 +245,71 @@ func TestSyncRoundTripsDISColumns(t *testing.T) {
 	}
 }
 
+// TestSyncAppliedByRoundTrip checks the schema-v3 columns against real
+// PostgreSQL: a HelmRelease's projected owning Kustomization survives Sync and
+// comes back out of Get and ChangedSince (the path the server mirrors it on),
+// while an unowned root stays nil.
+func TestSyncAppliedByRoundTrip(t *testing.T) {
+	s, _ := newStore(t)
+	ctx := context.Background()
+
+	child := flux.Resource{
+		Kind:        "HelmRelease",
+		APIVersion:  "helm.toolkit.fluxcd.io/v2",
+		Namespace:   "grafana",
+		Name:        "grafana-operator",
+		Ready:       flux.ReadyTrue,
+		AppliedBy:   &flux.AppliedBy{Name: "grafana-operator-grafana-operator", Namespace: "flux-system"},
+		Raw:         json.RawMessage(`{"kind":"HelmRelease"}`),
+		ContentHash: "child-1",
+	}
+	root := flux.Resource{
+		Kind:        "Kustomization",
+		APIVersion:  "kustomize.toolkit.fluxcd.io/v1",
+		Namespace:   "flux-system",
+		Name:        "root",
+		Ready:       flux.ReadyTrue,
+		Raw:         json.RawMessage(`{"kind":"Kustomization"}`),
+		ContentHash: "root-1",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{child, root}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	got, _, err := s.Get(ctx, "HelmRelease", "grafana", "grafana-operator")
+	if err != nil {
+		t.Fatalf("get child: %v", err)
+	}
+	if got.AppliedBy == nil || got.AppliedBy.Name != "grafana-operator-grafana-operator" || got.AppliedBy.Namespace != "flux-system" {
+		t.Fatalf("child Get AppliedBy: %+v", got.AppliedBy)
+	}
+
+	gotRoot, _, err := s.Get(ctx, "Kustomization", "flux-system", "root")
+	if err != nil {
+		t.Fatalf("get root: %v", err)
+	}
+	if gotRoot.AppliedBy != nil {
+		t.Fatalf("root Get AppliedBy should be nil: %+v", gotRoot.AppliedBy)
+	}
+
+	changed, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion)
+	if err != nil {
+		t.Fatalf("changed-since: %v", err)
+	}
+	var seenChild bool
+	for _, c := range changed {
+		if c.Name == "grafana-operator" {
+			seenChild = true
+			if c.AppliedBy == nil || c.AppliedBy.Name != "grafana-operator-grafana-operator" {
+				t.Fatalf("ChangedSince child AppliedBy: %+v", c.AppliedBy)
+			}
+		}
+	}
+	if !seenChild {
+		t.Fatalf("ChangedSince did not return child row: %+v", changed)
+	}
+}
+
 // TestSyncContentHashSkipsUnchangedRewrite asserts the write-hygiene contract:
 // an unchanged sweep leaves updated_at alone (no row/raw rewrite), while a
 // content change advances it. The central sync loop pulls on updated_at, so


### PR DESCRIPTION
## Problem

A HelmRelease's owning Kustomization is only visible in `raw.metadata.labels[kustomize.toolkit.fluxcd.io/name|namespace]`, and `raw` is detail-endpoint only — the UI cannot group child HelmReleases under their parent app from the list payload.

## Fix

Project the two kustomize-controller ownership labels into an `appliedBy {name,namespace}` field on the normalized `Resource` and thread it through both stores, so `/api/resources` carries it:

- `internal/flux`: `normalize()` reads the labels; nil for roots/Arc-managed objects (field omitted in JSON).
- `internal/store`: `applied_by_name`/`applied_by_namespace` columns (+`ALTER … IF NOT EXISTS` for existing tenant DBs), threaded through upsert/List/Get/ChangedSince. `SchemaVersion` → 3.
- `internal/central`: same columns; `Apply` upsert, `List` (the critical one) and `Get` return them.
- e2e: tenant + central round-trip tests; `TestCentralSyncSchemaV1Tenant` reworked to `TestCentralSyncSchemaV2Tenant` (the new N-1 bridge).

## Rollout

Same order as the v2 rollout: server first (version-keyed `ChangedSince` pulls v2 tenants with the v2 statement), then agents (each migrates its tenant DB in place at startup). The v1 pull variant is dropped — v1 is outside the supported N-1..N window and the engine skips such tenants before pulling.

## Verification

- `make run-checks-ci-cache` — fmt/vet/test/lint, 0 issues
- `make test-e2e-kind-ci` — 12/12 pass against real PostgreSQL in Kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resources now include ownership metadata showing which Kustomization applied them.
  * Lists and detail views can group child resources under their parent when that relationship is available.

* **Bug Fixes**
  * Unowned or platform-managed resources now correctly appear without ownership metadata.
  * Existing data is supported during the rollout, with no impact to current resource visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->