### PR TITLE
chore(dis-console): roll out v1.5.0 server to admin clusters

### DIFF
--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
           args:
             - server
           ports:


### PR DESCRIPTION
Bumps the central dis-console server to v1.5.0 (#3793: appliedBy projection, central schema gains the applied_by columns on migrate).

**Merge this before the agents rollout** — the v1.5.0 server reads both v2 and v3 tenants (version-keyed ChangedSince), while a v1.4.0 server would skip v3 tenants as unsupported. Agents PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the console deployment to a newer application version, which may include general improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->