### PR TITLE
fix(dis-console): backfill appliedBy into the central mirror for pre-existing rows

### DIFF
--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -160,6 +160,16 @@ func appliedByRef(name, namespace *string) *flux.AppliedBy {
 // sweep across the whole fleet. Keeping r.raw on the unchanged branch reuses the
 // existing TOAST datum. last_seen is always bumped so prune can tell which rows
 // were seen this sweep.
+//
+// updated_at additionally advances when the applied-by pair differs from the
+// stored value. The hash covers the object, not the agent's projection of it:
+// when a projection change (like adding appliedBy) starts deriving new columns
+// from labels that were already in the hashed object, every pre-existing row
+// gets the new columns with an unchanged hash — and the server's incremental
+// pull (updated_at > cursor) would never mirror them. The extra comparison
+// backfills each such row exactly once and is quiet steady-state (a real label
+// change also changes the hash). Any future projection derived from existing
+// object content must extend this CASE the same way.
 const upsertStmt = `
 WITH prev AS (
     SELECT ready, reason, revision
@@ -204,6 +214,8 @@ up AS (
         last_seen            = now(),
         updated_at           = CASE
             WHEN r.content_hash IS DISTINCT FROM EXCLUDED.content_hash
+              OR r.applied_by_name IS DISTINCT FROM EXCLUDED.applied_by_name
+              OR r.applied_by_namespace IS DISTINCT FROM EXCLUDED.applied_by_namespace
             THEN now() ELSE r.updated_at END
     RETURNING ready, reason, message, revision
 )

--- a/services/dis-console/test/e2e/store_test.go
+++ b/services/dis-console/test/e2e/store_test.go
@@ -349,6 +349,69 @@ func TestSyncContentHashSkipsUnchangedRewrite(t *testing.T) {
 	}
 }
 
+// TestSyncAppliedByBackfillAdvancesUpdatedAt reproduces the v1.4.0→v1.5.0
+// upgrade: rows written before the appliedBy projection have it NULL with an
+// unchanged content hash (the labels were already in the hashed object). The
+// first sweep that projects appliedBy must advance updated_at so the central
+// pull (updated_at > cursor) mirrors the backfilled row — and later identical
+// sweeps must not churn it.
+func TestSyncAppliedByBackfillAdvancesUpdatedAt(t *testing.T) {
+	s, pool := newStore(t)
+	ctx := context.Background()
+
+	updatedAt := func() time.Time {
+		var ts time.Time
+		if err := pool.QueryRow(ctx,
+			"SELECT updated_at FROM flux_resource WHERE name = $1", "grafana-operator").Scan(&ts); err != nil {
+			t.Fatalf("query updated_at: %v", err)
+		}
+		return ts
+	}
+
+	// Sweep 1: the pre-appliedBy shape (same object, projection not derived yet).
+	pre := flux.Resource{
+		Kind:        "HelmRelease",
+		APIVersion:  "helm.toolkit.fluxcd.io/v2",
+		Namespace:   "grafana",
+		Name:        "grafana-operator",
+		Ready:       flux.ReadyTrue,
+		Raw:         json.RawMessage(`{"kind":"HelmRelease"}`),
+		ContentHash: "same-object",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{pre}); err != nil {
+		t.Fatalf("sync 1: %v", err)
+	}
+	first := updatedAt()
+
+	// Sweep 2: identical object + hash, but the agent now projects appliedBy.
+	post := pre
+	post.AppliedBy = &flux.AppliedBy{Name: "grafana-operator-grafana-operator", Namespace: "flux-system"}
+	if _, err := s.Sync(ctx, []flux.Resource{post}); err != nil {
+		t.Fatalf("sync 2: %v", err)
+	}
+	second := updatedAt()
+	if !second.After(first) {
+		t.Fatalf("updated_at must advance when appliedBy is backfilled: %v -> %v", first, second)
+	}
+
+	// The advanced updated_at is what makes the row visible to the central pull.
+	changed, err := s.ChangedSince(ctx, first, store.SchemaVersion)
+	if err != nil {
+		t.Fatalf("changed-since: %v", err)
+	}
+	if len(changed) != 1 || changed[0].AppliedBy == nil || changed[0].AppliedBy.Name != "grafana-operator-grafana-operator" {
+		t.Fatalf("backfilled row not pulled: %+v", changed)
+	}
+
+	// Sweep 3: identical again (appliedBy unchanged) => no churn.
+	if _, err := s.Sync(ctx, []flux.Resource{post}); err != nil {
+		t.Fatalf("sync 3: %v", err)
+	}
+	if got := updatedAt(); !got.Equal(second) {
+		t.Fatalf("updated_at churned on an unchanged appliedBy sweep: %v -> %v", second, got)
+	}
+}
+
 // TestMetaRecordedOnSync checks the meta row: InitMeta stamps schema/agent
 // version with no sweep time yet, and a sweep records last_sweep_at.
 func TestMetaRecordedOnSync(t *testing.T) {


### PR DESCRIPTION
## Problem

After the v1.5.0 rollout the fleet API still serves `appliedBy: null` for everything. The agent writes `applied_by_*` to the tenant DB on every sweep, but `updated_at` only advances on a `content_hash` change — and the kustomize labels were already part of the hashed object before the projection existed. Pre-existing rows keep their old `updated_at`, so the server's incremental pull (`updated_at > cursor`) never mirrors the backfilled columns into central. (The e2e missed it because tests always insert fresh rows; the v1.4.0 DIS columns dodged it because DIS rows were newly swept.)

## Fix

Advance `updated_at` in the tenant upsert when the applied-by pair differs from the stored value. Each stale row backfills exactly once on the first sweep after rollout; steady-state is quiet (a genuine label change also changes the hash). Comment documents the pitfall for future projections derived from already-hashed content.

New e2e `TestSyncAppliedByBackfillAdvancesUpdatedAt` reproduces the upgrade sequence: pre-appliedBy row → same-hash sweep with appliedBy ⇒ `updated_at` advances and `ChangedSince` returns the row; a third identical sweep doesn't churn.

## Rollout

Agents only (the upsert is agent-side); no schema change, no version-window impact. Fleet backfills within one sweep+sync cycle of the agent rollout.

## Verification

- `make run-checks-ci-cache` — 0 issues
- `make test-e2e-kind-ci` — 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)