### PR TITLE
chore(dis-console): roll out v1.5.0 agents

### DIFF
--- a/deploy/admin/base/dis-console-agent-deployment.yaml
+++ b/deploy/admin/base/dis-console-agent-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
           args:
             - agent
           ports:

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
           args:
             - agent
           ports:

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
           args:
             - agent
           ports:

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.4.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
           args:
             - agent
           ports:


### PR DESCRIPTION
Bumps the dis-console agents to v1.5.0 (#3793: appliedBy projection): the admin-cluster agent, the at22/at23 fleet agents, and the tenant-app template. Each agent migrates its tenant DB in place at startup (ALTER TABLE IF NOT EXISTS) and stamps schema_version 3.

**Merge after #3810** (server first): a v1.4.0 server would skip v3 tenants as unsupported, so the server must be on v1.5.0 before agents start writing v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)