### PR TITLE
feat(dis-console): add --event-retention to purge aged status events

### DIFF
--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -79,13 +79,15 @@ Do not claim checks passed unless you actually ran them.
 - `internal/dbauth` — pgxpool builder; Entra-token `BeforeConnect` hook in the
   cluster, PGPASSWORD/trust fallback when Entra is disabled (Kind/CI/local).
 - `internal/store` — tenant pgxpool store: embedded `schema.sql`, `Migrate`,
-  `Sync` (content-hash-gated upsert + `flux_status_event` history + prune,
-  touches the `meta` row), the `meta` bookkeeping table (`InitMeta`/`GetMeta`,
-  `SchemaVersion`), and the server-side tenant readers (`ChangedSince`/`Keys`).
+  `Sync` (content-hash-gated upsert + `flux_status_event` history + prune +
+  optional event-retention purge, touches the `meta` row), the `meta`
+  bookkeeping table (`InitMeta`/`GetMeta`, `SchemaVersion`), and the
+  server-side tenant readers (`ChangedSince`/`Keys`).
 - `internal/central` — the server's central read model: cluster-keyed
   `schema.sql`, `Apply` (per-cluster upsert + prune + `cluster_report` in one
   tx), tenant `Discover`, the sync `Engine` (pulls each tenant incrementally via
-  `updated_at > cursor`), and the fleet-API read methods (`Clusters` with
+  `updated_at > cursor`, ages out central events once per cycle when
+  `--event-retention` is set), and the fleet-API read methods (`Clusters` with
   staleness, `Summary`/`List`/`Get`).
 - `internal/health` — `/healthz` + `/readyz` handlers used by the agent.
 - `internal/api` — the fleet API: `net/http` mux + JSON handlers reading the

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -142,7 +142,10 @@ psql "postgres://postgres@localhost:5432/postgres?sslmode=disable" -c 'SELECT ki
 
 Agent flags: `--http-address` (default `:8080`), `--poll-interval` (default
 `30s`), `--local` (kubeconfig instead of in-cluster config), `--db-uri` (default
-`DB_URI`), `--db-disable-entra` (default `DB_DISABLE_ENTRA`).
+`DB_URI`), `--db-disable-entra` (default `DB_DISABLE_ENTRA`),
+`--event-retention` (default `720h` — delete status-history events older than
+this; `0` keeps them forever). The server takes the same `--event-retention`
+for the central database.
 
 ## Develop
 

--- a/services/dis-console/cmd/main.go
+++ b/services/dis-console/cmd/main.go
@@ -77,6 +77,8 @@ func runAgent(args []string) {
 	fs := flag.NewFlagSet("agent", flag.ExitOnError)
 	httpAddr := fs.String("http-address", ":8080", "Address for the health probes (/healthz, /readyz)")
 	pollInterval := fs.Duration("poll-interval", 30*time.Second, "Flux resource poll interval (e.g. 30s, 1m)")
+	eventRetention := fs.Duration("event-retention", 720*time.Hour,
+		"Delete status-history events older than this from the tenant database (0 keeps them forever)")
 	local := fs.Bool("local", false, "Use the local kubeconfig instead of in-cluster config (laptop dev)")
 	dbURI := fs.String("db-uri", os.Getenv("DB_URI"),
 		"PostgreSQL connection URI without password (default from DB_URI env)")
@@ -87,6 +89,9 @@ func runAgent(args []string) {
 
 	if *pollInterval <= 0 {
 		log.Fatalf("--poll-interval must be greater than 0, got %s", *pollInterval)
+	}
+	if *eventRetention < 0 {
+		log.Fatalf("--event-retention must be zero (disabled) or positive, got %s", *eventRetention)
 	}
 	if *dbURI == "" {
 		log.Fatalf("--db-uri (or DB_URI env) must be set")
@@ -116,6 +121,7 @@ func runAgent(args []string) {
 		log.Fatalf("db pool: %v", err)
 	}
 	st := store.New(pool)
+	st.SetEventRetention(*eventRetention)
 	defer st.Close()
 
 	migrateCtx, cancel := context.WithTimeout(ctx, migrateTimeout)
@@ -173,6 +179,8 @@ func runServer(args []string) {
 	syncInterval := fs.Duration("sync-interval", 30*time.Second, "Tenant database sync interval (e.g. 30s, 1m)")
 	staleAfter := fs.Duration("stale-after", 2*time.Minute,
 		"Mark a cluster stale when its agent sweep / console sync is older than this")
+	eventRetention := fs.Duration("event-retention", 720*time.Hour,
+		"Delete status-history events older than this from the central database (0 keeps them forever)")
 	dbURI := fs.String("db-uri", os.Getenv("DB_URI"),
 		"Central PostgreSQL connection URI without password (default from DB_URI env). "+
 			"Tenant databases are discovered on the same server.")
@@ -186,6 +194,9 @@ func runServer(args []string) {
 	}
 	if *staleAfter <= 0 {
 		log.Fatalf("--stale-after must be greater than 0, got %s", *staleAfter)
+	}
+	if *eventRetention < 0 {
+		log.Fatalf("--event-retention must be zero (disabled) or positive, got %s", *eventRetention)
 	}
 	if *dbURI == "" {
 		log.Fatalf("--db-uri (or DB_URI env) must be set")
@@ -233,6 +244,7 @@ func runServer(args []string) {
 
 	// Run the sync loop until shutdown; readiness flips after the first cycle.
 	engine := central.NewEngine(cs, *dbURI, cred, *syncInterval)
+	engine.SetEventRetention(*eventRetention)
 	engine.Run(ctx, srv.MarkSynced)
 
 	gracefulShutdown(httpServer)
@@ -260,7 +272,8 @@ func poll(ctx context.Context, client *flux.Client, st *store.Store, h *health.S
 	}
 
 	h.MarkReady()
-	log.Printf("swept %d resources (%d changed, %d pruned)", stats.Upserted, stats.Changed, stats.Pruned)
+	log.Printf("swept %d resources (%d changed, %d pruned, %d events expired)",
+		stats.Upserted, stats.Changed, stats.Pruned, stats.EventsExpired)
 }
 
 func gracefulShutdown(srv *http.Server) {

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -197,6 +197,30 @@ WHERE e.cluster = $1
       AND r.namespace = e.namespace AND r.name = e.name
   )`
 
+// expireEventsStmt ages out central history rows older than the retention
+// window — the same predicate as the tenant store's purge, on the
+// cluster-keyed table. Aged rows are unreachable through the API (History
+// caps at historyLimit recent rows per resource). The per-cluster copy cursor
+// is cluster_report.event_cursor, independent of this table, so the purge can
+// neither regress the incremental event copy nor resurrect deleted rows.
+const expireEventsStmt = `
+DELETE FROM flux_status_event WHERE observed_at < now() - make_interval(secs => $1)`
+
+// PurgeExpiredEvents deletes status events older than retention from the
+// central event log across all clusters, returning how many rows went.
+// retention <= 0 disables the purge: the method returns without touching the
+// database.
+func (s *Store) PurgeExpiredEvents(ctx context.Context, retention time.Duration) (int64, error) {
+	if retention <= 0 {
+		return 0, nil
+	}
+	tag, err := s.pool.Exec(ctx, expireEventsStmt, retention.Seconds())
+	if err != nil {
+		return 0, fmt.Errorf("expire events: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // Apply mirrors one cluster's state into the central DB in a single transaction
 // — upsert the changed rows, prune the ones that disappeared, and record the
 // cluster_report — so readers never observe a half-synced cluster.

--- a/services/dis-console/internal/central/central_test.go
+++ b/services/dis-console/internal/central/central_test.go
@@ -1,6 +1,7 @@
 package central
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -85,6 +86,18 @@ func TestAdvanceEventCursor(t *testing.T) {
 	// All ids at/below the cursor: must never regress.
 	if got := advanceEventCursor(20, events); got != 20 {
 		t.Fatalf("advanceEventCursor must not regress, got %d", got)
+	}
+}
+
+func TestPurgeExpiredEventsDisabled(t *testing.T) {
+	// retention <= 0 disables the purge entirely: the method must return
+	// before running any SQL — the nil pool would panic if it did.
+	s := New(nil)
+	for _, d := range []time.Duration{0, -time.Hour} {
+		n, err := s.PurgeExpiredEvents(context.Background(), d)
+		if err != nil || n != 0 {
+			t.Fatalf("PurgeExpiredEvents(%s): n=%d err=%v, want a no-op", d, n, err)
+		}
 	}
 }
 

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -21,6 +21,9 @@ type Engine struct {
 	baseURI  string
 	cred     azcore.TokenCredential
 	interval time.Duration
+	// eventRetention > 0 purges central status events older than the window
+	// once per sync cycle; zero keeps them forever.
+	eventRetention time.Duration
 }
 
 // NewEngine builds a sync engine. baseURI is the central database URI; tenant
@@ -29,6 +32,11 @@ type Engine struct {
 func NewEngine(central *Store, baseURI string, cred azcore.TokenCredential, interval time.Duration) *Engine {
 	return &Engine{central: central, baseURI: baseURI, cred: cred, interval: interval}
 }
+
+// SetEventRetention enables time-based purging of the central event log: each
+// sync cycle deletes flux_status_event rows older than d. Zero (the default)
+// disables it. Set once, before Run; the field is not synchronized.
+func (e *Engine) SetEventRetention(d time.Duration) { e.eventRetention = d }
 
 // Run syncs all tenant databases on an interval until ctx is cancelled. It calls
 // ready (flipping /readyz) after the first cycle whose discovery succeeds — a
@@ -76,6 +84,16 @@ func (e *Engine) syncOnce(ctx context.Context) bool {
 		synced++
 	}
 	log.Printf("synced %d/%d tenant databases (%d failed)", synced, len(dbs), failed)
+
+	// Age out central history once per cycle. A failure is logged, not fatal:
+	// the next cycle retries, and syncing/serving must not depend on it.
+	if e.eventRetention > 0 {
+		if purged, err := e.central.PurgeExpiredEvents(ctx, e.eventRetention); err != nil {
+			log.Printf("expire central events failed: %v", err)
+		} else if purged > 0 {
+			log.Printf("expired %d central status events older than %s", purged, e.eventRetention)
+		}
+	}
 	return true
 }
 

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS flux_status_event (
 );
 
 CREATE INDEX IF NOT EXISTS idx_central_event_obj ON flux_status_event (cluster, lower(kind), namespace, name, observed_at DESC, tenant_id DESC);
+CREATE INDEX IF NOT EXISTS idx_central_event_observed_at ON flux_status_event (observed_at);
 
 CREATE TABLE IF NOT EXISTS cluster_report (
     cluster        text        PRIMARY KEY,

--- a/services/dis-console/internal/store/schema.sql
+++ b/services/dis-console/internal/store/schema.sql
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS flux_status_event (
 );
 
 CREATE INDEX IF NOT EXISTS idx_flux_event_obj ON flux_status_event (kind, namespace, name, observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_flux_event_observed_at ON flux_status_event (observed_at);
 
 CREATE TABLE IF NOT EXISTS meta (
     id             boolean     PRIMARY KEY DEFAULT true,

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -1,7 +1,9 @@
 // Package store persists normalized Flux resource snapshots in PostgreSQL and
 // serves the read queries behind the JSON API. Each sweep upserts the current
 // rows, records a history event whenever a resource's ready/reason/revision
-// changes, and prunes rows for objects that have disappeared from the cluster.
+// changes, prunes rows for objects that have disappeared from the cluster,
+// and — when event retention is enabled — ages out history events past the
+// retention window.
 package store
 
 import (
@@ -29,6 +31,9 @@ var ErrNotFound = errors.New("resource not found")
 // Store reads and writes Flux resource state in PostgreSQL.
 type Store struct {
 	pool *pgxpool.Pool
+	// eventRetention > 0 makes every Sync delete flux_status_event rows older
+	// than the window; zero keeps events forever.
+	eventRetention time.Duration
 }
 
 // New wraps an existing pgxpool. The store does not own the pool's lifecycle
@@ -36,6 +41,12 @@ type Store struct {
 func New(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
+
+// SetEventRetention enables time-based purging of status history: each Sync
+// deletes flux_status_event rows observed more than d before the database's
+// now(). Zero (the default) disables the purge. Set once at startup, before
+// the sweep loop; the field is not synchronized.
+func (s *Store) SetEventRetention(d time.Duration) { s.eventRetention = d }
 
 // Close releases the underlying connection pool.
 func (s *Store) Close() { s.pool.Close() }
@@ -113,9 +124,10 @@ func (s *Store) GetMeta(ctx context.Context) (Meta, error) {
 
 // SyncStats reports what a Sync did.
 type SyncStats struct {
-	Upserted int   // rows seen this sweep
-	Changed  int   // rows whose ready/reason/revision changed (history events written)
-	Pruned   int64 // rows deleted because their object disappeared from the cluster
+	Upserted      int   // rows seen this sweep
+	Changed       int   // rows whose ready/reason/revision changed (history events written)
+	Pruned        int64 // rows deleted because their object disappeared from the cluster
+	EventsExpired int64 // history rows deleted for aging past the event retention window
 }
 
 // parentCols splits an optional parent into its nullable column pair.
@@ -376,6 +388,16 @@ func (s *Store) Sync(ctx context.Context, resources []flux.Resource) (SyncStats,
 		}
 	}
 
+	// Age out history events past the retention window, in the same
+	// transaction so a sweep and its retention purge commit together.
+	if s.eventRetention > 0 {
+		tag, err := tx.Exec(ctx, expireEventsStmt, s.eventRetention.Seconds())
+		if err != nil {
+			return stats, fmt.Errorf("expire events: %w", err)
+		}
+		stats.EventsExpired = tag.RowsAffected()
+	}
+
 	// Record the sweep time atomically with its data. No-op until InitMeta has
 	// seeded the singleton row (the agent does so at startup, before sweeping).
 	if _, err := tx.Exec(ctx, touchMetaStmt); err != nil {
@@ -396,6 +418,19 @@ WHERE NOT EXISTS (
     SELECT 1 FROM flux_resource r
     WHERE r.kind = e.kind AND r.namespace = e.namespace AND r.name = e.name
 )`
+
+// expireEventsStmt ages out history rows older than the retention window,
+// using the DB clock like pruneStmt (the seconds ride in as a parameter, so
+// the statement stays cacheable). Aged events are dead weight: the History
+// endpoints return at most historyLimit recent rows per resource, so anything
+// past a sane window is unreachable through the API. The server's event copy
+// cursor lives in the central database (cluster_report.event_cursor), not in
+// this table, so deleting rows here never disturbs the incremental copy. The
+// one caveat: should central sync lag for longer than the retention window,
+// events can expire before the server copied them and are lost — accepted,
+// the console is a live mirror, not an audit log.
+const expireEventsStmt = `
+DELETE FROM flux_status_event WHERE observed_at < now() - make_interval(secs => $1)`
 
 const lastSweepStmt = `SELECT max(last_seen) FROM flux_resource`
 

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -603,6 +603,85 @@ func TestCentralEventCopyAndHistory(t *testing.T) {
 	}
 }
 
+// TestCentralEventRetention proves the safety contract behind the central
+// purge: the per-cluster event copy cursor lives in cluster_report
+// (event_cursor), not in the event table itself, so purging aged central
+// events must not regress the cursor, must not resurrect the purged rows on
+// the next sync, and must not stop newer tenant events from flowing.
+func TestCentralEventRetention(t *testing.T) {
+	cs, cpool := newCentral(t)
+	ctx := context.Background()
+	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
+
+	tpool, err := dbauth.NewPoolForDatabase(ctx, uri, "dis_console_ttd_at23", nil)
+	if err != nil {
+		t.Fatalf("tenant pool: %v", err)
+	}
+	defer tpool.Close()
+	ts := store.New(tpool)
+	if err := ts.Migrate(ctx); err != nil {
+		t.Fatalf("migrate tenant: %v", err)
+	}
+	if err := ts.InitMeta(ctx, "e2e"); err != nil {
+		t.Fatalf("init tenant meta: %v", err)
+	}
+
+	// One tenant event, copied into the central log.
+	if _, err := ts.Sync(ctx, []flux.Resource{res("infra", flux.ReadyFalse, "BuildFailed", "sha-1")}); err != nil {
+		t.Fatalf("tenant sync 1: %v", err)
+	}
+	pullAndApply(t, cs, ts, "ttd_at23")
+
+	cursorBefore, err := cs.EventCursor(ctx, "ttd_at23")
+	if err != nil || cursorBefore == 0 {
+		t.Fatalf("event cursor after first sync: %d err=%v", cursorBefore, err)
+	}
+
+	// Age every central event past the window, then purge.
+	if _, err := cpool.Exec(ctx,
+		"UPDATE flux_status_event SET observed_at = now() - interval '48 hours'"); err != nil {
+		t.Fatalf("backdate central events: %v", err)
+	}
+	purged, err := cs.PurgeExpiredEvents(ctx, 24*time.Hour)
+	if err != nil || purged != 1 {
+		t.Fatalf("purge: purged=%d err=%v, want 1", purged, err)
+	}
+	if h, err := cs.History(ctx, "ttd_at23", "Kustomization", "flux-system", "infra"); err != nil || len(h) != 0 {
+		t.Fatalf("history should be empty after purge: %+v err=%v", h, err)
+	}
+
+	// The copy cursor is untouched: it lives in cluster_report, not in the
+	// purged table.
+	if c, err := cs.EventCursor(ctx, "ttd_at23"); err != nil || c != cursorBefore {
+		t.Fatalf("purge disturbed the event cursor: %d -> %d err=%v", cursorBefore, c, err)
+	}
+
+	// A redundant sync must not resurrect the purged event: the tenant still
+	// has it, but the cursor records it as already copied.
+	pullAndApply(t, cs, ts, "ttd_at23")
+	if h, err := cs.History(ctx, "ttd_at23", "Kustomization", "flux-system", "infra"); err != nil || len(h) != 0 {
+		t.Fatalf("redundant sync resurrected purged events: %+v err=%v", h, err)
+	}
+
+	// Newer tenant events still flow after a purge.
+	if _, err := ts.Sync(ctx, []flux.Resource{res("infra", flux.ReadyTrue, "ReconciliationSucceeded", "sha-2")}); err != nil {
+		t.Fatalf("tenant sync 2: %v", err)
+	}
+	pullAndApply(t, cs, ts, "ttd_at23")
+	h, err := cs.History(ctx, "ttd_at23", "Kustomization", "flux-system", "infra")
+	if err != nil || len(h) != 1 || h[0].Ready != flux.ReadyTrue {
+		t.Fatalf("new event after purge: %+v err=%v", h, err)
+	}
+	if c, err := cs.EventCursor(ctx, "ttd_at23"); err != nil || c <= cursorBefore {
+		t.Fatalf("cursor should advance past %d for the new event, got %d err=%v", cursorBefore, c, err)
+	}
+
+	// Rows inside the window survive a purge.
+	if purged, err := cs.PurgeExpiredEvents(ctx, 24*time.Hour); err != nil || purged != 0 {
+		t.Fatalf("fresh event must survive the purge: purged=%d err=%v", purged, err)
+	}
+}
+
 // pullAndApply mirrors the engine's per-cluster sync against a tenant store: pull
 // the rows + events newer than the central cursors, then apply both (with the
 // advanced cursors) to the central store in one transaction.

--- a/services/dis-console/test/e2e/store_test.go
+++ b/services/dis-console/test/e2e/store_test.go
@@ -568,6 +568,83 @@ func TestSyncAppliedByBackfillAdvancesUpdatedAt(t *testing.T) {
 	}
 }
 
+// TestSyncEventRetention drives the time-based event purge against real
+// PostgreSQL: with a retention window set, Sync deletes history events older
+// than the window inside the sweep's transaction, fresh events and the
+// resource rows themselves survive, and with retention unset (the default)
+// nothing is ever purged.
+func TestSyncEventRetention(t *testing.T) {
+	s, pool := newStore(t)
+	ctx := context.Background()
+
+	countEvents := func() int {
+		t.Helper()
+		var n int
+		if err := pool.QueryRow(ctx, "SELECT count(*) FROM flux_status_event").Scan(&n); err != nil {
+			t.Fatalf("count events: %v", err)
+		}
+		return n
+	}
+
+	// Two sweeps: initial upsert, then a status change => two history events.
+	if _, err := s.Sync(ctx, []flux.Resource{res("apps", flux.ReadyTrue, "OK", "sha-1")}); err != nil {
+		t.Fatalf("sync 1: %v", err)
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{res("apps", flux.ReadyFalse, "Boom", "sha-2")}); err != nil {
+		t.Fatalf("sync 2: %v", err)
+	}
+	if n := countEvents(); n != 2 {
+		t.Fatalf("expected 2 events after two sweeps, got %d", n)
+	}
+
+	// Age the first event past the window configured below.
+	if _, err := pool.Exec(ctx,
+		"UPDATE flux_status_event SET observed_at = now() - interval '48 hours' WHERE ready = $1",
+		flux.ReadyTrue); err != nil {
+		t.Fatalf("backdate event: %v", err)
+	}
+
+	// Retention disabled (the default): a sweep must not purge anything.
+	stats, err := s.Sync(ctx, []flux.Resource{res("apps", flux.ReadyFalse, "Boom", "sha-2")})
+	if err != nil {
+		t.Fatalf("sync 3: %v", err)
+	}
+	if stats.EventsExpired != 0 || countEvents() != 2 {
+		t.Fatalf("disabled retention purged events: stats=%+v events=%d", stats, countEvents())
+	}
+
+	// 24h retention: the next sweep drops the aged event and keeps the fresh one.
+	s.SetEventRetention(24 * time.Hour)
+	stats, err = s.Sync(ctx, []flux.Resource{res("apps", flux.ReadyFalse, "Boom", "sha-2")})
+	if err != nil {
+		t.Fatalf("sync 4: %v", err)
+	}
+	if stats.EventsExpired != 1 || countEvents() != 1 {
+		t.Fatalf("expected exactly the aged event purged: stats=%+v events=%d", stats, countEvents())
+	}
+
+	// The resource row is untouched and the surviving history is the fresh event.
+	row, history, err := s.Get(ctx, "Kustomization", "flux-system", "apps")
+	if err != nil {
+		t.Fatalf("get apps: %v", err)
+	}
+	if row.Ready != flux.ReadyFalse {
+		t.Fatalf("purge disturbed the resource row: %+v", row)
+	}
+	if len(history) != 1 || history[0].Ready != flux.ReadyFalse {
+		t.Fatalf("unexpected history after purge: %+v", history)
+	}
+
+	// Steady state: nothing is old enough anymore, so the next sweep purges nothing.
+	stats, err = s.Sync(ctx, []flux.Resource{res("apps", flux.ReadyFalse, "Boom", "sha-2")})
+	if err != nil {
+		t.Fatalf("sync 5: %v", err)
+	}
+	if stats.EventsExpired != 0 || countEvents() != 1 {
+		t.Fatalf("steady-state sweep must purge nothing: stats=%+v events=%d", stats, countEvents())
+	}
+}
+
 // TestMetaRecordedOnSync checks the meta row: InitMeta stamps schema/agent
 // version with no sweep time yet, and a sweep records last_sweep_at.
 func TestMetaRecordedOnSync(t *testing.T) {


### PR DESCRIPTION
## Problem
`flux_status_event` grows unboundedly in every tenant DB and in the central mirror: the agent appends a row per ready/reason/revision transition and the server copies all of them, but rows are only deleted when their resource disappears. Both History endpoints cap at 50 recent rows per resource, so older rows are unreachable dead weight.

## Fix
- Both subcommands take `--event-retention` (default `720h`, `0` disables): the agent purges its tenant DB inside the `Sync` transaction; the server purges the central table once per sync cycle (non-fatal, retried next cycle).
- New `observed_at` indexes in both schemas keep the purge off seq scans.
- No SchemaVersion bump (stays 4): no column or read-contract change, so retention deploys independently of agent/server rollout order.
- Safety invariants encoded in e2e: the central copy cursor lives in `cluster_report.event_cursor`, not the event table — purging central rows neither regresses the incremental copy nor resurrects purged events. A tenant purge can drop uncopied events only if central sync lags longer than the retention window — accepted, documented at the purge site.

## Rollout
Default-on at 720h with unchanged manifests; the first sweep/cycle deletes the backlog older than 30 days (including old history of quiet resources). Tunable per env later via deployment args (`--event-retention=0` disables).

## Verification
- `make run-checks-ci-cache` — pass (fmt, vet, unit incl. new cursor/no-op tests, lint 0 issues)
- `make test-e2e-kind-ci` — pass, 18/18 incl. new `TestSyncEventRetention` + `TestCentralEventRetention`; re-run after rebasing onto #3820 (schema v4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)