### PR TITLE
feat(dis-console): sweep GitOps-applied workloads and surface container images

### DIFF
--- a/deploy/admin/base/dis-console-agent-rbac.yaml
+++ b/deploy/admin/base/dis-console-agent-rbac.yaml
@@ -64,6 +64,16 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -69,13 +69,16 @@ Do not claim checks passed unless you actually ran them.
   (health probes only); `server` migrates the central schema, runs the tenant
   sync loop, and serves the fleet API. Each wires its own DB pool and flags.
 - `internal/flux` — version-agnostic dynamic-client reader for the Flux and DIS
-  kinds; `normalize.go` decodes the projected status into the typed Flux `api`
+  kinds plus the GitOps-applied `apps` workloads (Deployment/StatefulSet/
+  DaemonSet, filtered on the kustomize-controller label in Sweep);
+  `normalize.go` decodes the projected status into the typed Flux `api`
   structs (kustomize/helm/source `api` + `pkg/apis/meta`) via runtime
-  conversion — and, for the DIS kinds, into a minimal local struct (never the
-  operator modules) that also projects `azureResourceId` and `parent` — while
-  keeping the full object for `raw`. `hygiene.go` strips volatile metadata
-  (`managedFields`, `resourceVersion`), computes the `content_hash`, and caps
-  `raw` at `MaxRawBytes`.
+  conversion — for the DIS kinds into a minimal local struct (never the
+  operator modules) that also projects `azureResourceId` and `parent`, and for
+  the workloads into `k8s.io/api/apps/v1` structs projecting `images` and
+  per-kind readiness — while keeping the full object for `raw`. `hygiene.go`
+  strips volatile metadata (`managedFields`, `resourceVersion`), computes the
+  `content_hash`, and caps `raw` at `MaxRawBytes`.
 - `internal/dbauth` — pgxpool builder; Entra-token `BeforeConnect` hook in the
   cluster, PGPASSWORD/trust fallback when Entra is disabled (Kind/CI/local).
 - `internal/store` — tenant pgxpool store: embedded `schema.sql`, `Migrate`,

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -33,6 +33,7 @@ via a discovery `RESTMapper` (robust to Azure Flux version bumps):
 | `vault.dis.altinn.cloud` | Vault |
 | `application.dis.altinn.cloud` | ApplicationIdentity |
 | `apim.dis.altinn.cloud` | Api, ApiVersion, Backend |
+| `apps` | Deployment, StatefulSet, DaemonSet — GitOps-applied only (see below) |
 
 A DIS kind whose CRD is not installed on a cluster is simply skipped by the
 sweep, so mixed fleets keep working.
@@ -52,6 +53,20 @@ an ApiVersion under the Api named by its controller owner reference). The DIS
 operators publish the same `Ready` condition; the APIM kinds publish only
 `status.provisioningState`, which is mapped onto ready
 (Succeeded→True, Failed→False, transitional→Unknown).
+
+The `apps` workloads are mirrored only when GitOps-applied — carrying the
+`kustomize.toolkit.fluxcd.io/name` label — which keeps kube-system and
+Azure-managed add-ons out. They exist for one field the Flux CRs cannot
+provide: `images` (`[{container,image}]` from `spec.template.spec.containers`;
+init containers skipped) — the app's *effective* version. A manifest revision
+or digest only names what should run, and with `postBuild` substitution the
+image tag can be resolved per cluster and never exist in git. `images` rides
+the list payload (`/api/resources?kind=Deployment`), so "which image runs
+where" needs no per-row detail fetch. Readiness is per kind (they share no
+condition semantics): Deployment takes its `Available` condition (and maps
+`spec.paused` onto `suspended`); StatefulSet and DaemonSet compare
+ready/desired replica counts, synthesized into a short reason/message
+(`2/3 ready`).
 
 Each kind is listed from the apiserver watch cache (`resourceVersion=0`, not a
 quorum read from etcd) and the discovery cache is refreshed only periodically,

--- a/services/dis-console/go.mod
+++ b/services/dis-console/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.30.0
 	github.com/fluxcd/source-controller/api v1.9.0
 	github.com/jackc/pgx/v5 v5.9.2
+	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 )
@@ -63,7 +64,6 @@ require (
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.36.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect

--- a/services/dis-console/internal/central/central.go
+++ b/services/dis-console/internal/central/central.go
@@ -115,7 +115,7 @@ INSERT INTO flux_resource (
     azure_resource_id, parent_kind, parent_name,
     applied_by_name, applied_by_namespace,
     source_ref_kind, source_ref_name, source_ref_namespace,
-    source_url, origin_revision, origin_source, inventory,
+    source_url, origin_revision, origin_source, inventory, images,
     updated_at, synced_at
 ) VALUES (
     $1, $2, $3, $4, $5,
@@ -124,8 +124,8 @@ INSERT INTO flux_resource (
     $16, $17, $18,
     $19, $20,
     $21, $22, $23,
-    $24, $25, $26, $27,
-    $28, now()
+    $24, $25, $26, $27, $28,
+    $29, now()
 )
 ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
     api_version          = EXCLUDED.api_version,
@@ -145,6 +145,7 @@ ON CONFLICT (cluster, kind, namespace, name) DO UPDATE SET
     origin_revision      = EXCLUDED.origin_revision,
     origin_source        = EXCLUDED.origin_source,
     inventory            = EXCLUDED.inventory,
+    images               = EXCLUDED.images,
     suspended            = EXCLUDED.suspended,
     generation           = EXCLUDED.generation,
     observed_generation  = EXCLUDED.observed_generation,
@@ -246,6 +247,10 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 			if err != nil {
 				return fmt.Errorf("%s %s/%s: %w", c.Kind, c.Namespace, c.Name, err)
 			}
+			images, err := imagesParam(c.Images)
+			if err != nil {
+				return fmt.Errorf("%s %s/%s: %w", c.Kind, c.Namespace, c.Name, err)
+			}
 			batch.Queue(upsertStmt,
 				st.Cluster, c.Kind, c.APIVersion, c.Namespace, c.Name,
 				c.Ready, c.Reason, c.Message, c.Revision, c.Suspended,
@@ -253,7 +258,7 @@ func (s *Store) Apply(ctx context.Context, st ClusterState) error {
 				c.AzureResourceID, parentKind, parentName,
 				appliedByName, appliedByNamespace,
 				sourceRefKind, sourceRefName, sourceRefNamespace,
-				nullable(c.SourceURL), nullable(c.OriginRevision), nullable(c.OriginSource), inventory,
+				nullable(c.SourceURL), nullable(c.OriginRevision), nullable(c.OriginSource), inventory, images,
 				c.UpdatedAt,
 			)
 		}
@@ -416,6 +421,31 @@ func inventoryFrom(raw []byte) ([]flux.InventoryEntry, error) {
 	return entries, nil
 }
 
+// imagesParam marshals a workload's images for their jsonb column; SQL NULL
+// when the resource has none.
+func imagesParam(images []flux.ContainerImage) (any, error) {
+	if len(images) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(images)
+	if err != nil {
+		return nil, fmt.Errorf("marshal images: %w", err)
+	}
+	return b, nil
+}
+
+// imagesFrom rebuilds the images from their jsonb column; nil when NULL.
+func imagesFrom(raw []byte) ([]flux.ContainerImage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var images []flux.ContainerImage
+	if err := json.Unmarshal(raw, &images); err != nil {
+		return nil, fmt.Errorf("unmarshal images: %w", err)
+	}
+	return images, nil
+}
+
 // clusterID strips the tenant-database prefix to get the cluster identifier
 // (e.g. "dis_console_ttd_at23" -> "ttd_at23").
 func clusterID(dbName string) string { return strings.TrimPrefix(dbName, dbPrefix) }
@@ -561,7 +591,8 @@ SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revi
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
        applied_by_name, applied_by_namespace,
        source_ref_kind, source_ref_name, source_ref_namespace,
-       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, '')
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
+       images
 FROM flux_resource
 WHERE ($1 = '' OR cluster = $1)
   AND ($2 = '' OR lower(kind) = lower($2))
@@ -573,7 +604,8 @@ ORDER BY cluster, kind, namespace, name`
 // across the fleet, or for one cluster when cluster is non-empty. An empty
 // kind/namespace/ready means "any". appliedBy rides in the list payload so the
 // UI can group child HelmReleases under their parent Kustomization without
-// fetching detail; sourceRef/sourceUrl/origin ride for the artifacts view.
+// fetching detail; sourceRef/sourceUrl/origin ride for the artifacts view, and
+// images ride so "which image runs where" is a plain ?kind=Deployment list.
 func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string) ([]Resource, error) {
 	rows, err := s.pool.Query(ctx, listStmt, cluster, kind, namespace, ready)
 	if err != nil {
@@ -587,6 +619,7 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 		var parentKind, parentName *string
 		var appliedByName, appliedByNamespace *string
 		var sourceRefKind, sourceRefName, sourceRefNamespace *string
+		var images []byte
 		if err := rows.Scan(
 			&r.Cluster, &r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
@@ -595,12 +628,16 @@ func (s *Store) List(ctx context.Context, cluster, kind, namespace, ready string
 			&appliedByName, &appliedByNamespace,
 			&sourceRefKind, &sourceRefName, &sourceRefNamespace,
 			&r.SourceURL, &r.OriginRevision, &r.OriginSource,
+			&images,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		r.Parent = parentRef(parentKind, parentName)
 		r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 		r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
+		if r.Images, err = imagesFrom(images); err != nil {
+			return nil, err
+		}
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -613,7 +650,7 @@ SELECT cluster, kind, api_version, namespace, name, ready, reason, message, revi
        applied_by_name, applied_by_namespace,
        source_ref_kind, source_ref_name, source_ref_namespace,
        COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
-       inventory
+       inventory, images
 FROM flux_resource
 WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
 
@@ -621,7 +658,7 @@ WHERE cluster = $1 AND lower(kind) = lower($2) AND namespace = $3 AND name = $4`
 // cluster, or ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) (*Resource, error) {
 	var r Resource
-	var raw, inventory []byte
+	var raw, inventory, images []byte
 	var parentKind, parentName *string
 	var appliedByName, appliedByNamespace *string
 	var sourceRefKind, sourceRefName, sourceRefNamespace *string
@@ -633,7 +670,7 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 		&appliedByName, &appliedByNamespace,
 		&sourceRefKind, &sourceRefName, &sourceRefNamespace,
 		&r.SourceURL, &r.OriginRevision, &r.OriginSource,
-		&inventory,
+		&inventory, &images,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -646,6 +683,9 @@ func (s *Store) Get(ctx context.Context, cluster, kind, namespace, name string) 
 	r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 	r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
 	if r.Inventory, err = inventoryFrom(inventory); err != nil {
+		return nil, err
+	}
+	if r.Images, err = imagesFrom(images); err != nil {
 		return nil, err
 	}
 	return &r, nil

--- a/services/dis-console/internal/central/engine.go
+++ b/services/dis-console/internal/central/engine.go
@@ -128,9 +128,9 @@ func (e *Engine) syncCluster(ctx context.Context, dbName string) error {
 	if err != nil {
 		return err
 	}
-	// The pull is keyed on the tenant's schema version: a version-3 tenant
-	// (agent not yet migrated) lacks the base-layer columns, so selecting
-	// them would fail the cluster's sync until its agent rolls out.
+	// The pull is keyed on the tenant's schema version: a version-4 tenant
+	// (agent not yet migrated) lacks the images column, so selecting it
+	// would fail the cluster's sync until its agent rolls out.
 	changed, err := ts.ChangedSince(ctx, cursor, meta.SchemaVersion)
 	if err != nil {
 		return err

--- a/services/dis-console/internal/central/schema.sql
+++ b/services/dis-console/internal/central/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS flux_resource (
     origin_revision      text,
     origin_source        text,
     inventory            jsonb,
+    images               jsonb,
     suspended            boolean     NOT NULL DEFAULT false,
     generation           bigint,
     observed_generation  bigint,
@@ -78,3 +79,4 @@ ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_url text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_revision text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_source text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS inventory jsonb;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS images jsonb;

--- a/services/dis-console/internal/flux/client.go
+++ b/services/dis-console/internal/flux/client.go
@@ -1,6 +1,7 @@
-// Package flux reads Flux and DIS custom resources across all namespaces using
-// the dynamic client and a discovery-backed RESTMapper, and normalizes their
-// deployment status into a small, stable shape the API serves.
+// Package flux reads Flux and DIS custom resources — plus the GitOps-applied
+// apps workloads — across all namespaces using the dynamic client and a
+// discovery-backed RESTMapper, and normalizes their deployment status into a
+// small, stable shape the API serves.
 //
 // The fetch stays dynamic on purpose (the discovery RESTMapper resolves
 // whichever served version Azure Flux exposes, and the full object is kept
@@ -57,6 +58,19 @@ const (
 	KindBackend             = "Backend"
 )
 
+// The built-in apps group and its workload kinds. An app's effective version
+// is its container image, which manifest revisions cannot show (postBuild
+// substitution can resolve a tag per cluster), so the sweep mirrors the
+// long-running workloads too. Jobs/CronJobs/Pods are deliberately out: the
+// console models what should be running, not runs.
+const (
+	GroupApps = "apps"
+
+	KindDeployment  = "Deployment"
+	KindStatefulSet = "StatefulSet"
+	KindDaemonSet   = "DaemonSet"
+)
+
 // isDISGroup reports whether group is one of the DIS platform API groups, which
 // normalize projects via the DIS status shape instead of the typed Flux structs.
 func isDISGroup(group string) bool {
@@ -67,11 +81,12 @@ func isDISGroup(group string) bool {
 	return false
 }
 
-// TargetKinds are the custom resource kinds the Console reads: the Flux
-// deployment machinery plus the DIS platform resources. The served API version
-// of each is resolved at runtime via the discovery RESTMapper, so the same
-// binary keeps working if Azure Flux bumps a version; kinds whose CRD is not
-// installed on a cluster are skipped by Sweep.
+// TargetKinds are the kinds the Console reads: the Flux deployment machinery,
+// the DIS platform resources, and the apps workload kinds (GitOps-applied
+// only — see Sweep). The served API version of each is resolved at runtime via
+// the discovery RESTMapper, so the same binary keeps working if Azure Flux
+// bumps a version; kinds whose CRD is not installed on a cluster are skipped
+// by Sweep (the apps kinds are built-in and always served).
 var TargetKinds = []schema.GroupKind{
 	{Group: GroupKustomize, Kind: KindKustomization},
 	{Group: GroupHelm, Kind: KindHelmRelease},
@@ -85,6 +100,9 @@ var TargetKinds = []schema.GroupKind{
 	{Group: GroupDISApim, Kind: KindApi},
 	{Group: GroupDISApim, Kind: KindApiVersion},
 	{Group: GroupDISApim, Kind: KindBackend},
+	{Group: GroupApps, Kind: KindDeployment},
+	{Group: GroupApps, Kind: KindStatefulSet},
+	{Group: GroupApps, Kind: KindDaemonSet},
 }
 
 // discoveryTTL bounds how often Sweep refreshes the discovery cache. It is long
@@ -155,6 +173,11 @@ func restConfig(local bool) (*rest.Config, error) {
 // (RBAC, auth, apiserver outage) aborts the sweep with an error so the caller
 // keeps the previous snapshot instead of publishing a partial one.
 //
+// Workloads (the apps kinds) are mirrored only when GitOps-applied — carrying
+// the kustomize-controller ownership label — which keeps kube-system and
+// Azure-managed add-ons out and matches the console's app model (everything
+// it shows joins a Kustomization's appliedBy closure).
+//
 // The discovery cache is reset at most once per discoveryTTL rather than on
 // every sweep, so a newly installed Flux CRD is detected only on the next reset
 // — up to discoveryTTL (~10 min) after it appears. Sweep is not safe for
@@ -192,6 +215,9 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 			return nil, warnings, fmt.Errorf("list %s: %w", gk, err)
 		}
 		for i := range list.Items {
+			if gk.Group == GroupApps && list.Items[i].GetLabels()[LabelAppliedByName] == "" {
+				continue
+			}
 			r, err := normalize(&list.Items[i])
 			if err != nil {
 				warnings = append(warnings, fmt.Errorf("normalize %s: %w", gk, err))

--- a/services/dis-console/internal/flux/client.go
+++ b/services/dis-console/internal/flux/client.go
@@ -210,7 +210,15 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 		// allows is irrelevant to a status poller (the agent re-lists every poll
 		// interval and the Console marks clusters stale only after minutes), and
 		// it keeps the repeated fleet-wide lists off etcd.
-		list, err := nri.List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+		opts := metav1.ListOptions{ResourceVersion: "0"}
+		if gk.Group == GroupApps {
+			// Existence selector: the apiserver drops unlabeled workloads
+			// (kube-system, Azure add-ons) before they ride the response. The
+			// in-loop guard below owns the semantics — it also drops a
+			// present-but-empty label, which a bare selector matches.
+			opts.LabelSelector = LabelAppliedByName
+		}
+		list, err := nri.List(ctx, opts)
 		if err != nil {
 			return nil, warnings, fmt.Errorf("list %s: %w", gk, err)
 		}

--- a/services/dis-console/internal/flux/client_test.go
+++ b/services/dis-console/internal/flux/client_test.go
@@ -39,28 +39,32 @@ func (m *fakeMapper) RESTMapping(gk schema.GroupKind, _ ...string) (*apimeta.RES
 }
 
 // fakeDynamic is a dynamic.Interface that records the ListOptions of every
-// List and returns an empty list. We capture the options here rather than via
-// dynamic/fake because the fake client drops ResourceVersion when building its
-// recorded action, which is exactly the field these tests assert on.
+// List and returns the items seeded for the resource (empty when none). We
+// capture the options here rather than via dynamic/fake because the fake
+// client drops ResourceVersion when building its recorded action, which is
+// exactly the field these tests assert on.
 type fakeDynamic struct {
 	dynamic.Interface
 	listOpts []metav1.ListOptions
+	// items are the objects List returns, keyed by resource (e.g. "deployments").
+	items map[string][]unstructured.Unstructured
 }
 
-func (d *fakeDynamic) Resource(schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
-	return &fakeResource{parent: d}
+func (d *fakeDynamic) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &fakeResource{parent: d, resource: gvr.Resource}
 }
 
 type fakeResource struct {
 	dynamic.NamespaceableResourceInterface
-	parent *fakeDynamic
+	parent   *fakeDynamic
+	resource string
 }
 
 func (r *fakeResource) Namespace(string) dynamic.ResourceInterface { return r }
 
 func (r *fakeResource) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	r.parent.listOpts = append(r.parent.listOpts, opts)
-	return &unstructured.UnstructuredList{}, nil
+	return &unstructured.UnstructuredList{Items: r.parent.items[r.resource]}, nil
 }
 
 func TestSweepResetsDiscoveryOnTTL(t *testing.T) {
@@ -110,6 +114,55 @@ func TestSweepListsFromWatchCache(t *testing.T) {
 			t.Errorf("list[%d] ResourceVersion = %q, want %q (served from the watch cache)",
 				i, opts.ResourceVersion, "0")
 		}
+	}
+}
+
+// TestSweepMirrorsOnlyGitOpsAppliedWorkloads pins the workload filter: an apps
+// object without the kustomize-controller ownership label (kube-system,
+// Azure-managed add-ons) is dropped before normalize, while the labeled one is
+// mirrored — and non-workload kinds are never filtered, labeled or not.
+func TestSweepMirrorsOnlyGitOpsAppliedWorkloads(t *testing.T) {
+	workload := func(name string, labels map[string]any) unstructured.Unstructured {
+		meta := map[string]any{"namespace": "ns", "name": name}
+		if labels != nil {
+			meta["labels"] = labels
+		}
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   meta,
+		}}
+	}
+	d := &fakeDynamic{items: map[string][]unstructured.Unstructured{
+		"deployments": {
+			workload("gitops-app", map[string]any{LabelAppliedByName: "app", LabelAppliedByNamespace: "ns"}),
+			workload("azure-managed", nil),
+		},
+		// An unlabeled non-workload kind must not be filtered.
+		"kustomizations": {{Object: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata":   map[string]any{"namespace": "flux-system", "name": "root"},
+		}}},
+	}}
+	c := &Client{dyn: d, mapper: &fakeMapper{}}
+
+	resources, warnings, err := c.Sweep(context.Background())
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	names := make([]string, len(resources))
+	for i, r := range resources {
+		names[i] = r.Name
+	}
+	if len(resources) != 2 || resources[0].Name != "root" || resources[1].Name != "gitops-app" {
+		t.Fatalf("expected the root Kustomization and the labeled workload only, got %v", names)
+	}
+	if resources[1].AppliedBy == nil || resources[1].AppliedBy.Name != "app" {
+		t.Fatalf("mirrored workload lost appliedBy: %+v", resources[1].AppliedBy)
 	}
 }
 

--- a/services/dis-console/internal/flux/client_test.go
+++ b/services/dis-console/internal/flux/client_test.go
@@ -114,6 +114,15 @@ func TestSweepListsFromWatchCache(t *testing.T) {
 			t.Errorf("list[%d] ResourceVersion = %q, want %q (served from the watch cache)",
 				i, opts.ResourceVersion, "0")
 		}
+		// The apps kinds are filtered to GitOps-applied objects server-side;
+		// every other kind lists unfiltered.
+		wantSelector := ""
+		if TargetKinds[i].Group == GroupApps {
+			wantSelector = LabelAppliedByName
+		}
+		if opts.LabelSelector != wantSelector {
+			t.Errorf("list[%d] LabelSelector = %q, want %q", i, opts.LabelSelector, wantSelector)
+		}
 	}
 }
 

--- a/services/dis-console/internal/flux/normalize.go
+++ b/services/dis-console/internal/flux/normalize.go
@@ -10,6 +10,8 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -62,12 +64,19 @@ type Resource struct {
 	// --source`), surfaced by source-controller in status.artifact.metadata:
 	// the git branch/SHA and repository behind the artifact digest. Empty when
 	// the pusher did not annotate.
-	OriginRevision     string     `json:"originRevision,omitempty"`
-	OriginSource       string     `json:"originSource,omitempty"`
-	Suspended          bool       `json:"suspended"`
-	Generation         int64      `json:"generation,omitempty"`
-	ObservedGeneration int64      `json:"observedGeneration,omitempty"`
-	LastTransition     *time.Time `json:"lastTransition,omitempty"`
+	OriginRevision string `json:"originRevision,omitempty"`
+	OriginSource   string `json:"originSource,omitempty"`
+	// Images are a workload's container images from its pod template
+	// (spec.template.spec.containers; init containers are skipped) — the
+	// app's effective version, which the manifest revision cannot show when
+	// the tag is resolved per cluster via postBuild substitution. Rides in
+	// list payloads (unlike Raw/Inventory) so the UI needs no detail fetch.
+	// Nil for every non-workload kind.
+	Images             []ContainerImage `json:"images,omitempty"`
+	Suspended          bool             `json:"suspended"`
+	Generation         int64            `json:"generation,omitempty"`
+	ObservedGeneration int64            `json:"observedGeneration,omitempty"`
+	LastTransition     *time.Time       `json:"lastTransition,omitempty"`
 	// Inventory is a Kustomization's applied-object set (status.inventory) —
 	// the parent→children edge of the deployment tree, covering kinds the agent
 	// does not sweep. Like Raw it is served on detail endpoints only; list
@@ -112,6 +121,13 @@ type SourceRef struct {
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
+}
+
+// ContainerImage is one container of a workload's pod template and the image
+// it runs. The JSON shape (container/image) is part of the UI contract.
+type ContainerImage struct {
+	Container string `json:"container"`
+	Image     string `json:"image"`
 }
 
 // InventoryEntry is one applied-object reference from a Kustomization's
@@ -170,10 +186,14 @@ func normalize(u *unstructured.Unstructured) (Resource, error) {
 // applyTypedStatus decodes the object into its typed Flux struct and fills the
 // projected status fields. The Ready condition is shared by every Flux kind
 // (meta.fluxcd.io semantics); the revision source differs per kind. DIS kinds
-// take their own projection path (see applyDISStatus).
+// and the apps workloads take their own projection paths (applyDISStatus,
+// applyWorkloadStatus).
 func (r *Resource) applyTypedStatus(u *unstructured.Unstructured) error {
-	if isDISGroup(u.GroupVersionKind().Group) {
+	switch group := u.GroupVersionKind().Group; {
+	case isDISGroup(group):
 		return r.applyDISStatus(u)
+	case group == GroupApps:
+		return r.applyWorkloadStatus(u)
 	}
 	switch u.GetKind() {
 	case KindKustomization:
@@ -392,6 +412,91 @@ func readyFromProvisioningState(state string) string {
 	default:
 		return ReadyUnknown
 	}
+}
+
+// applyWorkloadStatus fills the projected fields for an apps workload, decoded
+// into the typed k8s.io/api structs the same runtime-conversion way as the
+// Flux kinds. All three kinds project their pod template's container images;
+// readiness is per kind because they share no condition semantics: Deployment
+// publishes an Available condition, StatefulSet and DaemonSet publish only
+// replica counts, which are synthesized into a short reason/message.
+func (r *Resource) applyWorkloadStatus(u *unstructured.Unstructured) error {
+	switch u.GetKind() {
+	case KindDeployment:
+		var o appsv1.Deployment
+		if err := fromUnstructured(u, &o); err != nil {
+			return err
+		}
+		// paused is the workload analogue of a suspended Flux object:
+		// intentionally not being reconciled.
+		r.Suspended = o.Spec.Paused
+		r.ObservedGeneration = o.Status.ObservedGeneration
+		r.Images = containerImages(o.Spec.Template.Spec.Containers)
+		for _, c := range o.Status.Conditions {
+			if c.Type != appsv1.DeploymentAvailable {
+				continue
+			}
+			r.Ready = string(c.Status)
+			r.Reason = c.Reason
+			r.Message = c.Message
+			if !c.LastTransitionTime.Time.IsZero() {
+				t := c.LastTransitionTime.Time
+				r.LastTransition = &t
+			}
+		}
+	case KindStatefulSet:
+		var o appsv1.StatefulSet
+		if err := fromUnstructured(u, &o); err != nil {
+			return err
+		}
+		r.ObservedGeneration = o.Status.ObservedGeneration
+		r.Images = containerImages(o.Spec.Template.Spec.Containers)
+		desired := int32(1) // nil spec.replicas defaults to 1
+		if o.Spec.Replicas != nil {
+			desired = *o.Spec.Replicas
+		}
+		r.applyReadyReplicas(o.Status.ReadyReplicas, desired)
+	case KindDaemonSet:
+		var o appsv1.DaemonSet
+		if err := fromUnstructured(u, &o); err != nil {
+			return err
+		}
+		r.ObservedGeneration = o.Status.ObservedGeneration
+		r.Images = containerImages(o.Spec.Template.Spec.Containers)
+		r.applyReadyReplicas(o.Status.NumberReady, o.Status.DesiredNumberScheduled)
+	}
+	return nil
+}
+
+// applyReadyReplicas derives readiness from a workload's replica counts (the
+// kinds without a usable condition): every desired replica ready is healthy —
+// including a scaled-to-zero 0/0. An object its controller has never observed
+// (observedGeneration 0) stays Unknown rather than claiming 0/0 ready; a stale
+// True is downgraded by the generic observedGeneration check in normalize.
+func (r *Resource) applyReadyReplicas(ready, desired int32) {
+	if r.ObservedGeneration == 0 {
+		return
+	}
+	r.Ready = ReadyFalse
+	if ready == desired {
+		r.Ready = ReadyTrue
+	}
+	r.Reason = "ReadyReplicas"
+	r.Message = fmt.Sprintf("%d/%d ready", ready, desired)
+}
+
+// containerImages projects a pod template's containers into the images list;
+// nil when there are none. Init containers are deliberately skipped: the
+// long-running containers are what carries the app's version.
+func containerImages(containers []corev1.Container) []ContainerImage {
+	if len(containers) == 0 {
+		return nil
+	}
+	out := make([]ContainerImage, len(containers))
+	for i, c := range containers {
+		out[i] = ContainerImage{Container: c.Name, Image: c.Image}
+	}
+	return out
 }
 
 // fromUnstructured decodes the (version-agnostically fetched) object into a

--- a/services/dis-console/internal/flux/normalize_test.go
+++ b/services/dis-console/internal/flux/normalize_test.go
@@ -436,6 +436,237 @@ func TestNormalizeHelmRepositoryURLWithoutOrigin(t *testing.T) {
 	}
 }
 
+// A GitOps-applied Deployment projects its pod template's container images
+// (init containers skipped), takes readiness from the Available condition, and
+// joins the app closure through the same kustomize-controller labels as every
+// other kind.
+func TestNormalizeDeploymentImagesAndAvailable(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"namespace":  "product-team-a",
+			"name":       "app",
+			"generation": int64(7),
+			"labels": map[string]any{
+				"kustomize.toolkit.fluxcd.io/name":      "team-a-ab12-team-a",
+				"kustomize.toolkit.fluxcd.io/namespace": "product-team-a",
+			},
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"initContainers": []any{
+						map[string]any{"name": "migrate", "image": "registry.example.com/team-a/migrate:v9"},
+					},
+					"containers": []any{
+						map[string]any{"name": "app", "image": "registry.example.com/team-a/app:v42"},
+						map[string]any{"name": "sidecar", "image": "registry.example.com/team-a/sidecar:v1"},
+					},
+				},
+			},
+		},
+		"status": map[string]any{
+			"observedGeneration": int64(7),
+			"conditions": []any{
+				map[string]any{
+					"type":               "Progressing",
+					"status":             "True",
+					"reason":             "NewReplicaSetAvailable",
+					"message":            "ReplicaSet has successfully progressed.",
+					"lastTransitionTime": "2026-07-01T10:00:00Z",
+				},
+				map[string]any{
+					"type":               "Available",
+					"status":             "True",
+					"reason":             "MinimumReplicasAvailable",
+					"message":            "Deployment has minimum availability.",
+					"lastTransitionTime": "2026-07-01T10:05:00Z",
+				},
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(r.Images) != 2 ||
+		r.Images[0] != (ContainerImage{Container: "app", Image: "registry.example.com/team-a/app:v42"}) ||
+		r.Images[1] != (ContainerImage{Container: "sidecar", Image: "registry.example.com/team-a/sidecar:v1"}) {
+		t.Fatalf("unexpected images (init containers must be skipped): %+v", r.Images)
+	}
+	if r.Ready != ReadyTrue || r.Reason != "MinimumReplicasAvailable" {
+		t.Fatalf("expected ready from the Available condition, got %+v", r)
+	}
+	if r.LastTransition == nil {
+		t.Fatalf("expected lastTransition from the Available condition")
+	}
+	if r.Suspended {
+		t.Fatalf("unpaused deployment must not be suspended")
+	}
+	if r.AppliedBy == nil || r.AppliedBy.Name != "team-a-ab12-team-a" {
+		t.Fatalf("workloads must join the app closure via appliedBy: %+v", r.AppliedBy)
+	}
+}
+
+// A paused Deployment maps onto the console's suspended flag (intentionally
+// not reconciling); one that lost minimum availability surfaces the Available
+// condition's False verbatim.
+func TestNormalizeDeploymentPausedAndUnavailable(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"namespace": "product-team-a", "name": "app"},
+		"spec":       map[string]any{"paused": true},
+		"status": map[string]any{
+			"observedGeneration": int64(1),
+			"conditions": []any{
+				map[string]any{
+					"type":    "Available",
+					"status":  "False",
+					"reason":  "MinimumReplicasUnavailable",
+					"message": "Deployment does not have minimum availability.",
+				},
+			},
+		},
+	}}
+
+	r, err := normalize(u)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !r.Suspended {
+		t.Fatalf("paused deployment should project suspended")
+	}
+	if r.Ready != ReadyFalse || r.Reason != "MinimumReplicasUnavailable" {
+		t.Fatalf("unexpected ready condition: %+v", r)
+	}
+	if r.Images != nil {
+		t.Fatalf("no containers => nil images, got %+v", r.Images)
+	}
+}
+
+// StatefulSet readiness is replica math (there is no usable condition): every
+// desired replica ready is healthy, a shortfall is not, and an object its
+// controller never observed stays Unknown instead of claiming 0/0 ready.
+func TestNormalizeStatefulSetReadyFromReplicas(t *testing.T) {
+	sts := func(replicas any, status map[string]any) *unstructured.Unstructured {
+		spec := map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "db", "image": "registry.example.com/team-a/db:16.4"},
+					},
+				},
+			},
+		}
+		if replicas != nil {
+			spec["replicas"] = replicas
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata":   map[string]any{"namespace": "product-team-a", "name": "db"},
+			"spec":       spec,
+			"status":     status,
+		}}
+	}
+
+	cases := []struct {
+		name        string
+		u           *unstructured.Unstructured
+		wantReady   string
+		wantMessage string
+	}{
+		{
+			name:        "all replicas ready",
+			u:           sts(int64(3), map[string]any{"observedGeneration": int64(2), "readyReplicas": int64(3)}),
+			wantReady:   ReadyTrue,
+			wantMessage: "3/3 ready",
+		},
+		{
+			name:        "shortfall",
+			u:           sts(int64(3), map[string]any{"observedGeneration": int64(2), "readyReplicas": int64(2)}),
+			wantReady:   ReadyFalse,
+			wantMessage: "2/3 ready",
+		},
+		{
+			name:        "nil replicas defaults to one",
+			u:           sts(nil, map[string]any{"observedGeneration": int64(1), "readyReplicas": int64(1)}),
+			wantReady:   ReadyTrue,
+			wantMessage: "1/1 ready",
+		},
+		{
+			name:      "never observed stays unknown",
+			u:         sts(int64(3), map[string]any{}),
+			wantReady: ReadyUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := normalize(tc.u)
+			if err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if r.Ready != tc.wantReady {
+				t.Fatalf("ready: got %q, want %q", r.Ready, tc.wantReady)
+			}
+			if r.Message != tc.wantMessage {
+				t.Fatalf("message: got %q, want %q", r.Message, tc.wantMessage)
+			}
+			if len(r.Images) != 1 || r.Images[0].Image != "registry.example.com/team-a/db:16.4" {
+				t.Fatalf("unexpected images: %+v", r.Images)
+			}
+		})
+	}
+}
+
+// DaemonSet readiness compares ready pods against the nodes that should run
+// one; a scheduling shortfall is False with the counts in the message.
+func TestNormalizeDaemonSetReadyFromCounts(t *testing.T) {
+	ds := func(status map[string]any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "DaemonSet",
+			"metadata":   map[string]any{"namespace": "platform-system", "name": "node-agent"},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{"name": "agent", "image": "registry.example.com/platform/agent:v3"},
+						},
+					},
+				},
+			},
+			"status": status,
+		}}
+	}
+
+	r, err := normalize(ds(map[string]any{
+		"observedGeneration": int64(1), "desiredNumberScheduled": int64(4), "numberReady": int64(4),
+	}))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.Ready != ReadyTrue || r.Message != "4/4 ready" {
+		t.Fatalf("unexpected healthy daemonset: %+v", r)
+	}
+	if len(r.Images) != 1 || r.Images[0].Container != "agent" {
+		t.Fatalf("unexpected images: %+v", r.Images)
+	}
+
+	r, err = normalize(ds(map[string]any{
+		"observedGeneration": int64(1), "desiredNumberScheduled": int64(4), "numberReady": int64(2),
+	}))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if r.Ready != ReadyFalse || r.Reason != "ReadyReplicas" || r.Message != "2/4 ready" {
+		t.Fatalf("unexpected degraded daemonset: %+v", r)
+	}
+}
+
 func TestNormalizeOCIRepositoryRevisionFromArtifact(t *testing.T) {
 	u := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "source.toolkit.fluxcd.io/v1",

--- a/services/dis-console/internal/store/schema.sql
+++ b/services/dis-console/internal/store/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS flux_resource (
     origin_revision      text,
     origin_source        text,
     inventory            jsonb,
+    images               jsonb,
     suspended            boolean     NOT NULL DEFAULT false,
     generation           bigint,
     observed_generation  bigint,
@@ -44,6 +45,7 @@ ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS source_url text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_revision text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS origin_source text;
 ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS inventory jsonb;
+ALTER TABLE flux_resource ADD COLUMN IF NOT EXISTS images jsonb;
 
 CREATE INDEX IF NOT EXISTS idx_flux_resource_ready ON flux_resource (lower(ready));
 CREATE INDEX IF NOT EXISTS idx_flux_resource_kind  ON flux_resource (lower(kind));

--- a/services/dis-console/internal/store/store.go
+++ b/services/dis-console/internal/store/store.go
@@ -66,16 +66,16 @@ func (s *Store) Migrate(ctx context.Context) error {
 // the meta row at startup. The central console reads it to stay tolerant of
 // agents rolling out across the fleet at different times.
 //
-// Version 2 added the DIS projection columns (azure_resource_id, parent_kind,
-// parent_name). Version 3 added the applied-by columns (applied_by_name,
+// Version 3 added the applied-by columns (applied_by_name,
 // applied_by_namespace — the owning Kustomization). Version 4 added the
 // base-layer columns (source_ref_*, source_url, origin_revision,
 // origin_source, inventory — the artifact identity and applied-object set
-// behind the artifacts view). ChangedSince selects per version so the server
-// can still pull version-3 tenants whose agents have not migrated yet;
-// version 2 fell out of the supported window (schemaSupported covers the
-// current version and the previous one).
-const SchemaVersion = 4
+// behind the artifacts view). Version 5 added the images column (a workload's
+// container images — the app's effective running version). ChangedSince
+// selects per version so the server can still pull version-4 tenants whose
+// agents have not migrated yet; version 3 fell out of the supported window
+// (schemaSupported covers the current version and the previous one).
+const SchemaVersion = 5
 
 // Meta is the single bookkeeping row each agent maintains in its tenant DB.
 type Meta struct {
@@ -214,6 +214,31 @@ func inventoryFrom(raw []byte) ([]flux.InventoryEntry, error) {
 	return entries, nil
 }
 
+// imagesParam marshals a workload's images for their jsonb column; SQL NULL
+// when the resource has none.
+func imagesParam(images []flux.ContainerImage) (any, error) {
+	if len(images) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(images)
+	if err != nil {
+		return nil, fmt.Errorf("marshal images: %w", err)
+	}
+	return b, nil
+}
+
+// imagesFrom rebuilds the images from their jsonb column; nil when NULL.
+func imagesFrom(raw []byte) ([]flux.ContainerImage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var images []flux.ContainerImage
+	if err := json.Unmarshal(raw, &images); err != nil {
+		return nil, fmt.Errorf("unmarshal images: %w", err)
+	}
+	return images, nil
+}
+
 // upsertStmt upserts one resource and, in the same statement, writes a history
 // event when the row is new or its ready/reason/revision changed. The `prev`
 // CTE reads the pre-upsert row (CTEs see the snapshot from the start of the
@@ -229,8 +254,8 @@ func inventoryFrom(raw []byte) ([]flux.InventoryEntry, error) {
 // were seen this sweep.
 //
 // updated_at additionally advances when a projection-only column (the
-// applied-by pair and the base-layer columns) differs from the stored value.
-// The hash covers the object, not the agent's projection of it: when a
+// applied-by pair, the base-layer columns and images) differs from the stored
+// value. The hash covers the object, not the agent's projection of it: when a
 // projection change (like adding appliedBy, or the v4 base-layer fields)
 // starts deriving new columns from content that was already in the hashed
 // object, every pre-existing row gets the new columns with an unchanged hash —
@@ -253,7 +278,7 @@ up AS (
         azure_resource_id, parent_kind, parent_name,
         applied_by_name, applied_by_namespace,
         source_ref_kind, source_ref_name, source_ref_namespace,
-        source_url, origin_revision, origin_source, inventory,
+        source_url, origin_revision, origin_source, inventory, images,
         first_seen, last_seen, updated_at
     ) VALUES (
         $1, $2, $3, $4,
@@ -262,7 +287,7 @@ up AS (
         $15, $16, $17,
         $18, $19,
         $20, $21, $22,
-        $23, $24, $25, $26,
+        $23, $24, $25, $26, $27,
         now(), now(), now()
     )
     ON CONFLICT (kind, namespace, name) DO UPDATE SET
@@ -283,6 +308,7 @@ up AS (
         origin_revision      = EXCLUDED.origin_revision,
         origin_source        = EXCLUDED.origin_source,
         inventory            = EXCLUDED.inventory,
+        images               = EXCLUDED.images,
         suspended            = EXCLUDED.suspended,
         generation           = EXCLUDED.generation,
         observed_generation  = EXCLUDED.observed_generation,
@@ -303,6 +329,7 @@ up AS (
               OR r.origin_revision IS DISTINCT FROM EXCLUDED.origin_revision
               OR r.origin_source IS DISTINCT FROM EXCLUDED.origin_source
               OR r.inventory IS DISTINCT FROM EXCLUDED.inventory
+              OR r.images IS DISTINCT FROM EXCLUDED.images
             THEN now() ELSE r.updated_at END
     RETURNING ready, reason, message, revision
 )
@@ -347,6 +374,10 @@ func (s *Store) Sync(ctx context.Context, resources []flux.Resource) (SyncStats,
 			if err != nil {
 				return stats, fmt.Errorf("%s %s/%s: %w", r.Kind, r.Namespace, r.Name, err)
 			}
+			images, err := imagesParam(r.Images)
+			if err != nil {
+				return stats, fmt.Errorf("%s %s/%s: %w", r.Kind, r.Namespace, r.Name, err)
+			}
 			batch.Queue(upsertStmt,
 				r.Kind, r.APIVersion, r.Namespace, r.Name,
 				r.Ready, r.Reason, r.Message, r.Revision, r.Suspended,
@@ -354,7 +385,7 @@ func (s *Store) Sync(ctx context.Context, resources []flux.Resource) (SyncStats,
 				r.AzureResourceID, parentKind, parentName,
 				appliedByName, appliedByNamespace,
 				sourceRefKind, sourceRefName, sourceRefNamespace,
-				nullable(r.SourceURL), nullable(r.OriginRevision), nullable(r.OriginSource), inventory,
+				nullable(r.SourceURL), nullable(r.OriginRevision), nullable(r.OriginSource), inventory, images,
 			)
 		}
 		br := tx.SendBatch(ctx, batch)
@@ -496,16 +527,17 @@ SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
        applied_by_name, applied_by_namespace,
        source_ref_kind, source_ref_name, source_ref_namespace,
-       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, '')
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
+       images
 FROM flux_resource
 WHERE ($1 = '' OR lower(kind) = lower($1))
   AND ($2 = '' OR namespace = $2)
   AND ($3 = '' OR lower(ready) = lower($3))
 ORDER BY kind, namespace, name`
 
-// List returns normalized rows (without the raw and inventory payloads)
-// filtered by the optional kind/namespace/ready arguments; an empty argument
-// means "any".
+// List returns normalized rows (without the raw and inventory payloads, but
+// with images — the workload strip reads the list) filtered by the optional
+// kind/namespace/ready arguments; an empty argument means "any".
 func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux.Resource, error) {
 	rows, err := s.pool.Query(ctx, listStmt, kind, namespace, ready)
 	if err != nil {
@@ -519,6 +551,7 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 		var parentKind, parentName *string
 		var appliedByName, appliedByNamespace *string
 		var sourceRefKind, sourceRefName, sourceRefNamespace *string
+		var images []byte
 		if err := rows.Scan(
 			&r.Kind, &r.APIVersion, &r.Namespace, &r.Name, &r.Ready, &r.Reason,
 			&r.Message, &r.Revision, &r.Suspended, &r.Generation,
@@ -527,12 +560,16 @@ func (s *Store) List(ctx context.Context, kind, namespace, ready string) ([]flux
 			&appliedByName, &appliedByNamespace,
 			&sourceRefKind, &sourceRefName, &sourceRefNamespace,
 			&r.SourceURL, &r.OriginRevision, &r.OriginSource,
+			&images,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		r.Parent = parentRef(parentKind, parentName)
 		r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 		r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
+		if r.Images, err = imagesFrom(images); err != nil {
+			return nil, err
+		}
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -545,7 +582,7 @@ SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        applied_by_name, applied_by_namespace,
        source_ref_kind, source_ref_name, source_ref_namespace,
        COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
-       inventory
+       inventory, images
 FROM flux_resource
 WHERE lower(kind) = lower($1) AND namespace = $2 AND name = $3`
 
@@ -568,7 +605,7 @@ type Event struct {
 // history, newest first. It returns ErrNotFound when no row matches.
 func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Resource, []Event, error) {
 	var r flux.Resource
-	var raw, inventory []byte
+	var raw, inventory, images []byte
 	var parentKind, parentName *string
 	var appliedByName, appliedByNamespace *string
 	var sourceRefKind, sourceRefName, sourceRefNamespace *string
@@ -580,7 +617,7 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 		&appliedByName, &appliedByNamespace,
 		&sourceRefKind, &sourceRefName, &sourceRefNamespace,
 		&r.SourceURL, &r.OriginRevision, &r.OriginSource,
-		&inventory,
+		&inventory, &images,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, ErrNotFound
@@ -593,6 +630,9 @@ func (s *Store) Get(ctx context.Context, kind, namespace, name string) (*flux.Re
 	r.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 	r.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
 	if r.Inventory, err = inventoryFrom(inventory); err != nil {
+		return nil, nil, err
+	}
+	if r.Images, err = imagesFrom(images); err != nil {
 		return nil, nil, err
 	}
 
@@ -639,18 +679,21 @@ SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        applied_by_name, applied_by_namespace,
        source_ref_kind, source_ref_name, source_ref_namespace,
        COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
-       inventory
+       inventory, images
 FROM flux_resource
 WHERE updated_at > $1
 ORDER BY updated_at`
 
-// changedSinceStmtV3 is the pull for tenants still at schema version 3, whose
-// databases predate the base-layer columns; those fields stay empty.
-const changedSinceStmtV3 = `
+// changedSinceStmtV4 is the pull for tenants still at schema version 4, whose
+// databases predate the images column (and mirror no workloads); it stays nil.
+const changedSinceStmtV4 = `
 SELECT kind, api_version, namespace, name, ready, reason, message, revision,
        suspended, generation, observed_generation, last_transition, raw, content_hash, updated_at,
        COALESCE(azure_resource_id, ''), parent_kind, parent_name,
-       applied_by_name, applied_by_namespace
+       applied_by_name, applied_by_namespace,
+       source_ref_kind, source_ref_name, source_ref_namespace,
+       COALESCE(source_url, ''), COALESCE(origin_revision, ''), COALESCE(origin_source, ''),
+       inventory
 FROM flux_resource
 WHERE updated_at > $1
 ORDER BY updated_at`
@@ -666,9 +709,9 @@ ORDER BY updated_at`
 // the schemaSupported window are the caller's job to skip.
 func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersion int) ([]ChangedResource, error) {
 	stmt := changedSinceStmt
-	withBaseLayer := schemaVersion >= 4
-	if !withBaseLayer {
-		stmt = changedSinceStmtV3
+	withImages := schemaVersion >= 5
+	if !withImages {
+		stmt = changedSinceStmtV4
 	}
 	rows, err := s.pool.Query(ctx, stmt, cursor)
 	if err != nil {
@@ -679,7 +722,7 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 	out := []ChangedResource{}
 	for rows.Next() {
 		var c ChangedResource
-		var raw, inventory []byte
+		var raw, inventory, images []byte
 		var hash *string
 		var parentKind, parentName *string
 		var appliedByName, appliedByNamespace *string
@@ -690,13 +733,12 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 			&c.ObservedGeneration, &c.LastTransition, &raw, &hash, &c.UpdatedAt,
 			&c.AzureResourceID, &parentKind, &parentName,
 			&appliedByName, &appliedByNamespace,
+			&sourceRefKind, &sourceRefName, &sourceRefNamespace,
+			&c.SourceURL, &c.OriginRevision, &c.OriginSource,
+			&inventory,
 		}
-		if withBaseLayer {
-			dest = append(dest,
-				&sourceRefKind, &sourceRefName, &sourceRefNamespace,
-				&c.SourceURL, &c.OriginRevision, &c.OriginSource,
-				&inventory,
-			)
+		if withImages {
+			dest = append(dest, &images)
 		}
 		if err := rows.Scan(dest...); err != nil {
 			return nil, fmt.Errorf("scan changed row: %w", err)
@@ -709,6 +751,9 @@ func (s *Store) ChangedSince(ctx context.Context, cursor time.Time, schemaVersio
 		c.AppliedBy = appliedByRef(appliedByName, appliedByNamespace)
 		c.SourceRef = sourceRefFrom(sourceRefKind, sourceRefName, sourceRefNamespace)
 		if c.Inventory, err = inventoryFrom(inventory); err != nil {
+			return nil, err
+		}
+		if c.Images, err = imagesFrom(images); err != nil {
 			return nil, err
 		}
 		out = append(out, c)

--- a/services/dis-console/test/e2e/central_test.go
+++ b/services/dis-console/test/e2e/central_test.go
@@ -385,12 +385,12 @@ func TestCentralDISFieldsEndToEnd(t *testing.T) {
 	}
 }
 
-// TestCentralSyncSchemaV3Tenant proves the rollout order the schema gate
-// promises: a server at schema 4 can still pull a tenant whose agent is at
-// schema 3 (its database lacks the base-layer columns entirely). The tenant is
-// built by hand — migrate, then drop the v4 columns and stamp schema_version 3
-// — because a v4 agent binary can no longer write the v3 shape.
-func TestCentralSyncSchemaV3Tenant(t *testing.T) {
+// TestCentralSyncSchemaV4Tenant proves the rollout order the schema gate
+// promises: a server at schema 5 can still pull a tenant whose agent is at
+// schema 4 (its database lacks the images column entirely). The tenant is
+// built by hand — migrate, then drop the v5 column and stamp schema_version 4
+// — because a v5 agent binary can no longer write the v4 shape.
+func TestCentralSyncSchemaV4Tenant(t *testing.T) {
 	cs, _ := newCentral(t)
 	ctx := context.Background()
 	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
@@ -404,39 +404,36 @@ func TestCentralSyncSchemaV3Tenant(t *testing.T) {
 	if err := ts.Migrate(ctx); err != nil {
 		t.Fatalf("migrate tenant: %v", err)
 	}
-	if _, err := tpool.Exec(ctx, `ALTER TABLE flux_resource
-		DROP COLUMN source_ref_kind, DROP COLUMN source_ref_name, DROP COLUMN source_ref_namespace,
-		DROP COLUMN source_url, DROP COLUMN origin_revision, DROP COLUMN origin_source,
-		DROP COLUMN inventory`); err != nil {
-		t.Fatalf("shape tenant as v3: %v", err)
+	if _, err := tpool.Exec(ctx, "ALTER TABLE flux_resource DROP COLUMN images"); err != nil {
+		t.Fatalf("shape tenant as v4: %v", err)
 	}
 	if _, err := tpool.Exec(ctx,
-		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 3, 'v3-agent')"); err != nil {
-		t.Fatalf("stamp v3 meta: %v", err)
+		"INSERT INTO meta (id, schema_version, agent_version) VALUES (true, 4, 'v4-agent')"); err != nil {
+		t.Fatalf("stamp v4 meta: %v", err)
 	}
-	// The full column set a v3 agent writes: its upsert always passes the Go
+	// The full column set a v4 agent writes: its upsert always passes the Go
 	// zero values, so reason/message/revision land as '' (never NULL) and the
-	// DIS/applied-by pairs as NULL for a plain root Flux object.
+	// DIS/applied-by/base-layer columns as NULL for a plain root Flux object.
 	if _, err := tpool.Exec(ctx, `INSERT INTO flux_resource
 		(kind, api_version, namespace, name, ready, reason, message, revision,
 		 azure_resource_id, suspended, generation, observed_generation, raw, content_hash)
 		VALUES ('Kustomization', 'kustomize.toolkit.fluxcd.io/v1', 'flux-system', 'apps', 'True', '', '', '',
 		 '', false, 0, 0, '{}', 'h1')`); err != nil {
-		t.Fatalf("insert v3 row: %v", err)
+		t.Fatalf("insert v4 row: %v", err)
 	}
 
 	meta, err := ts.GetMeta(ctx)
-	if err != nil || meta.SchemaVersion != 3 {
+	if err != nil || meta.SchemaVersion != 4 {
 		t.Fatalf("tenant meta: %+v err=%v", meta, err)
 	}
 
 	// The version-keyed pull must succeed against the columnless table.
 	changed, err := ts.ChangedSince(ctx, time.Time{}, meta.SchemaVersion)
 	if err != nil {
-		t.Fatalf("changed-since on a v3 tenant: %v", err)
+		t.Fatalf("changed-since on a v4 tenant: %v", err)
 	}
-	if len(changed) != 1 || changed[0].SourceRef != nil || changed[0].Inventory != nil || changed[0].SourceURL != "" {
-		t.Fatalf("unexpected v3 pull: %+v", changed)
+	if len(changed) != 1 || changed[0].Images != nil {
+		t.Fatalf("unexpected v4 pull: %+v", changed)
 	}
 	keys, err := ts.Keys(ctx)
 	if err != nil {
@@ -452,15 +449,15 @@ func TestCentralSyncSchemaV3Tenant(t *testing.T) {
 		SchemaVersion: meta.SchemaVersion,
 		AgentVersion:  meta.AgentVersion,
 	}); err != nil {
-		t.Fatalf("apply v3 tenant: %v", err)
+		t.Fatalf("apply v4 tenant: %v", err)
 	}
 
 	rows, err := cs.List(ctx, "ttd_at23", "", "", "")
 	if err != nil || len(rows) != 1 {
-		t.Fatalf("central list after v3 sync: %+v err=%v", rows, err)
+		t.Fatalf("central list after v4 sync: %+v err=%v", rows, err)
 	}
-	if rows[0].SourceRef != nil || rows[0].SourceURL != "" {
-		t.Fatalf("v3 row should have empty base-layer fields, got %+v", rows[0])
+	if rows[0].Images != nil {
+		t.Fatalf("v4 row should have nil images, got %+v", rows[0].Images)
 	}
 }
 
@@ -525,6 +522,65 @@ func TestCentralBaseLayerRoundTrip(t *testing.T) {
 	}
 	if len(got.Inventory) != 1 || got.Inventory[0].ID != "product-team-a_appdb_storage.dis.altinn.cloud_Database" {
 		t.Fatalf("kustomization Get inventory: %+v", got.Inventory)
+	}
+}
+
+// TestCentralImagesEndToEnd walks a GitOps-applied Deployment through the full
+// pipeline against real PostgreSQL: agent Sync into the tenant database,
+// server pull (ChangedSince at the current schema) and Apply, then the
+// fleet-API reads — asserting the container images survive every hop and ride
+// the list payload (the UI's "which image runs where" needs no detail fetch).
+func TestCentralImagesEndToEnd(t *testing.T) {
+	cs, _ := newCentral(t)
+	ctx := context.Background()
+	uri := os.Getenv("DISCONSOLE_TEST_DB_URI")
+
+	tpool, err := dbauth.NewPoolForDatabase(ctx, uri, "dis_console_ttd_at23", nil)
+	if err != nil {
+		t.Fatalf("tenant pool: %v", err)
+	}
+	defer tpool.Close()
+	ts := store.New(tpool)
+	if err := ts.Migrate(ctx); err != nil {
+		t.Fatalf("migrate tenant: %v", err)
+	}
+	if err := ts.InitMeta(ctx, "e2e"); err != nil {
+		t.Fatalf("init tenant meta: %v", err)
+	}
+
+	if _, err := ts.Sync(ctx, []flux.Resource{{
+		Kind: "Deployment", APIVersion: "apps/v1",
+		Namespace: "product-team-a", Name: "app",
+		Ready: flux.ReadyTrue, Reason: "MinimumReplicasAvailable",
+		AppliedBy: &flux.AppliedBy{Name: "team-a-ab12-team-a", Namespace: "product-team-a"},
+		Images: []flux.ContainerImage{
+			{Container: "app", Image: "registry.example.com/team-a/app:v42"},
+		},
+		Raw: json.RawMessage(`{"kind":"Deployment"}`), ContentHash: "deploy-1",
+	}}); err != nil {
+		t.Fatalf("tenant sync: %v", err)
+	}
+
+	pullAndApply(t, cs, ts, "ttd_at23")
+
+	rows, err := cs.List(ctx, "ttd_at23", "Deployment", "", "")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("central list deployments: %+v err=%v", rows, err)
+	}
+	if len(rows[0].Images) != 1 ||
+		rows[0].Images[0] != (flux.ContainerImage{Container: "app", Image: "registry.example.com/team-a/app:v42"}) {
+		t.Fatalf("deployment lost its images in the central list: %+v", rows[0].Images)
+	}
+	if rows[0].AppliedBy == nil || rows[0].AppliedBy.Name != "team-a-ab12-team-a" {
+		t.Fatalf("deployment lost appliedBy in central: %+v", rows[0].AppliedBy)
+	}
+
+	got, err := cs.Get(ctx, "ttd_at23", "Deployment", "product-team-a", "app")
+	if err != nil {
+		t.Fatalf("central get deployment: %v", err)
+	}
+	if len(got.Images) != 1 || got.Images[0].Container != "app" {
+		t.Fatalf("deployment lost its images in central Get: %+v", got.Images)
 	}
 }
 

--- a/services/dis-console/test/e2e/store_test.go
+++ b/services/dis-console/test/e2e/store_test.go
@@ -314,7 +314,7 @@ func TestSyncAppliedByRoundTrip(t *testing.T) {
 // PostgreSQL: an OCIRepository's url/origin and a Kustomization's sourceRef +
 // inventory survive Sync and come back out of Get and ChangedSince, while List
 // carries everything except the inventory payload (detail-only, like raw), and
-// a version-3 pull omits the base-layer fields entirely.
+// the previous-version (v4) pull still selects them — they predate v5.
 func TestSyncBaseLayerRoundTrip(t *testing.T) {
 	s, _ := newStore(t)
 	ctx := context.Background()
@@ -393,15 +393,24 @@ func TestSyncBaseLayerRoundTrip(t *testing.T) {
 		}
 	}
 
-	// The version-3 SELECT (what the server uses against tenants whose agents
-	// have not migrated yet) must omit the base-layer fields but still succeed.
-	v3, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion-1)
+	// The previous-version SELECT (schema 4 — what the server uses against
+	// tenants whose agents have not migrated to v5 yet) still carries the
+	// base-layer fields: they predate v5, only images are gated on it (see
+	// TestSyncImagesRoundTrip).
+	v4, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion-1)
 	if err != nil {
-		t.Fatalf("v3 changed-since: %v", err)
+		t.Fatalf("v4 changed-since: %v", err)
 	}
-	for _, c := range v3 {
-		if c.SourceRef != nil || c.Inventory != nil || c.SourceURL != "" {
-			t.Fatalf("v3 pull must not select base-layer fields: %+v", c.Resource)
+	for _, c := range v4 {
+		switch c.Kind {
+		case "Kustomization":
+			if c.SourceRef == nil || len(c.Inventory) != 2 {
+				t.Fatalf("v4 pull lost base-layer fields: %+v", c.Resource)
+			}
+		case "OCIRepository":
+			if c.SourceURL == "" || c.OriginRevision == "" {
+				t.Fatalf("v4 pull lost base-layer fields: %+v", c.Resource)
+			}
 		}
 	}
 }
@@ -463,6 +472,143 @@ func TestSyncBaseLayerBackfillAdvancesUpdatedAt(t *testing.T) {
 	}
 	if got := updatedAt(); !got.Equal(second) {
 		t.Fatalf("updated_at churned on an unchanged base-layer sweep: %v -> %v", second, got)
+	}
+}
+
+// TestSyncImagesRoundTrip checks the schema-v5 column against real PostgreSQL:
+// a mirrored workload's container images survive Sync and come back out of
+// List (the UI reads the list — no detail fetch), Get and ChangedSince, while
+// a version-4 pull (agent not yet migrated) omits them entirely.
+func TestSyncImagesRoundTrip(t *testing.T) {
+	s, _ := newStore(t)
+	ctx := context.Background()
+
+	deploy := flux.Resource{
+		Kind: "Deployment", APIVersion: "apps/v1",
+		Namespace: "product-team-a", Name: "app",
+		Ready: flux.ReadyTrue, Reason: "MinimumReplicasAvailable",
+		AppliedBy: &flux.AppliedBy{Name: "team-a-ab12-team-a", Namespace: "product-team-a"},
+		Images: []flux.ContainerImage{
+			{Container: "app", Image: "registry.example.com/team-a/app:v42"},
+			{Container: "sidecar", Image: "registry.example.com/team-a/sidecar:v1"},
+		},
+		Raw: json.RawMessage(`{"kind":"Deployment"}`), ContentHash: "deploy-1",
+	}
+	kust := flux.Resource{
+		Kind: "Kustomization", APIVersion: "kustomize.toolkit.fluxcd.io/v1",
+		Namespace: "product-team-a", Name: "team-a-ab12-team-a",
+		Ready: flux.ReadyTrue,
+		Raw:   json.RawMessage(`{"kind":"Kustomization"}`), ContentHash: "kust-1",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{deploy, kust}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	rows, err := s.List(ctx, "Deployment", "", "")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("list deployments: %+v err=%v", rows, err)
+	}
+	if len(rows[0].Images) != 2 ||
+		rows[0].Images[0] != (flux.ContainerImage{Container: "app", Image: "registry.example.com/team-a/app:v42"}) ||
+		rows[0].Images[1] != (flux.ContainerImage{Container: "sidecar", Image: "registry.example.com/team-a/sidecar:v1"}) {
+		t.Fatalf("list must carry images: %+v", rows[0].Images)
+	}
+
+	got, _, err := s.Get(ctx, "Deployment", "product-team-a", "app")
+	if err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if len(got.Images) != 2 || got.Images[0].Container != "app" {
+		t.Fatalf("get lost images: %+v", got.Images)
+	}
+
+	gotKust, _, err := s.Get(ctx, "Kustomization", "product-team-a", "team-a-ab12-team-a")
+	if err != nil {
+		t.Fatalf("get kustomization: %v", err)
+	}
+	if gotKust.Images != nil {
+		t.Fatalf("non-workload rows must keep nil images, got %+v", gotKust.Images)
+	}
+
+	changed, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion)
+	if err != nil || len(changed) != 2 {
+		t.Fatalf("changed-since: %d rows err=%v", len(changed), err)
+	}
+	for _, c := range changed {
+		if c.Kind == "Deployment" && len(c.Images) != 2 {
+			t.Fatalf("changed deployment lost images: %+v", c.Resource)
+		}
+	}
+
+	// The version-4 SELECT (what the server uses against tenants whose agents
+	// have not migrated yet) must omit images but still succeed.
+	v4, err := s.ChangedSince(ctx, time.Time{}, store.SchemaVersion-1)
+	if err != nil {
+		t.Fatalf("v4 changed-since: %v", err)
+	}
+	for _, c := range v4 {
+		if c.Images != nil {
+			t.Fatalf("v4 pull must not select images: %+v", c.Resource)
+		}
+	}
+}
+
+// TestSyncImagesBackfillAdvancesUpdatedAt reproduces the v4→v5 upgrade for a
+// projection derived from already-hashed content: a workload row written
+// before the images projection has the column NULL with an unchanged content
+// hash. The first sweep that projects images must advance updated_at so the
+// central pull mirrors the backfilled row — and later identical sweeps must
+// not churn it. Same contract as the appliedBy and base-layer backfills.
+func TestSyncImagesBackfillAdvancesUpdatedAt(t *testing.T) {
+	s, pool := newStore(t)
+	ctx := context.Background()
+
+	updatedAt := func() time.Time {
+		var ts time.Time
+		if err := pool.QueryRow(ctx,
+			"SELECT updated_at FROM flux_resource WHERE name = $1", "app").Scan(&ts); err != nil {
+			t.Fatalf("query updated_at: %v", err)
+		}
+		return ts
+	}
+
+	// Sweep 1: the pre-v5 shape (same object, images not projected yet).
+	pre := flux.Resource{
+		Kind: "Deployment", APIVersion: "apps/v1",
+		Namespace: "product-team-a", Name: "app",
+		Ready: flux.ReadyTrue,
+		Raw:   json.RawMessage(`{"kind":"Deployment"}`), ContentHash: "same-object",
+	}
+	if _, err := s.Sync(ctx, []flux.Resource{pre}); err != nil {
+		t.Fatalf("sync 1: %v", err)
+	}
+	first := updatedAt()
+
+	// Sweep 2: identical object + hash, but the agent now projects images.
+	post := pre
+	post.Images = []flux.ContainerImage{{Container: "app", Image: "registry.example.com/team-a/app:v42"}}
+	if _, err := s.Sync(ctx, []flux.Resource{post}); err != nil {
+		t.Fatalf("sync 2: %v", err)
+	}
+	second := updatedAt()
+	if !second.After(first) {
+		t.Fatalf("updated_at must advance when images are backfilled: %v -> %v", first, second)
+	}
+
+	changed, err := s.ChangedSince(ctx, first, store.SchemaVersion)
+	if err != nil {
+		t.Fatalf("changed-since: %v", err)
+	}
+	if len(changed) != 1 || len(changed[0].Images) != 1 {
+		t.Fatalf("backfilled row not pulled: %+v", changed)
+	}
+
+	// Sweep 3: identical again (images unchanged) => no churn.
+	if _, err := s.Sync(ctx, []flux.Resource{post}); err != nil {
+		t.Fatalf("sync 3: %v", err)
+	}
+	if got := updatedAt(); !got.Equal(second) {
+		t.Fatalf("updated_at churned on an unchanged images sweep: %v -> %v", second, got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The console shows manifest-state versions (revisions/digests), but an app's effective version is its container image tag — and with azapi `postBuild` substitution a tag can be resolved per cluster and never exist in git. The fleet API had no view of what actually runs.

## Fix

- **Agent sweep**: `apps/v1` Deployment/StatefulSet/DaemonSet join `TargetKinds`, mirrored only when GitOps-applied (carrying the `kustomize.toolkit.fluxcd.io/name` label) so kube-system and Azure-managed add-ons stay out; workloads join the existing `appliedBy` app closure for free. Jobs/CronJobs/Pods deliberately out.
- **Normalize**: `images [{container,image}]` projected from the pod template via typed `k8s.io/api/apps/v1` structs (initContainers skipped). Readiness per kind: Deployment = `Available` condition (and `spec.paused` → `suspended`); StatefulSet/DaemonSet = ready/desired replica math (`2/3 ready`), Unknown until the controller has observed the object.
- **Schema v5**: `images jsonb` in tenant + central stores, served on **list** (`/api/resources?kind=Deployment` — no per-row detail fetch) and detail; the `updated_at` backfill CASE extended so pre-existing rows re-mirror once (f7db0d0d lesson); v5 server still pulls v4 tenants. No new endpoints.
- **Admin RBAC**: `dis-console-flux-reader` gains the `apps` read grants (rides the same syncroot artifact as the admin agent).

## Rollout

1. dis-way/gitops-manifests#1336 deploys first — it also fixes a live gap: the TE-fleet `dis-console-reader` never got the DIS groups, so v1.6.0 sweeps abort Forbidden wherever dis-* CRDs are installed. The `apps` grant must precede any v1.7.0 agent (core kinds are always served; no skip-if-absent safety).
2. Then server gitops ref bump, then agents — same two-PR sequence as v1.6.0 (v5 server reads v4 tenants).

Verified: `make run-checks-ci-cache` and `make test-e2e-kind-ci` pass (normalize fixtures for all three kinds, sweep label-filter test, v5 round-trip + backfill e2e, agent→server→central images e2e, v4-tenant rollout-gate e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility for GitOps-applied Deployments, StatefulSets, and DaemonSets.
  * Added container image details and workload readiness status to resource views and APIs.
  * Added support for displaying image and readiness information in central resource listings and details.
  * Granted read-only access to supported Kubernetes workload resources.

* **Bug Fixes**
  * Excluded non-GitOps application workloads from mirrored resources.

* **Documentation**
  * Updated documentation to describe workload filtering, image reporting, and readiness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->