### PR TITLE
feat(dis-console): track base-layer OCI artifacts and their applied-object inventory

### DIFF
--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -90,6 +90,11 @@ Do not claim checks passed unless you actually ran them.
 - `internal/health` — `/healthz` + `/readyz` handlers used by the agent.
 - `internal/api` — the fleet API: `net/http` mux + JSON handlers reading the
   central store (`/api/clusters`, `?cluster=` filters, detail by cluster), wired
-  by `server`.
+  by `server`. Also the base-layer views: `/api/artifacts` classifies every
+  OCIRepository by its URL (product syncroot / admin syncroot / infra /
+  operator — the URL is the only identity these artifacts carry) with the
+  deploying Kustomizations attached, and
+  `/api/kustomizations/{cluster}/{ns}/{name}/inventory` expands a
+  Kustomization's applied-object set enriched with mirrored status.
 - `test/e2e` — `e2e`-tagged store + central tests run against Kind Postgres.
 - `config/kind/postgres.yaml` — trust-auth Postgres for the e2e.

--- a/services/dis-console/Dockerfile
+++ b/services/dis-console/Dockerfile
@@ -1,5 +1,5 @@
 # Build the dis-console binary
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -89,6 +89,8 @@ the detail endpoint is not populated yet.)
 | GET | `/api/kustomizations?cluster=` | server | alias for `?kind=Kustomization` |
 | GET | `/api/helmreleases?cluster=` | server | alias for `?kind=HelmRelease` |
 | GET | `/api/resources/{cluster}/{kind}/{namespace}/{name}` | server | single row incl. the full `raw` object (status `history` pending) |
+| GET | `/api/artifacts?cluster=&class=` | server | base-layer OCI artifacts: every OCIRepository classified by URL (`product-syncroot`, `admin-syncroot`, `infra`, `operator`, `other`) with fetched revision (`tag@sha256:…`), pushed git origin, and the deploying Kustomizations |
+| GET | `/api/kustomizations/{cluster}/{namespace}/{name}/inventory` | server | a Kustomization's applied-object set (Flux `status.inventory`) expanded, each entry enriched with the mirrored row when it is a swept kind |
 
 ## Database & auth
 

--- a/services/dis-console/internal/api/artifacts.go
+++ b/services/dis-console/internal/api/artifacts.go
@@ -1,0 +1,250 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/central"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
+)
+
+// Artifact classes derived from the OCI URL path — the only identity a
+// base-layer artifact carries (neither the CRs nor the artifacts have product
+// or team labels). The fleet's conventions: product syncroots live at
+// <product>/syncroot (the dis_products_syncroot_multitenancy fluxConfiguration
+// module), admin syncroots at <ns>/syncroot-admin, gitops-manifests packages
+// at manifests/infra/<pkg>, and operator kustomize configs at
+// dis/kustomize/<operator>.
+const (
+	ClassProductSyncroot = "product-syncroot"
+	ClassAdminSyncroot   = "admin-syncroot"
+	ClassInfra           = "infra"
+	ClassOperator        = "operator"
+	ClassOther           = "other"
+)
+
+// classifyArtifact derives (class, owner) from an OCIRepository URL. Owner is
+// the product for the syncroot classes and the package/operator name for the
+// platform classes; empty when the URL matches no convention.
+func classifyArtifact(url string) (class, owner string) {
+	segs := strings.Split(strings.Trim(strings.TrimPrefix(url, "oci://"), "/"), "/")
+	if len(segs) < 2 {
+		return ClassOther, ""
+	}
+	segs = segs[1:] // drop the registry host
+	last := len(segs) - 1
+	switch {
+	case len(segs) >= 2 && segs[last] == "syncroot":
+		return ClassProductSyncroot, strings.Join(segs[:last], "/")
+	case len(segs) >= 2 && segs[last] == "syncroot-admin":
+		return ClassAdminSyncroot, strings.Join(segs[:last], "/")
+	case len(segs) >= 3 && segs[0] == "manifests" && segs[1] == "infra":
+		return ClassInfra, strings.Join(segs[2:], "/")
+	case len(segs) >= 3 && segs[0] == "dis" && segs[1] == "kustomize":
+		return ClassOperator, strings.Join(segs[2:], "/")
+	}
+	return ClassOther, ""
+}
+
+// artifactKustomization is a Kustomization deploying an artifact, as embedded
+// in the artifacts view: identity plus the applied revision and health, enough
+// for a version matrix without a second request.
+type artifactKustomization struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Revision  string `json:"revision,omitempty"`
+	Ready     string `json:"ready"`
+	Reason    string `json:"reason,omitempty"`
+	Suspended bool   `json:"suspended"`
+}
+
+// artifactView is one OCIRepository row served as a base-layer artifact.
+// Revision is the fetched artifact (tag@sha256:… — the digest is the real
+// version; the tags are mutable environment/ring tags), while each attached
+// kustomization's revision is what is actually applied, so a mismatch between
+// the two is a rollout in flight.
+type artifactView struct {
+	Cluster        string                  `json:"cluster"`
+	Namespace      string                  `json:"namespace"`
+	Name           string                  `json:"name"`
+	URL            string                  `json:"url"`
+	Class          string                  `json:"class"`
+	Owner          string                  `json:"owner,omitempty"`
+	Revision       string                  `json:"revision,omitempty"`
+	OriginRevision string                  `json:"originRevision,omitempty"`
+	OriginSource   string                  `json:"originSource,omitempty"`
+	Ready          string                  `json:"ready"`
+	Reason         string                  `json:"reason,omitempty"`
+	Suspended      bool                    `json:"suspended"`
+	Kustomizations []artifactKustomization `json:"kustomizations"`
+}
+
+type artifactsResponse struct {
+	Count     int            `json:"count"`
+	Artifacts []artifactView `json:"artifacts"`
+}
+
+// handleArtifacts serves the base-layer overview: every OCIRepository in the
+// mirror (one cluster when ?cluster= is set), classified by URL, with the
+// Kustomizations that build from it attached. ?class= filters to one class.
+func (s *Server) handleArtifacts(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	cluster, class := q.Get("cluster"), q.Get("class")
+
+	repos, err := s.store.List(r.Context(), cluster, flux.KindOCIRepository, "", "")
+	if err != nil {
+		s.fail(w, "artifacts", err)
+		return
+	}
+	kusts, err := s.store.List(r.Context(), cluster, flux.KindKustomization, "", "")
+	if err != nil {
+		s.fail(w, "artifacts", err)
+		return
+	}
+
+	byRepo := map[string][]artifactKustomization{}
+	for _, k := range kusts {
+		if k.SourceRef == nil || k.SourceRef.Kind != flux.KindOCIRepository {
+			continue
+		}
+		key := repoKey(k.Cluster, k.SourceRef.Namespace, k.SourceRef.Name)
+		byRepo[key] = append(byRepo[key], artifactKustomization{
+			Name:      k.Name,
+			Namespace: k.Namespace,
+			Revision:  k.Revision,
+			Ready:     k.Ready,
+			Reason:    k.Reason,
+			Suspended: k.Suspended,
+		})
+	}
+
+	artifacts := []artifactView{}
+	for _, repo := range repos {
+		c, owner := classifyArtifact(repo.SourceURL)
+		if class != "" && !strings.EqualFold(c, class) {
+			continue
+		}
+		ks := byRepo[repoKey(repo.Cluster, repo.Namespace, repo.Name)]
+		if ks == nil {
+			ks = []artifactKustomization{}
+		}
+		artifacts = append(artifacts, artifactView{
+			Cluster:        repo.Cluster,
+			Namespace:      repo.Namespace,
+			Name:           repo.Name,
+			URL:            repo.SourceURL,
+			Class:          c,
+			Owner:          owner,
+			Revision:       repo.Revision,
+			OriginRevision: repo.OriginRevision,
+			OriginSource:   repo.OriginSource,
+			Ready:          repo.Ready,
+			Reason:         repo.Reason,
+			Suspended:      repo.Suspended,
+			Kustomizations: ks,
+		})
+	}
+	writeJSON(w, http.StatusOK, artifactsResponse{Count: len(artifacts), Artifacts: artifacts})
+}
+
+// repoKey identifies an OCIRepository within a cluster; a Kustomization's
+// projected sourceRef namespace is already default-resolved, so the join is a
+// plain key match.
+func repoKey(cluster, namespace, name string) string {
+	return cluster + "|" + namespace + "|" + name
+}
+
+// inventoryEntryView is one applied object from a Kustomization's inventory,
+// expanded from Flux's compact id. Resource carries the mirrored row when the
+// entry is a kind the agent sweeps (DIS CRs, HelmReleases, nested Flux
+// objects); null for everything else (Deployments, Services, ...).
+type inventoryEntryView struct {
+	Group     string            `json:"group,omitempty"`
+	Kind      string            `json:"kind"`
+	Namespace string            `json:"namespace,omitempty"`
+	Name      string            `json:"name"`
+	Version   string            `json:"version,omitempty"`
+	Resource  *central.Resource `json:"resource,omitempty"`
+}
+
+type inventoryResponse struct {
+	Cluster   string               `json:"cluster"`
+	Namespace string               `json:"namespace"`
+	Name      string               `json:"name"`
+	Revision  string               `json:"revision,omitempty"`
+	Count     int                  `json:"count"`
+	Entries   []inventoryEntryView `json:"entries"`
+}
+
+// handleKustomizationInventory expands one Kustomization's applied-object set
+// (status.inventory) — the full deployment tree of a syncroot or infra package
+// — enriched with the mirrored status of every entry the agent sweeps. Empty
+// entries mean the Kustomization has not recorded an inventory yet.
+func (s *Server) handleKustomizationInventory(w http.ResponseWriter, r *http.Request) {
+	cluster := r.PathValue("cluster")
+	res, err := s.store.Get(r.Context(),
+		cluster, flux.KindKustomization, r.PathValue("namespace"), r.PathValue("name"))
+	if errors.Is(err, central.ErrNotFound) {
+		writeJSON(w, http.StatusNotFound, errorBody("kustomization not found"))
+		return
+	}
+	if err != nil {
+		s.fail(w, "inventory", err)
+		return
+	}
+
+	entries := []inventoryEntryView{}
+	if len(res.Inventory) > 0 {
+		// One cluster-wide list indexes every mirrored row for enrichment; the
+		// payload equals what /api/resources?cluster= already serves.
+		rows, err := s.store.List(r.Context(), cluster, "", "", "")
+		if err != nil {
+			s.fail(w, "inventory", err)
+			return
+		}
+		byKey := make(map[string]*central.Resource, len(rows))
+		for i := range rows {
+			byKey[resourceKey(rows[i].Kind, rows[i].Namespace, rows[i].Name)] = &rows[i]
+		}
+		for _, e := range res.Inventory {
+			v := entryView(e)
+			v.Resource = byKey[resourceKey(v.Kind, v.Namespace, v.Name)]
+			entries = append(entries, v)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, inventoryResponse{
+		Cluster:   cluster,
+		Namespace: res.Namespace,
+		Name:      res.Name,
+		Revision:  res.Revision,
+		Count:     len(entries),
+		Entries:   entries,
+	})
+}
+
+// entryView expands Flux's compact inventory id (`<namespace>_<name>_<group>_
+// <kind>`; namespace empty for cluster-scoped objects, group empty for the
+// core API). Kubernetes names, namespaces and groups cannot contain
+// underscores, so the split is unambiguous; a malformed id (never produced by
+// kustomize-controller) degrades to the raw id in Name so it stays visible.
+func entryView(e flux.InventoryEntry) inventoryEntryView {
+	parts := strings.Split(e.ID, "_")
+	if len(parts) != 4 {
+		return inventoryEntryView{Name: e.ID, Version: e.Version}
+	}
+	return inventoryEntryView{
+		Namespace: parts[0],
+		Name:      parts[1],
+		Group:     parts[2],
+		Kind:      parts[3],
+		Version:   e.Version,
+	}
+}
+
+// resourceKey identifies a mirrored resource within a cluster; kind is folded
+// because inventory ids carry CRD-spelled kinds while rows store them as swept.
+func resourceKey(kind, namespace, name string) string {
+	return strings.ToLower(kind) + "|" + namespace + "|" + name
+}

--- a/services/dis-console/internal/api/artifacts_test.go
+++ b/services/dis-console/internal/api/artifacts_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/central"
+	"github.com/Altinn/altinn-platform/services/dis-console/internal/flux"
+)
+
+// The fixtures use example hosts/teams on purpose; only the path shapes
+// (<owner>/syncroot, manifests/infra/, dis/kustomize/) are the real contract
+// the classifier keys on.
+func TestClassifyArtifact(t *testing.T) {
+	cases := []struct {
+		url, class, owner string
+	}{
+		{"oci://registry.example.com/team-a/syncroot", ClassProductSyncroot, "team-a"},
+		{"oci://registry.example.com/org/team-a/syncroot", ClassProductSyncroot, "org/team-a"},
+		{"oci://registry.example.com/team-a/syncroot-admin", ClassAdminSyncroot, "team-a"},
+		{"oci://registry.example.com/manifests/infra/example-package", ClassInfra, "example-package"},
+		{"oci://registry.example.com/dis/kustomize/example-operator", ClassOperator, "example-operator"},
+		{"oci://registry.example.com/monitoring/dashboards", ClassOther, ""},
+		{"oci://registry.example.com/standalone", ClassOther, ""},
+		{"", ClassOther, ""},
+	}
+	for _, tc := range cases {
+		class, owner := classifyArtifact(tc.url)
+		if class != tc.class || owner != tc.owner {
+			t.Fatalf("classify(%q): got (%q, %q), want (%q, %q)", tc.url, class, owner, tc.class, tc.owner)
+		}
+	}
+}
+
+// artifactsTestServer mirrors a small fleet: a product syncroot on two
+// clusters (one with its deploying Kustomization), an operator artifact, and a
+// git-sourced Kustomization that must not attach to any artifact.
+func artifactsTestServer() *Server {
+	syncrootRepo := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "OCIRepository", Namespace: "product-team-a", Name: "team-a-ab12",
+		Ready: flux.ReadyTrue, Revision: "at23@sha256:abc",
+		SourceURL:      "oci://registry.example.com/team-a/syncroot",
+		OriginRevision: "main/0c2a3b4", OriginSource: "https://git.example.com/team-a/syncroot",
+	}}
+	syncrootKust := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "Kustomization", Namespace: "product-team-a", Name: "team-a-ab12-team-a",
+		Ready: flux.ReadyFalse, Reason: "HealthCheckFailed", Revision: "at23@sha256:old",
+		SourceRef: &flux.SourceRef{Kind: "OCIRepository", Name: "team-a-ab12", Namespace: "product-team-a"},
+	}}
+	operatorRepo := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "OCIRepository", Namespace: "platform-system", Name: "example-operator",
+		Ready: flux.ReadyTrue, Revision: "v1.2.3@sha256:def",
+		SourceURL: "oci://registry.example.com/dis/kustomize/example-operator",
+	}}
+	gitKust := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "Kustomization", Namespace: "flux-system", Name: "from-git",
+		Ready:     flux.ReadyTrue,
+		SourceRef: &flux.SourceRef{Kind: "GitRepository", Name: "repo", Namespace: "flux-system"},
+	}}
+	otherClusterRepo := central.Resource{Cluster: "team-b_at23", Resource: flux.Resource{
+		Kind: "OCIRepository", Namespace: "product-team-b", Name: "team-b-cd34",
+		Ready: flux.ReadyTrue, Revision: "at23@sha256:fed",
+		SourceURL: "oci://registry.example.com/team-b/syncroot",
+	}}
+	s := NewServer(&fakeStore{
+		resources: []central.Resource{syncrootRepo, syncrootKust, operatorRepo, gitKust, otherClusterRepo},
+	}, time.Minute)
+	s.MarkSynced()
+	return s
+}
+
+func getArtifacts(t *testing.T, s *Server, target string) artifactsResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var resp artifactsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+func TestArtifacts(t *testing.T) {
+	s := artifactsTestServer()
+	resp := getArtifacts(t, s, "/api/artifacts")
+	if resp.Count != 3 {
+		t.Fatalf("expected 3 artifacts, got %d: %+v", resp.Count, resp.Artifacts)
+	}
+
+	byName := map[string]artifactView{}
+	for _, a := range resp.Artifacts {
+		byName[a.Name] = a
+	}
+
+	syncroot := byName["team-a-ab12"]
+	if syncroot.Class != ClassProductSyncroot || syncroot.Owner != "team-a" {
+		t.Fatalf("unexpected syncroot classification: %+v", syncroot)
+	}
+	if syncroot.Revision != "at23@sha256:abc" || syncroot.OriginRevision != "main/0c2a3b4" {
+		t.Fatalf("unexpected syncroot versions: %+v", syncroot)
+	}
+	if len(syncroot.Kustomizations) != 1 {
+		t.Fatalf("expected the deploying kustomization attached, got %+v", syncroot.Kustomizations)
+	}
+	k := syncroot.Kustomizations[0]
+	if k.Name != "team-a-ab12-team-a" || k.Revision != "at23@sha256:old" || k.Ready != flux.ReadyFalse {
+		t.Fatalf("unexpected attached kustomization: %+v", k)
+	}
+
+	operator := byName["example-operator"]
+	if operator.Class != ClassOperator || operator.Owner != "example-operator" {
+		t.Fatalf("unexpected operator classification: %+v", operator)
+	}
+	if operator.Kustomizations == nil || len(operator.Kustomizations) != 0 {
+		t.Fatalf("expected empty (non-null) kustomizations, got %+v", operator.Kustomizations)
+	}
+}
+
+func TestArtifactsFilters(t *testing.T) {
+	s := artifactsTestServer()
+
+	resp := getArtifacts(t, s, "/api/artifacts?cluster=team-b_at23")
+	if resp.Count != 1 || resp.Artifacts[0].Cluster != "team-b_at23" {
+		t.Fatalf("unexpected cluster filter result: %+v", resp)
+	}
+
+	resp = getArtifacts(t, s, "/api/artifacts?class=product-syncroot")
+	if resp.Count != 2 {
+		t.Fatalf("expected 2 product syncroots, got %+v", resp)
+	}
+	for _, a := range resp.Artifacts {
+		if a.Class != ClassProductSyncroot {
+			t.Fatalf("class filter leaked %+v", a)
+		}
+	}
+}
+
+// inventoryTestServer holds one Kustomization whose inventory spans a swept
+// DIS kind (enriched), an unswept Deployment, and a cluster-scoped object.
+func inventoryTestServer() *Server {
+	kust := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "Kustomization", Namespace: "product-team-a", Name: "team-a-ab12-team-a",
+		Ready: flux.ReadyTrue, Revision: "at23@sha256:abc",
+		Inventory: []flux.InventoryEntry{
+			{ID: "product-team-a_appdb_storage.dis.altinn.cloud_Database", Version: "v1alpha1"},
+			{ID: "product-team-a_app_apps_Deployment", Version: "v1"},
+			{ID: "_allow-all_kyverno.io_ClusterPolicy", Version: "v1"},
+		},
+	}}
+	empty := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "Kustomization", Namespace: "product-team-a", Name: "never-reconciled",
+		Ready: flux.ReadyUnknown,
+	}}
+	db := central.Resource{Cluster: "team-a_at23", Resource: flux.Resource{
+		Kind: "Database", Namespace: "product-team-a", Name: "appdb",
+		Ready: flux.ReadyTrue, Parent: &flux.ParentRef{Kind: "DatabaseServer", Name: "pg-main"},
+	}}
+	s := NewServer(&fakeStore{resources: []central.Resource{kust, empty, db}}, time.Minute)
+	s.MarkSynced()
+	return s
+}
+
+func getInventory(t *testing.T, s *Server, target string) (int, inventoryResponse) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.Routes().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+	var resp inventoryResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+	}
+	return rec.Code, resp
+}
+
+func TestKustomizationInventory(t *testing.T) {
+	s := inventoryTestServer()
+	code, resp := getInventory(t, s, "/api/kustomizations/team-a_at23/product-team-a/team-a-ab12-team-a/inventory")
+	if code != http.StatusOK {
+		t.Fatalf("status: %d", code)
+	}
+	if resp.Count != 3 || resp.Revision != "at23@sha256:abc" {
+		t.Fatalf("unexpected inventory response: %+v", resp)
+	}
+
+	swept := resp.Entries[0]
+	if swept.Kind != "Database" || swept.Namespace != "product-team-a" || swept.Name != "appdb" ||
+		swept.Group != "storage.dis.altinn.cloud" || swept.Version != "v1alpha1" {
+		t.Fatalf("unexpected expanded entry: %+v", swept)
+	}
+	if swept.Resource == nil || swept.Resource.Ready != flux.ReadyTrue || swept.Resource.Parent == nil {
+		t.Fatalf("swept entry should carry the mirrored row: %+v", swept.Resource)
+	}
+
+	unswept := resp.Entries[1]
+	if unswept.Kind != "Deployment" || unswept.Group != "apps" || unswept.Resource != nil {
+		t.Fatalf("unswept entry should expand without a mirrored row: %+v", unswept)
+	}
+
+	clusterScoped := resp.Entries[2]
+	if clusterScoped.Kind != "ClusterPolicy" || clusterScoped.Namespace != "" || clusterScoped.Name != "allow-all" {
+		t.Fatalf("unexpected cluster-scoped entry: %+v", clusterScoped)
+	}
+}
+
+func TestKustomizationInventoryEmpty(t *testing.T) {
+	s := inventoryTestServer()
+	code, resp := getInventory(t, s, "/api/kustomizations/team-a_at23/product-team-a/never-reconciled/inventory")
+	if code != http.StatusOK {
+		t.Fatalf("status: %d", code)
+	}
+	if resp.Count != 0 || resp.Entries == nil || len(resp.Entries) != 0 {
+		t.Fatalf("expected empty (non-null) entries, got %+v", resp)
+	}
+}
+
+func TestKustomizationInventoryNotFound(t *testing.T) {
+	s := inventoryTestServer()
+	code, _ := getInventory(t, s, "/api/kustomizations/team-a_at23/product-team-a/missing/inventory")
+	if code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", code)
+	}
+}

--- a/services/dis-console/internal/api/server.go
+++ b/services/dis-console/internal/api/server.go
@@ -59,7 +59,9 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /api/resources", s.handleResources)
 	mux.HandleFunc("GET /api/resources/{cluster}/{kind}/{namespace}/{name}", s.handleResourceDetail)
 	mux.HandleFunc("GET /api/kustomizations", s.handleKustomizations)
+	mux.HandleFunc("GET /api/kustomizations/{cluster}/{namespace}/{name}/inventory", s.handleKustomizationInventory)
 	mux.HandleFunc("GET /api/helmreleases", s.handleHelmReleases)
+	mux.HandleFunc("GET /api/artifacts", s.handleArtifacts)
 	return mux
 }
 

--- a/services/dis-console/internal/api/server_test.go
+++ b/services/dis-console/internal/api/server_test.go
@@ -78,7 +78,9 @@ func (f *fakeStore) List(_ context.Context, cluster, kind, namespace, ready stri
 		if ready != "" && !strings.EqualFold(r.Ready, ready) {
 			continue
 		}
+		// The SQL list omits the detail-only payloads.
 		r.Raw = nil
+		r.Inventory = nil
 		out = append(out, r)
 	}
 	return out, nil

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -114,6 +114,8 @@ INSERT INTO flux_resource (
     generation, observed_generation, last_transition, raw, content_hash,
     azure_resource_id, parent_kind, parent_name,
     applied_by_name, applied_by_namespace,
+    source_ref_kind, source_ref_name, source_ref_namespace,
+    source_url, origin_revision, origin_source, inventory,
     updated_at, synced_at
 ) VALUES (
     $1, $2, $3, $4, $5,
@@ -121,7 +123,9 @@ INSERT INTO flux_resource (
     $11, $12, $13, $14, $15,
     $16, $17, $18,
     $19, $20,
-    $21, now()
+    $21, $22, $23,
+    $24, $25, $26, $27,
+    $28, now()
 )
 ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
     api_version          = EXCLUDED.api_version,
@@ -134,6 +138,13 @@ ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
     parent_name          = EXCLUDED.parent_name,
     applied_by_name      = EXCLUDED.applied_by_name,
     applied_by_namespace = EXCLUDED.applied_by_namespace,
+    source_ref_kind      = EXCLUDED.source_ref_kind,
+    source_ref_name      = EXCLUDED.source_ref_name,
+    source_ref_namespace = EXCLUDED.source_ref_namespace,
+    source_url           = EXCLUDED.source_url,
+    origin_revision      = EXCLUDED.origin_revision,
+    origin_source        = EXCLUDED.origin_source,
+    inventory            = EXCLUDED.inventory,
     suspended            = EXCLUDED.suspended,
     generation           = EXCLUDED.generation,
     observed_generation  = EXCLUDED.observed_generation,
@@ -206,12 +217,19 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 			}
 			parentKind, parentName := parentCols(c.Parent)
 			appliedByName, appliedByNamespace := appliedByCols(c.AppliedBy)
+			sourceRefKind, sourceRefName, sourceRefNamespace := sourceRefCols(c.SourceRef)
+			inventory, err := inventoryParam(c.Inventory)
+			if err != nil {
+				return fmt.Errorf("%s %s/%s: %w", c.Kind, c.Namespace, c.Name, err)
+			}
 			batch.Queue(upsertStmt,
 				st.Cluster, c.Kind, c.APIVersion, c.Namespace, c.Name,
 				c.Ready, c.Reason, c.Message, c.Revision, c.Suspended,
 				c.Generation, c.ObservedGeneration, c.LastTransition, []byte(raw), c.ContentHash,
 				c.AzureResourceID, parentKind, parentName,
 				appliedByName, appliedByNamespace,
+				sourceRefKind, sourceRefName, sourceRefNamespace,
+				nullable(c.SourceURL), nullable(c.OriginRevision), nullable(c.OriginSource), inventory,
 				c.UpdatedAt,
 			)
 		}
@@ -322,6 +340,56 @@ func appliedByRef(name, namespace *string) *flux.AppliedBy {
 		return nil
 	}
 	return &flux.AppliedBy{Name: *name, Namespace: *namespace}
+}
+
+// sourceRefCols splits an optional source ref into its nullable column triple.
+func sourceRefCols(sr *flux.SourceRef) (kind, name, namespace *string) {
+	if sr == nil {
+		return nil, nil, nil
+	}
+	return &sr.Kind, &sr.Name, &sr.Namespace
+}
+
+// sourceRefFrom rebuilds the optional source ref from its nullable columns.
+func sourceRefFrom(kind, name, namespace *string) *flux.SourceRef {
+	if kind == nil || name == nil || namespace == nil {
+		return nil
+	}
+	return &flux.SourceRef{Kind: *kind, Name: *name, Namespace: *namespace}
+}
+
+// nullable maps "" to NULL, mirroring the tenant store's storage of the
+// base-layer string columns.
+func nullable(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// inventoryParam marshals the inventory for its jsonb column; SQL NULL when
+// the resource has none.
+func inventoryParam(entries []flux.InventoryEntry) (any, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(entries)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inventory: %w", err)
+	}
+	return b, nil
+}
+
+// inventoryFrom rebuilds the inventory from its jsonb column; nil when NULL.
+func inventoryFrom(raw []byte) ([]flux.InventoryEntry, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var entries []flux.InventoryEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("unmarshal inventory: %w", err)
+	}
+	return entries, nil
 }
 
 // clusterID strips the tenant-database prefix to get the cluster identifier
@@ -467,7 +535,9 @@ const listStmt = `
 SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
-       applied_by_name, applied_by_namespace
+       applied_by_name, applied_by_namespace,
+       source_ref_kind, source_ref_name, source_ref_namespace,
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, '')
 FROM flux_resource
 WHERE ($1 = '' OR cluster = $1)
   AND ($2 = '' OR lower(kind) = lower($2))
@@ -475,10 +545,11 @@ WHERE ($1 = '' OR cluster = $1)
   AND ($4 = '' OR lower(ready) = lower($4))
 ORDER BY cluster, kind, namespace, name`
 
-// List returns matching resources (without the raw payload) across the fleet,
-// or for one cluster when cluster is non-empty. An empty kind/namespace/ready
-// means "any". appliedBy rides in the list payload so the UI can group child
-// HelmReleases under their parent Kustomization without fetching detail.
+// List returns matching resources (without the raw and inventory payloads)
+// across the fleet, or for one cluster when cluster is non-empty. An empty
+// kind/namespace/ready means "any". appliedBy rides in the list payload so the
+// UI can group child HelmReleases under their parent Kustomization without
+// fetching detail; sourceRef/sourceUrl/origin ride for the artifacts view.
 func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string) ([]Resource, error) {
 	rows, err := s.pool.Query(ctx, listStmt, cluster, kind, namespace, ready)
 	if err != nil {
@@ -491,17 +562,21 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 		var r Resource
 		var parentKind, parentName *string
 		var appliedByName, appliedByNamespace *string
+		var sourceRefKind, sourceRefName, sourceRefNamespace *string
 		if err := rows.Scan(
 			&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 			&r.ObservedGeneration, &r.LastTransition,
 			&r.AzureResourceID, &parentKind, &parentName,
 			&appliedByName, &appliedByNamespace,
+			&sourceRefKind, &sourceRefName, &sourceRefNamespace,
+			&r.SourceURL, &r.OriginRevision, &r.OriginSource,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		r.Parent = parentRef(parentKind, parentName)
 		r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
+		r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -511,23 +586,30 @@ const getStmt = `
 SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
-       applied_by_name, applied_by_namespace
+       applied_by_name, applied_by_namespace,
+       source_ref_kind, source_ref_name, source_ref_namespace,
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
+       inventory
 FROM flux_resource
 WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
 
-// Get returns one resource (including its raw payload) in a cluster, or
-// ErrNotFound when no row matches.
+// Get returns one resource (including its raw and inventory payloads) in a
+// cluster, or ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) (*Resource, error) {
 	var r Resource
-	var raw []byte
+	var raw, inventory []byte
 	var parentKind, parentName *string
 	var appliedByName, appliedByNamespace *string
+	var sourceRefKind, sourceRefName, sourceRefNamespace *string
 	err := s.pool.QueryRow(ctx, getStmt, cluster, kind, namespace, name).Scan(
 		&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 		&r.ObservedGeneration, &r.LastTransition, &raw,
 		&r.AzureResourceID, &parentKind, &parentName,
 		&appliedByName, &appliedByNamespace,
+		&sourceRefKind, &sourceRefName, &sourceRefNamespace,
+		&r.SourceURL, &r.OriginRevision, &r.OriginSource,
+		&inventory,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -538,6 +620,10 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 	r.Raw = raw
 	r.Parent = parentRef(parentKind, parentName)
 	r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
+	r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
+	if r.Inventory, err = inventoryFrom(inventory); err != nil {
+		return nil, err
+	}
 	return &r, nil
 }
 

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -110,8 +110,8 @@ func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
 	if err != nil {
 		return err
 	}
-	// The pull is keyed on the tenant's schema version: a version-2 tenant
-	// (agent not yet migrated) lacks the applied-by columns, so selecting
+	// The pull is keyed on the tenant's schema version: a version-3 tenant
+	// (agent not yet migrated) lacks the base-layer columns, so selecting
 	// them would fail the cluster's sync until its agent rolls out.
 	changed, err := ts.ChangedSince(ctx, cursor, meta.SchemaVersion)
 	if err != nil {

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -13,6 +13,13 @@ CREATE TABLE IF NOT EXISTS flux_resource (
     parent_name          text,
     applied_by_name      text,
     applied_by_namespace text,
+    source_ref_kind      text,
+    source_ref_name      text,
+    source_ref_namespace text,
+    source_url           text,
+    origin_revision      text,
+    origin_source        text,
+    inventory            jsonb,
     suspended            boolean     NOT NULL DEFAULT false,
     generation           bigint,
     observed_generation  bigint,
@@ -63,3 +70,10 @@ ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_kind text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_name text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_name text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_namespace text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_ref_kind text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_ref_name text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_ref_namespace text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_url text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_revision text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_source text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS inventory jsonb;

--- a/services/dis-console/internal/flux/normalize.go
+++ b/services/dis-console/internal/flux/normalize.go
@@ -48,12 +48,33 @@ type Resource struct {
 	// controller stamps on everything it applies, so the list endpoint (which
 	// omits Raw) can group child resources under their parent app. Empty for
 	// roots and Arc-managed objects, which carry no such labels.
-	AppliedBy          *AppliedBy      `json:"appliedBy,omitempty"`
-	Suspended          bool            `json:"suspended"`
-	Generation         int64           `json:"generation,omitempty"`
-	ObservedGeneration int64           `json:"observedGeneration,omitempty"`
-	LastTransition     *time.Time      `json:"lastTransition,omitempty"`
-	Raw                json.RawMessage `json:"raw,omitempty"`
+	AppliedBy *AppliedBy `json:"appliedBy,omitempty"`
+	// SourceRef is the Flux source a Kustomization builds from — the join key
+	// from a Kustomization row to the OCIRepository row holding the base-layer
+	// artifact it deploys. Nil for every other kind.
+	SourceRef *SourceRef `json:"sourceRef,omitempty"`
+	// SourceURL is a source kind's artifact URL (OCIRepository/HelmRepository
+	// spec.url). It is the only identity a base-layer artifact carries — the
+	// CRs have no product/team labels — so the artifacts view classifies on it.
+	SourceURL string `json:"sourceUrl,omitempty"`
+	// OriginRevision/OriginSource are the artifact's org.opencontainers.image
+	// revision/source annotations (stamped by `flux push artifact --revision
+	// --source`), surfaced by source-controller in status.artifact.metadata:
+	// the git branch/SHA and repository behind the artifact digest. Empty when
+	// the pusher did not annotate.
+	OriginRevision     string     `json:"originRevision,omitempty"`
+	OriginSource       string     `json:"originSource,omitempty"`
+	Suspended          bool       `json:"suspended"`
+	Generation         int64      `json:"generation,omitempty"`
+	ObservedGeneration int64      `json:"observedGeneration,omitempty"`
+	LastTransition     *time.Time `json:"lastTransition,omitempty"`
+	// Inventory is a Kustomization's applied-object set (status.inventory) —
+	// the parent→children edge of the deployment tree, covering kinds the agent
+	// does not sweep. Like Raw it is served on detail endpoints only; list
+	// payloads omit it. Kept in Flux's compact entry shape (the source object
+	// is bounded by etcd, so the projection needs no cap of its own).
+	Inventory []InventoryEntry `json:"inventory,omitempty"`
+	Raw       json.RawMessage  `json:"raw,omitempty"`
 	// ContentHash is a stable digest of the full object (after volatile
 	// metadata is stripped). The store rewrites a row's raw payload only when
 	// this changes, so unchanged objects don't churn the database every sweep.
@@ -82,6 +103,33 @@ type AppliedBy struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
+
+// SourceRef identifies the Flux source a Kustomization builds from
+// (spec.sourceRef). Namespace is resolved to the Kustomization's own namespace
+// when the reference omits it, so consumers can join without knowing the
+// defaulting rule. The JSON shape is part of the UI contract.
+type SourceRef struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// InventoryEntry is one applied-object reference from a Kustomization's
+// status.inventory, in Flux's compact wire shape: ID is
+// `<namespace>_<name>_<group>_<kind>` (namespace empty for cluster-scoped
+// objects) and Version the object's API version. The API expands it when
+// serving; the store keeps the compact form.
+type InventoryEntry struct {
+	ID      string `json:"id"`
+	Version string `json:"v"`
+}
+
+// Annotation keys `flux push artifact` stamps on an artifact and
+// source-controller copies into status.artifact.metadata.
+const (
+	annotationOriginRevision = "org.opencontainers.image.revision"
+	annotationOriginSource   = "org.opencontainers.image.source"
+)
 
 // normalize projects an unstructured Flux object into a Resource. The fetch
 // stays dynamic (discovery-resolved, version-agnostic) and the full object is
@@ -138,6 +186,8 @@ func (r *Resource) applyTypedStatus(u *unstructured.Unstructured) error {
 			revision = o.Status.LastAttemptedRevision
 		}
 		r.applyStatus(o.Spec.Suspend, o.Status.ObservedGeneration, o.Status.Conditions, revision)
+		r.SourceRef = kustomizationSourceRef(&o)
+		r.Inventory = inventoryEntries(o.Status.Inventory)
 	case KindHelmRelease:
 		var o helmv2.HelmRelease
 		if err := fromUnstructured(u, &o); err != nil {
@@ -157,12 +207,15 @@ func (r *Resource) applyTypedStatus(u *unstructured.Unstructured) error {
 			return err
 		}
 		r.applyStatus(o.Spec.Suspend, o.Status.ObservedGeneration, o.Status.Conditions, artifactRevision(o.Status.Artifact))
+		r.SourceURL = o.Spec.URL
+		r.OriginRevision, r.OriginSource = artifactOrigin(o.Status.Artifact)
 	case KindHelmRepository:
 		var o sourcev1.HelmRepository
 		if err := fromUnstructured(u, &o); err != nil {
 			return err
 		}
 		r.applyStatus(o.Spec.Suspend, o.Status.ObservedGeneration, o.Status.Conditions, artifactRevision(o.Status.Artifact))
+		r.SourceURL = o.Spec.URL
 	case KindHelmChart:
 		var o sourcev1.HelmChart
 		if err := fromUnstructured(u, &o); err != nil {
@@ -201,6 +254,44 @@ func artifactRevision(a *fluxmeta.Artifact) string {
 		return ""
 	}
 	return a.Revision
+}
+
+// artifactOrigin extracts the artifact's origin annotations — the git
+// branch/SHA and repository the artifact was pushed from. Empty when the
+// pusher did not annotate (only `flux push artifact --revision --source`
+// stamps them).
+func artifactOrigin(a *fluxmeta.Artifact) (revision, source string) {
+	if a == nil {
+		return "", ""
+	}
+	return a.Metadata[annotationOriginRevision], a.Metadata[annotationOriginSource]
+}
+
+// kustomizationSourceRef projects spec.sourceRef with the namespace default
+// resolved (an omitted namespace means the Kustomization's own).
+func kustomizationSourceRef(o *kustomizev1.Kustomization) *SourceRef {
+	ref := o.Spec.SourceRef
+	if ref.Name == "" {
+		return nil
+	}
+	ns := ref.Namespace
+	if ns == "" {
+		ns = o.Namespace
+	}
+	return &SourceRef{Kind: ref.Kind, Name: ref.Name, Namespace: ns}
+}
+
+// inventoryEntries projects status.inventory into the stored entry shape; nil
+// when the Kustomization has not recorded an inventory (never reconciled).
+func inventoryEntries(inv *kustomizev1.ResourceInventory) []InventoryEntry {
+	if inv == nil || len(inv.Entries) == 0 {
+		return nil
+	}
+	out := make([]InventoryEntry, len(inv.Entries))
+	for i, e := range inv.Entries {
+		out[i] = InventoryEntry{ID: e.ID, Version: e.Version}
+	}
+	return out
 }
 
 // appliedByFrom projects the kustomize-controller ownership labels into an

--- a/services/dis-console/internal/flux/normalize_test.go
+++ b/services/dis-console/internal/flux/normalize_test.go
@@ -309,6 +309,133 @@ func TestNormalizeAppliedByEmptyWithoutLabels(t *testing.T) {
 	}
 }
 
+// The base-layer projections: a Kustomization's sourceRef (namespace
+// defaulted to its own) and its applied-object inventory, kept in Flux's
+// compact entry shape.
+func TestNormalizeKustomizationSourceRefAndInventory(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"namespace": "product-team-a", "name": "team-a-ab12-team-a"},
+		"spec": map[string]any{
+			"sourceRef": map[string]any{"kind": "OCIRepository", "name": "team-a-ab12"},
+		},
+		"status": map[string]any{
+			"inventory": map[string]any{
+				"entries": []any{
+					map[string]any{"id": "product-team-a_appdb_storage.dis.altinn.cloud_Database", "v": "v1alpha1"},
+					map[string]any{"id": "product-team-a_app_apps_Deployment", "v": "v1"},
+				},
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.SourceRef == nil || r.SourceRef.Kind != KindOCIRepository || r.SourceRef.Name != "team-a-ab12" {
+		t.Fatalf("unexpected sourceRef: %+v", r.SourceRef)
+	}
+	if r.SourceRef.Namespace != "product-team-a" {
+		t.Fatalf("sourceRef namespace should default to the Kustomization's own, got %q", r.SourceRef.Namespace)
+	}
+	if len(r.Inventory) != 2 ||
+		r.Inventory[0].ID != "product-team-a_appdb_storage.dis.altinn.cloud_Database" ||
+		r.Inventory[0].Version != "v1alpha1" ||
+		r.Inventory[1].ID != "product-team-a_app_apps_Deployment" {
+		t.Fatalf("unexpected inventory: %+v", r.Inventory)
+	}
+}
+
+// An explicit cross-namespace sourceRef is kept as-is; a Kustomization without
+// an inventory (never reconciled) projects nil so the JSON omits the field.
+func TestNormalizeKustomizationSourceRefExplicitNamespace(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"namespace": "platform-system", "name": "example-operator"},
+		"spec": map[string]any{
+			"sourceRef": map[string]any{"kind": "OCIRepository", "name": "example-operator", "namespace": "flux-system"},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.SourceRef == nil || r.SourceRef.Namespace != "flux-system" {
+		t.Fatalf("explicit sourceRef namespace should be kept, got %+v", r.SourceRef)
+	}
+	if r.Inventory != nil {
+		t.Fatalf("expected nil inventory without status.inventory, got %+v", r.Inventory)
+	}
+}
+
+// A source kind's url and the artifact's origin annotations (git revision and
+// repository, stamped by `flux push artifact`) — the identity + provenance of
+// a base-layer artifact. The mutable tag rides in revision; the digest there
+// is the real version.
+func TestNormalizeOCIRepositoryURLAndOrigin(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "OCIRepository",
+		"metadata":   map[string]any{"namespace": "product-team-a", "name": "team-a-ab12"},
+		"spec":       map[string]any{"url": "oci://registry.example.com/team-a/syncroot"},
+		"status": map[string]any{
+			"artifact": map[string]any{
+				"revision": "at23@sha256:abc123",
+				"metadata": map[string]any{
+					"org.opencontainers.image.revision": "main/0c2a3b4",
+					"org.opencontainers.image.source":   "https://git.example.com/team-a/syncroot",
+				},
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.SourceURL != "oci://registry.example.com/team-a/syncroot" {
+		t.Fatalf("unexpected sourceUrl: %q", r.SourceURL)
+	}
+	if r.Revision != "at23@sha256:abc123" {
+		t.Fatalf("unexpected revision: %q", r.Revision)
+	}
+	if r.OriginRevision != "main/0c2a3b4" || r.OriginSource != "https://git.example.com/team-a/syncroot" {
+		t.Fatalf("unexpected origin: %q %q", r.OriginRevision, r.OriginSource)
+	}
+	if r.SourceRef != nil {
+		t.Fatalf("sourceRef is a Kustomization projection, got %+v", r.SourceRef)
+	}
+}
+
+// A HelmRepository projects its url too; an artifact without the origin
+// annotations (not pushed by flux push) stays empty.
+func TestNormalizeHelmRepositoryURLWithoutOrigin(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "HelmRepository",
+		"metadata":   map[string]any{"namespace": "platform-system", "name": "example-charts"},
+		"spec":       map[string]any{"url": "https://charts.example.com"},
+		"status": map[string]any{
+			"artifact": map[string]any{"revision": "sha256:abc"},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.SourceURL != "https://charts.example.com" {
+		t.Fatalf("unexpected sourceUrl: %q", r.SourceURL)
+	}
+	if r.OriginRevision != "" || r.OriginSource != "" {
+		t.Fatalf("expected empty origin without annotations, got %q %q", r.OriginRevision, r.OriginSource)
+	}
+}
+
 func TestNormalizeOCIRepositoryRevisionFromArtifact(t *testing.T) {
 	u := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "source.toolkit.fluxcd.io/v1",

--- a/services/dis-console/internal/store/schema.sql
+++ b/services/dis-console/internal/store/schema.sql
@@ -12,6 +12,13 @@ CREATE TABLE IF NOT EXISTS flux_resource (
     parent_name          text,
     applied_by_name      text,
     applied_by_namespace text,
+    source_ref_kind      text,
+    source_ref_name      text,
+    source_ref_namespace text,
+    source_url           text,
+    origin_revision      text,
+    origin_source        text,
+    inventory            jsonb,
     suspended            boolean     NOT NULL DEFAULT false,
     generation           bigint,
     observed_generation  bigint,
@@ -30,6 +37,13 @@ ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_kind text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS parent_name text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_name text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS applied_by_namespace text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_ref_kind text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_ref_name text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_ref_namespace text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_url text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_revision text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_source text;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS inventory jsonb;
 
 CREATE INDEX IF NOT EXISTS idx_flux_resource_ready ON flux_resource (lower(ready));
 CREATE INDEX IF NOT EXISTS idx_flux_resource_kind  ON flux_resource (lower(kind));

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -57,11 +57,14 @@ func (s *Store) Migrate(ctx context.Context) error {
 //
 // Version 2 added the DIS projection columns (azure_resource_id, parent_kind,
 // parent_name). Version 3 added the applied-by columns (applied_by_name,
-// applied_by_namespace — the owning Kustomization). ChangedSince selects per
-// version so the server can still pull version-2 tenants whose agents have not
-// migrated yet; version 1 fell out of the supported window (schemaSupported
-// covers the current version and the previous one).
-const SchemaVersion = 3
+// applied_by_namespace — the owning Kustomization). Version 4 added the
+// base-layer columns (source_ref_*, source_url, origin_revision,
+// origin_source, inventory — the artifact identity and applied-object set
+// behind the artifacts view). ChangedSince selects per version so the server
+// can still pull version-3 tenants whose agents have not migrated yet;
+// version 2 fell out of the supported window (schemaSupported covers the
+// current version and the previous one).
+const SchemaVersion = 4
 
 // Meta is the single bookkeeping row each agent maintains in its tenant DB.
 type Meta struct {
@@ -147,6 +150,58 @@ func appliedByRef(name, namespace *string) *flux.AppliedBy {
 	return &flux.AppliedBy{Name: *name, Namespace: *namespace}
 }
 
+// sourceRefCols splits an optional source ref into its nullable column triple.
+func sourceRefCols(sr *flux.SourceRef) (kind, name, namespace *string) {
+	if sr == nil {
+		return nil, nil, nil
+	}
+	return &sr.Kind, &sr.Name, &sr.Namespace
+}
+
+// sourceRefFrom rebuilds the optional source ref from its nullable columns.
+func sourceRefFrom(kind, name, namespace *string) *flux.SourceRef {
+	if kind == nil || name == nil || namespace == nil {
+		return nil
+	}
+	return &flux.SourceRef{Kind: *kind, Name: *name, Namespace: *namespace}
+}
+
+// nullable maps "" to NULL. The base-layer string columns are stored NULL when
+// the projection is absent so the upsert's updated_at backfill comparison stays
+// quiet for the many rows that never carry them (NULL = NULL), instead of
+// re-mirroring the whole fleet once over ” vs NULL.
+func nullable(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// inventoryParam marshals the inventory for its jsonb column; SQL NULL when the
+// resource has none.
+func inventoryParam(entries []flux.InventoryEntry) (any, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(entries)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inventory: %w", err)
+	}
+	return b, nil
+}
+
+// inventoryFrom rebuilds the inventory from its jsonb column; nil when NULL.
+func inventoryFrom(raw []byte) ([]flux.InventoryEntry, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var entries []flux.InventoryEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("unmarshal inventory: %w", err)
+	}
+	return entries, nil
+}
+
 // upsertStmt upserts one resource and, in the same statement, writes a history
 // event when the row is new or its ready/reason/revision changed. The `prev`
 // CTE reads the pre-upsert row (CTEs see the snapshot from the start of the
@@ -161,15 +216,17 @@ func appliedByRef(name, namespace *string) *flux.AppliedBy {
 // existing TOAST datum. last_seen is always bumped so prune can tell which rows
 // were seen this sweep.
 //
-// updated_at additionally advances when the applied-by pair differs from the
-// stored value. The hash covers the object, not the agent's projection of it:
-// when a projection change (like adding appliedBy) starts deriving new columns
-// from labels that were already in the hashed object, every pre-existing row
-// gets the new columns with an unchanged hash — and the server's incremental
-// pull (updated_at > cursor) would never mirror them. The extra comparison
-// backfills each such row exactly once and is quiet steady-state (a real label
-// change also changes the hash). Any future projection derived from existing
-// object content must extend this CASE the same way.
+// updated_at additionally advances when a projection-only column (the
+// applied-by pair and the base-layer columns) differs from the stored value.
+// The hash covers the object, not the agent's projection of it: when a
+// projection change (like adding appliedBy, or the v4 base-layer fields)
+// starts deriving new columns from content that was already in the hashed
+// object, every pre-existing row gets the new columns with an unchanged hash —
+// and the server's incremental pull (updated_at > cursor) would never mirror
+// them. The extra comparisons backfill each such row exactly once and are
+// quiet steady-state (a real content change also changes the hash). Any future
+// projection derived from existing object content must extend this CASE the
+// same way.
 const upsertStmt = `
 WITH prev AS (
     SELECT ready, reason, revision
@@ -183,6 +240,8 @@ up AS (
         generation, observed_generation, last_transition, raw, content_hash,
         azure_resource_id, parent_kind, parent_name,
         applied_by_name, applied_by_namespace,
+        source_ref_kind, source_ref_name, source_ref_namespace,
+        source_url, origin_revision, origin_source, inventory,
         first_seen, last_seen, updated_at
     ) VALUES (
         $1, $2, $3, $4,
@@ -190,6 +249,8 @@ up AS (
         $10, $11, $12, $13, $14,
         $15, $16, $17,
         $18, $19,
+        $20, $21, $22,
+        $23, $24, $25, $26,
         now(), now(), now()
     )
     ON CONFLICT (kind, namespace, name) DO UPDATE SET
@@ -203,6 +264,13 @@ up AS (
         parent_name          = EXCLUDED.parent_name,
         applied_by_name      = EXCLUDED.applied_by_name,
         applied_by_namespace = EXCLUDED.applied_by_namespace,
+        source_ref_kind      = EXCLUDED.source_ref_kind,
+        source_ref_name      = EXCLUDED.source_ref_name,
+        source_ref_namespace = EXCLUDED.source_ref_namespace,
+        source_url           = EXCLUDED.source_url,
+        origin_revision      = EXCLUDED.origin_revision,
+        origin_source        = EXCLUDED.origin_source,
+        inventory            = EXCLUDED.inventory,
         suspended            = EXCLUDED.suspended,
         generation           = EXCLUDED.generation,
         observed_generation  = EXCLUDED.observed_generation,
@@ -216,6 +284,13 @@ up AS (
             WHEN r.content_hash IS DISTINCT FROM EXCLUDED.content_hash
               OR r.applied_by_name IS DISTINCT FROM EXCLUDED.applied_by_name
               OR r.applied_by_namespace IS DISTINCT FROM EXCLUDED.applied_by_namespace
+              OR r.source_ref_kind IS DISTINCT FROM EXCLUDED.source_ref_kind
+              OR r.source_ref_name IS DISTINCT FROM EXCLUDED.source_ref_name
+              OR r.source_ref_namespace IS DISTINCT FROM EXCLUDED.source_ref_namespace
+              OR r.source_url IS DISTINCT FROM EXCLUDED.source_url
+              OR r.origin_revision IS DISTINCT FROM EXCLUDED.origin_revision
+              OR r.origin_source IS DISTINCT FROM EXCLUDED.origin_source
+              OR r.inventory IS DISTINCT FROM EXCLUDED.inventory
             THEN now() ELSE r.updated_at END
     RETURNING ready, reason, message, revision
 )
@@ -255,12 +330,19 @@ func (s *Store) Sync(ctx context.Context, resources []flux.Resource) (SyncStats,
 			}
 			parentKind, parentName := parentCols(r.Parent)
 			appliedByName, appliedByNamespace := appliedByCols(r.AppliedBy)
+			sourceRefKind, sourceRefName, sourceRefNamespace := sourceRefCols(r.SourceRef)
+			inventory, err := inventoryParam(r.Inventory)
+			if err != nil {
+				return stats, fmt.Errorf("%s %s/%s: %w", r.Kind, r.Namespace, r.Name, err)
+			}
 			batch.Queue(upsertStmt,
 				r.Kind, r.APIVersion, r.Namespace, r.Name,
 				r.Ready, r.Reason, r.Message, r.Revision, r.Suspended,
 				r.Generation, r.ObservedGeneration, r.LastTransition, []byte(raw), r.ContentHash,
 				r.AzureResourceID, parentKind, parentName,
 				appliedByName, appliedByNamespace,
+				sourceRefKind, sourceRefName, sourceRefNamespace,
+				nullable(r.SourceURL), nullable(r.OriginRevision), nullable(r.OriginSource), inventory,
 			)
 		}
 		br := tx.SendBatch(ctx, batch)
@@ -377,15 +459,18 @@ const listStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
-       applied_by_name, applied_by_namespace
+       applied_by_name, applied_by_namespace,
+       source_ref_kind, source_ref_name, source_ref_namespace,
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, '')
 FROM flux_resource
 WHERE ($1 = '' OR lower(kind) = lower($1))
   AND ($2 = '' OR namespace = $2)
   AND ($3 = '' OR lower(ready) = lower($3))
 ORDER BY kind, namespace, name`
 
-// List returns normalized rows (without the raw payload) filtered by the
-// optional kind/namespace/ready arguments; an empty argument means "any".
+// List returns normalized rows (without the raw and inventory payloads)
+// filtered by the optional kind/namespace/ready arguments; an empty argument
+// means "any".
 func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux.Resource, error) {
 	rows, err := s.pool.Query(ctx, listStmt, kind, namespace, ready)
 	if err != nil {
@@ -398,17 +483,21 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 		var r flux.Resource
 		var parentKind, parentName *string
 		var appliedByName, appliedByNamespace *string
+		var sourceRefKind, sourceRefName, sourceRefNamespace *string
 		if err := rows.Scan(
 			&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 			&r.ObservedGeneration, &r.LastTransition,
 			&r.AzureResourceID, &parentKind, &parentName,
 			&appliedByName, &appliedByNamespace,
+			&sourceRefKind, &sourceRefName, &sourceRefNamespace,
+			&r.SourceURL, &r.OriginRevision, &r.OriginSource,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		r.Parent = parentRef(parentKind, parentName)
 		r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
+		r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -418,7 +507,10 @@ const getStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
-       applied_by_name, applied_by_namespace
+       applied_by_name, applied_by_namespace,
+       source_ref_kind, source_ref_name, source_ref_namespace,
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
+       inventory
 FROM flux_resource
 WHERE lower(kind) = lower($1) AND namespace = $2 AND name = $3`
 
@@ -441,15 +533,19 @@ type Event struct {
 // history, newest first. It returns ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Resource, []Event, error) {
 	var r flux.Resource
-	var raw []byte
+	var raw, inventory []byte
 	var parentKind, parentName *string
 	var appliedByName, appliedByNamespace *string
+	var sourceRefKind, sourceRefName, sourceRefNamespace *string
 	err := s.pool.QueryRow(ctx, getStmt, kind, namespace, name).Scan(
 		&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 		&r.Message, &r.Revision, &r.Suspended, &r.Generation,
 		&r.ObservedGeneration, &r.LastTransition, &raw,
 		&r.AzureResourceID, &parentKind, &parentName,
 		&appliedByName, &appliedByNamespace,
+		&sourceRefKind, &sourceRefName, &sourceRefNamespace,
+		&r.SourceURL, &r.OriginRevision, &r.OriginSource,
+		&inventory,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, ErrNotFound
@@ -460,6 +556,10 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 	r.Raw = raw
 	r.Parent = parentRef(parentKind, parentName)
 	r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
+	r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
+	if r.Inventory, err = inventoryFrom(inventory); err != nil {
+		return nil, nil, err
+	}
 
 	rows, err := s.pool.Query(ctx, historyStmt, r.Kind, r.Namespace, r.Name, historyLimit)
 	if err != nil {
@@ -501,17 +601,21 @@ const changedSinceStmt = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
-       applied_by_name, applied_by_namespace
+       applied_by_name, applied_by_namespace,
+       source_ref_kind, source_ref_name, source_ref_namespace,
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
+       inventory
 FROM flux_resource
 WHERE updated_at > $1
 ORDER BY updated_at`
 
-// changedSinceStmtV2 is the pull for tenants still at schema version 2, whose
-// databases predate the applied-by columns; that field stays nil.
-const changedSinceStmtV2 = `
+// changedSinceStmtV3 is the pull for tenants still at schema version 3, whose
+// databases predate the base-layer columns; those fields stay empty.
+const changedSinceStmtV3 = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at,
-       COALESCE(azure_resource_id, ''), parent_kind, parent_name
+       COALESCE(azure_resource_id, ''), parent_kind, parent_name,
+       applied_by_name, applied_by_namespace
 FROM flux_resource
 WHERE updated_at > $1
 ORDER BY updated_at`
@@ -527,9 +631,9 @@ ORDER BY updated_at`
 // the schemaSupported window are the caller's job to skip.
 func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersion int) ([]ChangedResource, error) {
 	stmt := changedSinceStmt
-	withAppliedBy := schemaVersion >= 3
-	if !withAppliedBy {
-		stmt = changedSinceStmtV2
+	withBaseLayer := schemaVersion >= 4
+	if !withBaseLayer {
+		stmt = changedSinceStmtV3
 	}
 	rows, err := s.pool.Query(ctx, stmt, cursor)
 	if err != nil {
@@ -540,18 +644,24 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 	out := []ChangedResource{}
 	for rows.Next() {
 		var c ChangedResource
-		var raw []byte
+		var raw, inventory []byte
 		var hash *string
 		var parentKind, parentName *string
 		var appliedByName, appliedByNamespace *string
+		var sourceRefKind, sourceRefName, sourceRefNamespace *string
 		dest := []any{
 			&c.Kind, &c.APIVersion, &c.Namespace, &c.Name, &c.Ready, &c.Reason,
 			&c.Message, &c.Revision, &c.Suspended, &c.Generation,
 			&c.ObservedGeneration, &c.LastTransition, &raw, &hash, &c.UpdatedAt,
 			&c.AzureResourceID, &parentKind, &parentName,
+			&appliedByName, &appliedByNamespace,
 		}
-		if withAppliedBy {
-			dest = append(dest, &appliedByName, &appliedByNamespace)
+		if withBaseLayer {
+			dest = append(dest,
+				&sourceRefKind, &sourceRefName, &sourceRefNamespace,
+				&c.SourceURL, &c.OriginRevision, &c.OriginSource,
+				&inventory,
+			)
 		}
 		if err := rows.Scan(dest...); err != nil {
 			return nil, fmt.Errorf("scan changed row: %w", err)
@@ -562,6 +672,10 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 		}
 		c.Parent = parentRef(parentKind, parentName)
 		c.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
+		c.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
+		if c.Inventory, err = inventoryFrom(inventory); err != nil {
+			return nil, err
+		}
 		out = append(out, c)
 	}
 	return out, rows.Err()

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -169,7 +169,7 @@ func sourceRefFrom(kind, name, namespace *string) *flux.SourceRef {
 // nullable maps "" to NULL. The base-layer string columns are stored NULL when
 // the projection is absent so the upsert's updated_at backfill comparison stays
 // quiet for the many rows that never carry them (NULL = NULL), instead of
-// re-mirroring the whole fleet once over '' vs NULL.
+// re-mirroring the whole fleet once over empty-string vs NULL.
 func nullable(s string) *string {
 	if s == "" {
 		return nil

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -169,7 +169,7 @@ func sourceRefFrom(kind, name, namespace *string) *flux.SourceRef {
 // nullable maps "" to NULL. The base-layer string columns are stored NULL when
 // the projection is absent so the upsert's updated_at backfill comparison stays
 // quiet for the many rows that never carry them (NULL = NULL), instead of
-// re-mirroring the whole fleet once over ” vs NULL.
+// re-mirroring the whole fleet once over '' vs NULL.
 func nullable(s string) *string {
 	if s == "" {
 		return nil

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -385,12 +385,12 @@ func TestCentralDISFieldsEndToEnd(t *testing.T) {
 	}
 }
 
-// TestCentralSyncSchemaV2Tenant proves the rollout order the schema gate
-// promises: a server at schema 3 can still pull a tenant whose agent is at
-// schema 2 (its database lacks the applied-by columns entirely). The tenant is
-// built by hand — migrate, then drop the v3 columns and stamp schema_version 2
-// — because a v3 agent binary can no longer write the v2 shape.
-func TestCentralSyncSchemaV2Tenant(t *testing.T) {
+// TestCentralSyncSchemaV3Tenant proves the rollout order the schema gate
+// promises: a server at schema 4 can still pull a tenant whose agent is at
+// schema 3 (its database lacks the base-layer columns entirely). The tenant is
+// built by hand — migrate, then drop the v4 columns and stamp schema_version 3
+// — because a v4 agent binary can no longer write the v3 shape.
+func TestCentralSyncSchemaV3Tenant(t *testing.T) {
 	cs, _ := newCentral(t)
 	ctx := context.Background()
 	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
@@ -405,36 +405,38 @@ func TestCentralSyncSchemaV2Tenant(t *testing.T) {
 		t.Fatalf("migrate tenant: %v", err)
 	}
 	if _, err := tpool.Exec(ctx, `ALTER TABLE flux_resource
-		DROP COLUMN applied_by_name, DROP COLUMN applied_by_namespace`); err != nil {
-		t.Fatalf("shape tenant as v2: %v", err)
+		DROP COLUMN source_ref_kind, DROP COLUMN source_ref_name, DROP COLUMN source_ref_namespace,
+		DROP COLUMN source_url, DROP COLUMN origin_revision, DROP COLUMN origin_source,
+		DROP COLUMN inventory`); err != nil {
+		t.Fatalf("shape tenant as v3: %v", err)
 	}
 	if _, err := tpool.Exec(ctx,
-		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 2, 'v2-agent')"); err != nil {
-		t.Fatalf("stamp v2 meta: %v", err)
+		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 3, 'v3-agent')"); err != nil {
+		t.Fatalf("stamp v3 meta: %v", err)
 	}
-	// The full column set a v2 agent writes: its upsert always passes the Go
+	// The full column set a v3 agent writes: its upsert always passes the Go
 	// zero values, so reason/message/revision land as '' (never NULL) and the
-	// DIS pair as NULL for a plain Flux object.
+	// DIS/applied-by pairs as NULL for a plain root Flux object.
 	if _, err := tpool.Exec(ctx, `INSERT INTO flux_resource
 		(kind, api_version, namespace, name, ready, reason, message, revision,
 		 azure_resource_id, suspended, generation, observed_generation, raw, content_hash)
 		VALUES ('Kustomization', 'kustomize.toolkit.fluxcd.io/v1', 'flux-system', 'apps', 'True', '', '', '',
 		 '', false, 0, 0, '{}', 'h1')`); err != nil {
-		t.Fatalf("insert v2 row: %v", err)
+		t.Fatalf("insert v3 row: %v", err)
 	}
 
 	meta, err := ts.GetMeta(ctx)
-	if err != nil || meta.SchemaVersion != 2 {
+	if err != nil || meta.SchemaVersion != 3 {
 		t.Fatalf("tenant meta: %+v err=%v", meta, err)
 	}
 
 	// The version-keyed pull must succeed against the columnless table.
 	changed, err := ts.ChangedSince(ctx, time.Time{}, meta.SchemaVersion)
 	if err != nil {
-		t.Fatalf("changed-since on a v2 tenant: %v", err)
+		t.Fatalf("changed-since on a v3 tenant: %v", err)
 	}
-	if len(changed) != 1 || changed[0].AppliedBy != nil {
-		t.Fatalf("unexpected v2 pull: %+v", changed)
+	if len(changed) != 1 || changed[0].SourceRef != nil || changed[0].Inventory != nil || changed[0].SourceURL != "" {
+		t.Fatalf("unexpected v3 pull: %+v", changed)
 	}
 	keys, err := ts.Keys(ctx)
 	if err != nil {
@@ -450,15 +452,79 @@ func TestCentralSyncSchemaV2Tenant(t *testing.T) {
 		SchemaVersion: meta.SchemaVersion,
 		AgentVersion:  meta.AgentVersion,
 	}); err != nil {
-		t.Fatalf("apply v2 tenant: %v", err)
+		t.Fatalf("apply v3 tenant: %v", err)
 	}
 
 	rows, err := cs.List(ctx, "ttd_at23", "", "", "")
 	if err != nil || len(rows) != 1 {
-		t.Fatalf("central list after v2 sync: %+v err=%v", rows, err)
+		t.Fatalf("central list after v3 sync: %+v err=%v", rows, err)
 	}
-	if rows[0].AppliedBy != nil {
-		t.Fatalf("v2 row should have nil appliedBy, got %+v", rows[0])
+	if rows[0].SourceRef != nil || rows[0].SourceURL != "" {
+		t.Fatalf("v3 row should have empty base-layer fields, got %+v", rows[0])
+	}
+}
+
+// TestCentralBaseLayerRoundTrip checks the base-layer projections are carried
+// end-to-end into the central read model: List (no inventory) surfaces
+// sourceRef/url/origin for the artifacts view, and Get returns the full
+// inventory for the tree expansion.
+func TestCentralBaseLayerRoundTrip(t *testing.T) {
+	cs, _ := newCentral(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	repo := changed("team-a-ab12", "OCIRepository", flux.ReadyTrue, "h1", now)
+	repo.SourceURL = "oci://registry.example.com/team-a/syncroot"
+	repo.OriginRevision = "main/0c2a3b4"
+	repo.OriginSource = "https://git.example.com/team-a/syncroot"
+	kust := changed("team-a-ab12-team-a", "Kustomization", flux.ReadyTrue, "h2", now)
+	kust.SourceRef = &flux.SourceRef{Kind: "OCIRepository", Name: "team-a-ab12", Namespace: "flux-system"}
+	kust.Inventory = []flux.InventoryEntry{
+		{ID: "product-team-a_appdb_storage.dis.altinn.cloud_Database", Version: "v1alpha1"},
+	}
+	if err := cs.Apply(ctx, central.ClusterState{
+		Cluster:     "ttd_at23",
+		Environment: "at23",
+		Changed:     []store.ChangedResource{repo, kust},
+		Keys: []store.ResourceKey{
+			{Kind: "OCIRepository", Namespace: "flux-system", Name: "team-a-ab12"},
+			{Kind: "Kustomization", Namespace: "flux-system", Name: "team-a-ab12-team-a"},
+		},
+		Cursor:        now,
+		SchemaVersion: store.SchemaVersion,
+		AgentVersion:  "e2e",
+		LastSweepAt:   now,
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	rows, err := cs.List(ctx, "ttd_at23", "", "", "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, r := range rows {
+		switch r.Kind {
+		case "OCIRepository":
+			if r.SourceURL != "oci://registry.example.com/team-a/syncroot" ||
+				r.OriginRevision != "main/0c2a3b4" || r.OriginSource != "https://git.example.com/team-a/syncroot" {
+				t.Fatalf("repository List lost base-layer fields: %+v", r)
+			}
+		case "Kustomization":
+			if r.SourceRef == nil || r.SourceRef.Name != "team-a-ab12" {
+				t.Fatalf("kustomization List lost sourceRef: %+v", r)
+			}
+			if r.Inventory != nil {
+				t.Fatalf("List must omit the inventory payload: %+v", r.Inventory)
+			}
+		}
+	}
+
+	got, err := cs.Get(ctx, "ttd_at23", "Kustomization", "flux-system", "team-a-ab12-team-a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Inventory) != 1 || got.Inventory[0].ID != "product-team-a_appdb_storage.dis.altinn.cloud_Database" {
+		t.Fatalf("kustomization Get inventory: %+v", got.Inventory)
 	}
 }
 

--- a/services/dis-console/test/e2e/store_test.go
+++ b/services/dis-console/test/e2e/store_test.go
@@ -310,6 +310,162 @@ func TestSyncAppliedByRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSyncBaseLayerRoundTrip checks the schema-v4 columns against real
+// PostgreSQL: an OCIRepository's url/origin and a Kustomization's sourceRef +
+// inventory survive Sync and come back out of Get and ChangedSince, while List
+// carries everything except the inventory payload (detail-only, like raw), and
+// a version-3 pull omits the base-layer fields entirely.
+func TestSyncBaseLayerRoundTrip(t *testing.T) {
+	s, _ := newStore(t)
+	ctx := context.Background()
+
+	repo := flux.Resource{
+		Kind: "OCIRepository", APIVersion: "source.toolkit.fluxcd.io/v1",
+		Namespace: "product-team-a", Name: "team-a-ab12",
+		Ready: flux.ReadyTrue, Revision: "at23@sha256:abc",
+		SourceURL:      "oci://registry.example.com/team-a/syncroot",
+		OriginRevision: "main/0c2a3b4", OriginSource: "https://git.example.com/team-a/syncroot",
+		Raw: json.RawMessage(`{"kind":"OCIRepository"}`), ContentHash: "repo-1",
+	}
+	kust := flux.Resource{
+		Kind: "Kustomization", APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+		Namespace: "product-team-a", Name: "team-a-ab12-team-a",
+		Ready: flux.ReadyTrue, Revision: "at23@sha256:abc",
+		SourceRef: &flux.SourceRef{Kind: "OCIRepository", Name: "team-a-ab12", Namespace: "product-team-a"},
+		Inventory: []flux.InventoryEntry{
+			{ID: "product-team-a_appdb_storage.dis.altinn.cloud_Database", Version: "v1alpha1"},
+			{ID: "product-team-a_app_apps_Deployment", Version: "v1"},
+		},
+		Raw: json.RawMessage(`{"kind":"Kustomization"}`), ContentHash: "kust-1",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{repo, kust}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	gotKust, _, err := s.Get(ctx, "Kustomization", "product-team-a", "team-a-ab12-team-a")
+	if err != nil {
+		t.Fatalf("get kustomization: %v", err)
+	}
+	if gotKust.SourceRef == nil || gotKust.SourceRef.Kind != "OCIRepository" ||
+		gotKust.SourceRef.Name != "team-a-ab12" || gotKust.SourceRef.Namespace != "product-team-a" {
+		t.Fatalf("kustomization Get sourceRef: %+v", gotKust.SourceRef)
+	}
+	if len(gotKust.Inventory) != 2 ||
+		gotKust.Inventory[0].ID != "product-team-a_appdb_storage.dis.altinn.cloud_Database" ||
+		gotKust.Inventory[0].Version != "v1alpha1" {
+		t.Fatalf("kustomization Get inventory: %+v", gotKust.Inventory)
+	}
+
+	gotRepo, _, err := s.Get(ctx, "OCIRepository", "product-team-a", "team-a-ab12")
+	if err != nil {
+		t.Fatalf("get repository: %v", err)
+	}
+	if gotRepo.SourceURL != "oci://registry.example.com/team-a/syncroot" ||
+		gotRepo.OriginRevision != "main/0c2a3b4" || gotRepo.OriginSource != "https://git.example.com/team-a/syncroot" {
+		t.Fatalf("repository Get base-layer fields: %+v", gotRepo)
+	}
+
+	rows, err := s.List(ctx, "Kustomization", "", "")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("list kustomizations: %+v err=%v", rows, err)
+	}
+	if rows[0].SourceRef == nil || rows[0].SourceRef.Name != "team-a-ab12" {
+		t.Fatalf("list should carry sourceRef: %+v", rows[0])
+	}
+	if rows[0].Inventory != nil {
+		t.Fatalf("list must omit the inventory payload, got %+v", rows[0].Inventory)
+	}
+
+	changed, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion)
+	if err != nil || len(changed) != 2 {
+		t.Fatalf("changed-since: %d rows err=%v", len(changed), err)
+	}
+	for _, c := range changed {
+		switch c.Kind {
+		case "Kustomization":
+			if c.SourceRef == nil || len(c.Inventory) != 2 {
+				t.Fatalf("changed kustomization lost base-layer fields: %+v", c.Resource)
+			}
+		case "OCIRepository":
+			if c.SourceURL == "" || c.OriginRevision == "" {
+				t.Fatalf("changed repository lost base-layer fields: %+v", c.Resource)
+			}
+		}
+	}
+
+	// The version-3 SELECT (what the server uses against tenants whose agents
+	// have not migrated yet) must omit the base-layer fields but still succeed.
+	v3, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion-1)
+	if err != nil {
+		t.Fatalf("v3 changed-since: %v", err)
+	}
+	for _, c := range v3 {
+		if c.SourceRef != nil || c.Inventory != nil || c.SourceURL != "" {
+			t.Fatalf("v3 pull must not select base-layer fields: %+v", c.Resource)
+		}
+	}
+}
+
+// TestSyncBaseLayerBackfillAdvancesUpdatedAt reproduces the v3→v4 upgrade:
+// rows written before the base-layer projection have the columns NULL with an
+// unchanged content hash (sourceRef, url and inventory were already inside the
+// hashed object). The first sweep that projects them must advance updated_at
+// so the central pull mirrors the backfilled row — and later identical sweeps
+// must not churn it. Same contract the appliedBy backfill established.
+func TestSyncBaseLayerBackfillAdvancesUpdatedAt(t *testing.T) {
+	s, pool := newStore(t)
+	ctx := context.Background()
+
+	updatedAt := func() time.Time {
+		var ts time.Time
+		if err := pool.QueryRow(ctx,
+			"SELECT updated_at FROM flux_resource WHERE name = $1", "team-a-ab12-team-a").Scan(&ts); err != nil {
+			t.Fatalf("query updated_at: %v", err)
+		}
+		return ts
+	}
+
+	// Sweep 1: the pre-v4 shape (same object, projections not derived yet).
+	pre := flux.Resource{
+		Kind: "Kustomization", APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+		Namespace: "product-team-a", Name: "team-a-ab12-team-a",
+		Ready: flux.ReadyTrue,
+		Raw:   json.RawMessage(`{"kind":"Kustomization"}`), ContentHash: "same-object",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{pre}); err != nil {
+		t.Fatalf("sync 1: %v", err)
+	}
+	first := updatedAt()
+
+	// Sweep 2: identical object + hash, but the agent now projects the fields.
+	post := pre
+	post.SourceRef = &flux.SourceRef{Kind: "OCIRepository", Name: "team-a-ab12", Namespace: "product-team-a"}
+	post.Inventory = []flux.InventoryEntry{{ID: "product-team-a_app_apps_Deployment", Version: "v1"}}
+	if _, err := s.Sync(ctx, []flux.Resource{post}); err != nil {
+		t.Fatalf("sync 2: %v", err)
+	}
+	second := updatedAt()
+	if !second.After(first) {
+		t.Fatalf("updated_at must advance when base-layer fields are backfilled: %v -> %v", first, second)
+	}
+
+	changed, err := s.ChangedSince(ctx, first, store.SchemaVersion)
+	if err != nil {
+		t.Fatalf("changed-since: %v", err)
+	}
+	if len(changed) != 1 || changed[0].SourceRef == nil || len(changed[0].Inventory) != 1 {
+		t.Fatalf("backfilled row not pulled: %+v", changed)
+	}
+
+	// Sweep 3: identical again (projections unchanged) => no churn.
+	if _, err := s.Sync(ctx, []flux.Resource{post}); err != nil {
+		t.Fatalf("sync 3: %v", err)
+	}
+	if got := updatedAt(); !got.Equal(second) {
+		t.Fatalf("updated_at churned on an unchanged base-layer sweep: %v -> %v", second, got)
+	}
+}
+
 // TestSyncContentHashSkipsUnchangedRewrite asserts the write-hygiene contract:
 // an unchanged sweep leaves updated_at alone (no row/raw rewrite), while a
 // content change advances it. The central sync loop pulls on updated_at, so


### PR DESCRIPTION
## Problem
Clusters run two kinds of base-layer OCI artifacts — product syncroots (`<product>/syncroot`, mutable env tags) and infra packages (`manifests/infra/*`, `dis/kustomize/*`) — but the console has no view of which artifact/version is deployed where, nor of what a syncroot actually created. The CRs carry no product/team labels and syncroot tags are mutable, so the OCI URL and digest are the only identity.

## Change
- **Agent (schema v4)** projects four new fields from objects it already sweeps: a Kustomization's `spec.sourceRef` and `status.inventory` (Flux's applied-object set — the deployment tree), a source kind's `spec.url`, and the artifact's `org.opencontainers.image.{revision,source}` annotations (git provenance stamped by `flux push`).
- New columns are stored NULL-when-absent and the upsert's `updated_at` CASE is extended, so pre-existing rows backfill exactly once and rows that never carry the fields stay quiet (the #3812 lesson).
- `ChangedSince` keeps a v3 SELECT: a v4 server still pulls v3 agents (schema window 3–4).
- **Server** adds `GET /api/artifacts?cluster=&class=` (OCIRepositories classified by URL as `product-syncroot` / `admin-syncroot` / `infra` / `operator` / `other`, with fetched `tag@digest`, git origin, and the deploying Kustomizations) and `GET /api/kustomizations/{cluster}/{namespace}/{name}/inventory` (the expanded applied-object tree, entries enriched with mirrored status for swept kinds). Inventory is detail-only like `raw`; list payloads stay small.

## Rollout
Server before agents (same as v1.5.0). First v4 agent sweep re-mirrors only the rows that gain the new fields.

## Verification
`make run-checks-ci-cache` and `make test-e2e-kind-ci` green, including e2e for the backfill-advances-updated_at-once contract and a v4 server pulling a v3-shaped tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API views for browsing OCI artifacts, including classification, provenance, deployment details, and filtering by class or cluster.
  * Added Kustomization inventory details with expanded applied-resource information and readiness status.
  * Improved resource tracking with source references, artifact origins, URLs, and inventory metadata.

* **Documentation**
  * Documented the new API endpoints and inventory capabilities.

* **Bug Fixes**
  * Preserved newly added resource metadata across storage, synchronization, and schema upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->