### PR TITLE
fix(dis-pgsql-operator): preserve legacy FQDN-named private DNS zone CRs

### DIFF
--- a/services/dis-pgsql-operator/internal/controller/database_controller_test.go
+++ b/services/dis-pgsql-operator/internal/controller/database_controller_test.go
@@ -2903,6 +2903,78 @@ var _ = Describe("DatabaseServer controller", func() {
 			Should(Equal(expectedFlexibleServerResourceID(db.Name)))
 	})
 
+	It("preserves the legacy FQDN-named DNS zone and links on pre-rename servers", func() {
+		const serverName = "my-app-db-legacy-zone"
+		legacyZoneName := serverName + ".private.postgres.database.azure.com"
+		loc := privateDNSZoneLocation
+		regFalse := false
+
+		// The zone + links as the pre-rename operator laid them out: the zone CR
+		// named after the FQDN, the links owned by it.
+		zone := &networkv1.PrivateDnsZone{
+			ObjectMeta: metav1.ObjectMeta{Name: legacyZoneName, Namespace: ns},
+			Spec: networkv1.PrivateDnsZone_Spec{
+				AzureName: legacyZoneName,
+				Location:  &loc,
+				Owner: &genruntime.KnownResourceReference{
+					ARMID: "/subscriptions/my-subscription-id/resourceGroups/rg-dis-dev-network",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, zone)).To(Succeed())
+
+		for linkName, vnetID := range map[string]string{
+			serverName + "-vnetlink":     "/subscriptions/my-subscription-id/resourceGroups/rg-dis-dev-network/providers/Microsoft.Network/virtualNetworks/vnet-dis-dev-001",
+			serverName + "-aks-vnetlink": "/subscriptions/my-subscription-id/resourceGroups/aks-vnet-rg/providers/Microsoft.Network/virtualNetworks/aks-vnet-dis-dev-001",
+		} {
+			link := &networkv1.PrivateDnsZonesVirtualNetworkLink{
+				ObjectMeta: metav1.ObjectMeta{Name: linkName, Namespace: ns},
+				Spec: networkv1.PrivateDnsZonesVirtualNetworkLink_Spec{
+					AzureName:           linkName,
+					Location:            &loc,
+					Owner:               &genruntime.KnownResourceReference{Name: legacyZoneName},
+					RegistrationEnabled: &regFalse,
+					VirtualNetwork: &networkv1.SubResource{
+						Reference: &genruntime.ResourceReference{ARMID: vnetID},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, link)).To(Succeed())
+		}
+
+		db := newDedicatedDatabaseServer(serverName, adminAuth(
+			adminManagedIdentity,
+			adminManagedIdentityID,
+			adminManagedIdentity,
+		))
+		Expect(k8sClient.Create(ctx, db)).To(Succeed())
+		markASOReady(ctx, db)
+
+		// The reconcile completes past the DNS children and persists the ids.
+		Eventually(func(g Gomega) string {
+			var updated storagev1alpha1.DatabaseServer
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      db.Name,
+				Namespace: db.Namespace,
+			}, &updated)).To(Succeed())
+			return updated.Status.ResourceID
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).
+			Should(Equal(expectedFlexibleServerResourceID(db.Name)))
+
+		// The links still belong to the legacy zone (their owner is immutable in
+		// ASO), and no duplicate zone CR appeared under the new name.
+		var link networkv1.PrivateDnsZonesVirtualNetworkLink
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      serverName + "-vnetlink",
+			Namespace: ns,
+		}, &link)).To(Succeed())
+		Expect(link.Spec.Owner.Name).To(Equal(legacyZoneName))
+
+		var dupe networkv1.PrivateDnsZone
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: serverName, Namespace: ns}, &dupe)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "no zone CR should be created under the new name")
+	})
+
 	It("surfaces a ServerNameConflict and suppresses owner-not-found parameter errors when the FlexibleServer name is taken", func() {
 		db := newDedicatedDatabaseServer("my-app-db-name-conflict", adminAuth(
 			adminManagedIdentity,

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller.go
@@ -216,11 +216,22 @@ func (r *DatabaseServerReconciler) deleteDedicatedNetworkChildren(
 	}
 
 	// Second wave: the zone, now that nothing nested under it remains.
-	zoneGone, err := r.ensureChildDeleted(ctx, logger, db.Namespace, zoneCRNameForDatabaseServer(db), &networkv1.PrivateDnsZone{})
-	if err != nil {
-		return false, err
+	// Pre-rename servers own the legacy FQDN-named zone CR, so both names are
+	// deleted; ensureChildDeleted treats an absent one as already gone.
+	zonesGone := true
+	for _, zoneName := range []string{
+		zoneCRNameForDatabaseServer(db),
+		zoneAzureNameForDatabaseServer(db),
+	} {
+		gone, err := r.ensureChildDeleted(ctx, logger, db.Namespace, zoneName, &networkv1.PrivateDnsZone{})
+		if err != nil {
+			return false, err
+		}
+		if !gone {
+			zonesGone = false
+		}
 	}
-	return !zoneGone, nil
+	return !zonesGone, nil
 }
 
 // ensureChildDeleted issues a delete for the named owned resource if it is still present
@@ -299,8 +310,15 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 		logger.Info("database server already has subnetCIDR", "subnetCIDR", db.Status.SubnetCIDR)
 	}
 
-	// Private Dns zone
-	if err := r.ensurePrivateDNSZone(ctx, logger, db); err != nil {
+	// Private Dns zone. Pre-rename servers keep their legacy FQDN-named zone CR
+	// (and the links owned by it); the resolved name is threaded through every
+	// child that references the zone.
+	zoneCRName, err := r.resolveZoneCRName(ctx, db)
+	if err != nil {
+		logger.Error(err, "failed to resolve private DNS zone CR name")
+		return ctrl.Result{}, err
+	}
+	if err := r.ensurePrivateDNSZone(ctx, logger, db, zoneCRName); err != nil {
 		logger.Error(err, "failed to ensure private DNS zone")
 		return ctrl.Result{}, err
 	}
@@ -323,7 +341,7 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 	// DB VNet link
 	if err := r.ensurePrivateDNSVNetLink(
 		ctx, logger, db,
-		zoneCRNameForDatabaseServer(db),
+		zoneCRName,
 		dbVNetLinkNameForDatabaseServer(db),
 		r.Config.DBVNetName,
 		dbVnetID,
@@ -335,7 +353,7 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 	// AKS VNet link
 	if err := r.ensurePrivateDNSVNetLink(
 		ctx, logger, db,
-		zoneCRNameForDatabaseServer(db),
+		zoneCRName,
 		aksVNetLinkNameForDatabaseServer(db),
 		r.Config.AKSVNetName,
 		aksVnetID,
@@ -344,7 +362,7 @@ func (r *DatabaseServerReconciler) reconcileDedicatedDatabaseServer(
 		return ctrl.Result{}, err
 	}
 
-	networkConfig, err := r.dedicatedPostgresNetworkConfig(db, zoneCRNameForDatabaseServer(db))
+	networkConfig, err := r.dedicatedPostgresNetworkConfig(db, zoneCRName)
 	if err != nil {
 		logger.Error(err, "failed to build dedicated PostgreSQL network config")
 		return ctrl.Result{}, err

--- a/services/dis-pgsql-operator/internal/controller/databaseserver_controller_dns.go
+++ b/services/dis-pgsql-operator/internal/controller/databaseserver_controller_dns.go
@@ -19,6 +19,9 @@ import (
 // The suffix we use for per-database-server private DNS zones.
 const postgresPrivateZoneSuffix = "private.postgres.database.azure.com"
 
+// Private DNS zones (and their vnet links) use 'global' for Location in Azure.
+const privateDNSZoneLocation = "global"
+
 // zoneCRNameForDatabaseServer is the Kubernetes object name of the server's
 // Private DNS zone CR. It stays equal to the DatabaseServer CR name (which is a
 // valid flexible-server name, so <=63 chars) rather than the FQDN. ASO stamps a
@@ -28,6 +31,27 @@ const postgresPrivateZoneSuffix = "private.postgres.database.azure.com"
 // a '.' and failing label validation, which blocked the vnet links entirely.
 func zoneCRNameForDatabaseServer(db *storagev1alpha1.DatabaseServer) string {
 	return db.Name
+}
+
+// resolveZoneCRName returns the zone CR name to use for this server. Servers
+// created before the zone CR was renamed to db.Name own a zone CR named after
+// the Azure FQDN, with vnet links owned by it; ASO forbids changing a link's
+// owner, and creating a second zone CR would double-manage the same Azure
+// zone, so the legacy name is preserved for as long as that CR exists.
+func (r *DatabaseServerReconciler) resolveZoneCRName(
+	ctx context.Context,
+	db *storagev1alpha1.DatabaseServer,
+) (string, error) {
+	legacyName := zoneAzureNameForDatabaseServer(db)
+	var legacy networkv1.PrivateDnsZone
+	err := r.Get(ctx, types.NamespacedName{Name: legacyName, Namespace: db.Namespace}, &legacy)
+	if err == nil {
+		return legacyName, nil
+	}
+	if !errors.IsNotFound(err) {
+		return "", fmt.Errorf("get legacy PrivateDnsZone %s/%s: %w", db.Namespace, legacyName, err)
+	}
+	return zoneCRNameForDatabaseServer(db), nil
 }
 
 // zoneAzureNameForDatabaseServer is the Azure-side name of the server's Private
@@ -50,12 +74,12 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSZone(
 	ctx context.Context,
 	logger logr.Logger,
 	db *storagev1alpha1.DatabaseServer,
+	zoneCRName string,
 ) error {
 	if r.Config.ResourceGroup == "" {
 		return fmt.Errorf("ResourceGroup is not configured on DatabaseServerReconciler")
 	}
 	ns := db.Namespace
-	zoneCRName := zoneCRNameForDatabaseServer(db)
 	zoneAzureName := zoneAzureNameForDatabaseServer(db)
 	key := types.NamespacedName{
 		Name:      zoneCRName,
@@ -80,7 +104,7 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSZone(
 		"azureName", zoneAzureName,
 		"asoNamespace", ns)
 
-	loc := "global" // Private DNS zones use 'global' for Location in Azure.
+	loc := privateDNSZoneLocation
 
 	zone := &networkv1.PrivateDnsZone{
 		ObjectMeta: metav1.ObjectMeta{
@@ -136,7 +160,7 @@ func (r *DatabaseServerReconciler) ensurePrivateDNSVNetLink(
 	vnetID string,
 ) error {
 	ns := db.Namespace
-	loc := "global"
+	loc := privateDNSZoneLocation
 	regFalse := false
 	desiredLabels := map[string]string{
 		databaseServerNameLabelKey: db.Name,


### PR DESCRIPTION
Live on admin-test: `product-dis/dis-console-central` (created June 17, pre-#3769) fails every reconcile with

    admission webhook ... denied the request: updating 'spec.owner.name' is not allowed for PrivateDnsZonesVirtualNetworkLink

so its status has been frozen since June — the #3795 persist fix never gets to run for it, and today's reconciles also created a duplicate new-named zone CR double-managing the same Azure zone (deleting either would delete the zone).

**Root cause:** #3769 renamed the zone CR from the FQDN to `db.Name` with no migration for existing servers. Their vnet links keep the same CR name but are owned by the FQDN-named zone; ASO forbids changing a link's owner, so the in-place update is denied and the whole reconcile aborts before any status is written. (All pre-#3769 servers had `<=27`-char names, so their legacy zone+links work fine — nothing needs recreating.)

**Fix:** resolve the zone CR name once per reconcile — prefer the legacy FQDN-named CR while it exists (same back-compat pattern as `flexibleServerAzureName` in #3758) — and thread it through the zone ensure, both vnet links, and the FlexibleServer network config. Teardown deletes both zone names. Regression test pre-creates the legacy zone+links, then asserts the reconcile completes, the link owner is untouched, and no duplicate zone CR appears — it fails on the previous code.

Checks: `make run-checks-ci-cache` green; full envtest controller suite green (67 specs).

**Manual cleanup on admin-test after rollout** (the duplicate zone CR already created today; detach so Azure keeps the zone):

    kubectl -n product-dis annotate privatednszone dis-console-central serviceoperator.azure.com/reconcile-policy=detach-on-delete
    kubectl -n product-dis delete privatednszone dis-console-central

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dedicated database server private DNS reconciliation to correctly use the appropriate PrivateDnsZone name, including legacy FQDN-based zones.
  * Improved cleanup of DNS children by attempting deletion for both legacy and renamed private DNS zone CRs, avoiding duplicates.
  * Ensured VNet link ownership and DNS network config remain consistent and continued to use a consistent global location setting.

* **Tests**
  * Added an integration test covering legacy FQDN-named DNS zone preservation and correct vnet link behavior on pre-rename servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->