### PR TITLE
Crete a dedicated namespace for Authorization

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -157,7 +157,12 @@ variable "k8s_rbac" {
       namespace = "authentication"
       dev_group = "5c42ac79-86e2-46d0-85d3-ae751dd5f057"
       sp_group  = "328cbe61-aeb1-4782-bb36-d288c69b4f15"
-    }
+    },
+    authorization = {
+      namespace = "authorization"
+      dev_group = "dcf337f1-f1ba-428e-b101-642d9d619c73"
+      sp_group  = "447482ce-de4b-4081-b611-e510252c3120"
+    },
     platform = {
       namespace = "platform"
       dev_group = "975d2ed6-f3dc-48a3-b014-8d876cb96e25"


### PR DESCRIPTION
Currently, both teams are under "authentication"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Kubernetes RBAC entry for authorization, including namespace and group mappings.
  * Updated access configuration to support the additional authorization area alongside existing environment entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->