### PR TITLE
chore(dis-console): roll out v1.6.0 agents

### DIFF
--- a/deploy/admin/base/dis-console-agent-deployment.yaml
+++ b/deploy/admin/base/dis-console-agent-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.6.0
           args:
             - agent
           ports:

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.6.0
           args:
             - agent
           ports:

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.6.0
           args:
             - agent
           ports:

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.5.0
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.6.0
           args:
             - agent
           ports:


### PR DESCRIPTION
Bumps every agent (admin base, at22/at23, tenant-app template) to [v1.6.0](https://github.com/Altinn/altinn-platform/releases/tag/dis-console-v1.6.0): base-layer artifact projection (#3820) and status-event retention (#3822, default 720h — each agent's first sweep purges its tenant backlog older than 30 days; watch for the one-off `N events expired` log line).

Merge after #3823: v1.6.0 agents stamp tenant schema v4, which the v1.5.0 server skips as unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)