### PR TITLE
fix(dis-pgsql-operator): persist status.resourceId on already-Ready servers

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -2818,6 +2818,91 @@ var _ = Describe("DatabaseServer controller", func() {
 			Should(Equal(metav1.ConditionTrue))
 	})
 
+	It("persists the Azure resource id on an already-Ready DatabaseServer", func() {
+		db := newDedicatedDatabaseServer("my-app-db-late-id", adminAuth(
+			adminManagedIdentity,
+			adminManagedIdentityID,
+			adminManagedIdentity,
+		))
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+		serverKey := types.NamespacedName{Name: db.Name, Namespace: db.Namespace}
+
+		// ASO reports Ready before Azure has filled in the server's ARM id
+		// (no FullyQualifiedDomainName/Id yet).
+		Eventually(func() error {
+			var server dbforpostgresqlv1.FlexibleServer
+			if err := k8sClient.Get(ctx, serverKey, &server); err != nil {
+				return err
+			}
+			server.Status.Conditions = []asoconditions.Condition{
+				{
+					Type:               asoconditions.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             databaseConditionReady,
+					LastTransitionTime: metav1.Now(),
+					ObservedGeneration: server.Generation,
+				},
+			}
+			return k8sClient.Status().Update(ctx, &server)
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		Eventually(func() error {
+			var admin dbforpostgresqlv1.FlexibleServersAdministrator
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      fmt.Sprintf("%s-admin", db.Name),
+				Namespace: db.Namespace,
+			}, &admin); err != nil {
+				return err
+			}
+			admin.Status.Conditions = []asoconditions.Condition{
+				{
+					Type:               asoconditions.ConditionTypeReady,
+					Status:             metav1.ConditionTrue,
+					Reason:             databaseConditionReady,
+					LastTransitionTime: metav1.Now(),
+					ObservedGeneration: admin.Generation,
+				},
+			}
+			return k8sClient.Status().Update(ctx, &admin)
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Succeed())
+
+		// The server settles Ready without a resource id.
+		Eventually(func(g Gomega) metav1.ConditionStatus {
+			var updated storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, serverKey, &updated)).To(Succeed())
+			ready := meta.FindStatusCondition(updated.Status.Conditions, databaseServerConditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(updated.Status.ResourceID).To(BeEmpty())
+			return ready.Status
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(metav1.ConditionTrue))
+
+		// Azure reports the ARM id afterwards; the Ready condition no longer
+		// changes, but the id must still be persisted.
+		Eventually(func() error {
+			var server dbforpostgresqlv1.FlexibleServer
+			if err := k8sClient.Get(ctx, serverKey, &server); err != nil {
+				return err
+			}
+			host := fmt.Sprintf("%s.postgres.database.azure.com", db.Name)
+			server.Status.FullyQualifiedDomainName = &host
+			resourceID := expectedFlexibleServerResourceID(db.Name)
+			server.Status.Id = &resourceID
+			return k8sClient.Status().Update(ctx, &server)
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).
+			Should(Succeed())
+
+		Eventually(func(g Gomega) string {
+			var updated storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, serverKey, &updated)).To(Succeed())
+			g.Expect(updated.Status.Host).To(Equal(fmt.Sprintf("%s.postgres.database.azure.com", db.Name)))
+			return updated.Status.ResourceID
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(expectedFlexibleServerResourceID(db.Name)))
+	})
+
 	It("surfaces a ServerNameConflict and suppresses owner-not-found parameter errors when the FlexibleServer name is taken", func() {
 		db := newDedicatedDatabaseServer("my-app-db-name-conflict", adminAuth(
 			adminManagedIdentity,

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
@@ -543,17 +543,27 @@ func (r *DatabaseServerReconciler) asoResourcesReady(
 	}
 
 	// Publish the Azure-side identity on the DatabaseServer status as soon as ASO
-	// has filled it in. setDatabaseServerReadyCondition flushes the status, so
-	// this only needs to mutate the in-memory object.
+	// has filled it in. Persisted here, not left to the ready-condition flush:
+	// that flush diffs against a snapshot taken after these writes, so on a
+	// server whose condition is already settled it never sees them as a change.
+	azureIdentityChanged := false
 	if server.Status.FullyQualifiedDomainName != nil {
-		if host := strings.TrimSpace(*server.Status.FullyQualifiedDomainName); host != "" {
+		if host := strings.TrimSpace(*server.Status.FullyQualifiedDomainName); host != "" && host != db.Status.Host {
 			db.Status.Host = host
+			azureIdentityChanged = true
 		}
 	}
 
 	if server.Status.Id != nil {
-		if resourceID := strings.TrimSpace(*server.Status.Id); resourceID != "" {
+		if resourceID := strings.TrimSpace(*server.Status.Id); resourceID != "" && resourceID != db.Status.ResourceID {
 			db.Status.ResourceID = resourceID
+			azureIdentityChanged = true
+		}
+	}
+
+	if azureIdentityChanged {
+		if err := r.Status().Update(ctx, db); err != nil {
+			return false, fmt.Errorf("update database server status with Azure server identity: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Live on admin-test after the 0.12.0 rollout: only DatabaseServers with recent condition churn got `status.resourceId`; settled ones (e.g. `product-dis/dis-console-central`, Ready since June 29) never did — so their dis-console Portal links stay missing.

**Root cause:** `asoResourcesReady` sets `Status.ResourceID`/`Status.Host` in-memory and relies on the ready-condition flush to persist them — but the flush diffs against a snapshot taken *after* those writes, so on a server whose condition doesn't change it concludes nothing changed and skips `Status().Update`. The #3786 test only covered a fresh server transitioning to Ready, where the condition change forces the write.

**Fix:** track whether the Azure-side fields actually changed and persist them in `asoResourcesReady` itself (same pattern as the subnet allocation next to it and dis-vault's `setIfChanged`). Regression test covers the already-Ready case (ASO `Id` arriving after the condition settled) — it fails on the previous code and passes with the fix.

Checks: `make run-checks-ci-cache` green; full envtest controller suite green (66 specs).

Rollout: patch release via release-please rides the ring rollout; the operator restart reconciles every server and now persists the id on settled ones too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)