### PR TITLE
chore(dis-console): roll out v1.6.0 server to admin clusters

### DIFF
--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.6.0
           args:
             - server
           ports:


### PR DESCRIPTION
Bumps the central server to [v1.6.0](https://github.com/Altinn/altinn-platform/releases/tag/dis-console-v1.6.0): base-layer artifact tracking (#3820, schema v4) and status-event retention (#3822, default 720h — the first sync cycle purges the central backlog older than 30 days).

Merge before the agents rollout PR: the v1.6.0 agents stamp tenant schema v4, which a v1.5.0 server would skip as unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)