### PR TITLE
fix(dis-console): mirror Helm-managed workloads and resolve their HelmRelease owner

### DIFF
--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -69,10 +69,10 @@ Do not claim checks passed unless you actually ran them.
   (health probes only); `server` migrates the central schema, runs the tenant
   sync loop, and serves the fleet API. Each wires its own DB pool and flags.
 - `internal/flux` — version-agnostic dynamic-client reader for the Flux and DIS
-  kinds plus the GitOps-applied `apps` workloads (Deployment/StatefulSet/
+  kinds plus the label-filtered `apps` workloads (Deployment/StatefulSet/
   DaemonSet, filtered in Sweep on the kustomize-controller label or Helm's
   managed-by label, the latter resolved to the owning HelmRelease via the
-  `meta.helm.sh` release annotations);
+  `meta.helm.sh` release annotations — or kept unowned when none matches);
   `normalize.go` decodes the projected status into the typed Flux `api`
   structs (kustomize/helm/source `api` + `pkg/apis/meta`) via runtime
   conversion — for the DIS kinds into a minimal local struct (never the

--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -70,7 +70,9 @@ Do not claim checks passed unless you actually ran them.
   sync loop, and serves the fleet API. Each wires its own DB pool and flags.
 - `internal/flux` — version-agnostic dynamic-client reader for the Flux and DIS
   kinds plus the GitOps-applied `apps` workloads (Deployment/StatefulSet/
-  DaemonSet, filtered on the kustomize-controller label in Sweep);
+  DaemonSet, filtered in Sweep on the kustomize-controller label or Helm's
+  managed-by label, the latter resolved to the owning HelmRelease via the
+  `meta.helm.sh` release annotations);
   `normalize.go` decodes the projected status into the typed Flux `api`
   structs (kustomize/helm/source `api` + `pkg/apis/meta`) via runtime
   conversion — for the DIS kinds into a minimal local struct (never the

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -33,7 +33,7 @@ via a discovery `RESTMapper` (robust to Azure Flux version bumps):
 | `vault.dis.altinn.cloud` | Vault |
 | `application.dis.altinn.cloud` | ApplicationIdentity |
 | `apim.dis.altinn.cloud` | Api, ApiVersion, Backend |
-| `apps` | Deployment, StatefulSet, DaemonSet — GitOps-applied only (see below) |
+| `apps` | Deployment, StatefulSet, DaemonSet — label-filtered (see below) |
 
 A DIS kind whose CRD is not installed on a cluster is simply skipped by the
 sweep, so mixed fleets keep working.
@@ -56,11 +56,13 @@ operators publish the same `Ready` condition; the APIM kinds publish only
 `status.provisioningState`, which is mapped onto ready
 (Succeeded→True, Failed→False, transitional→Unknown).
 
-The `apps` workloads are mirrored only when GitOps-applied — carrying the
-`kustomize.toolkit.fluxcd.io/name` label, or Helm's
-`app.kubernetes.io/managed-by=Helm` label for chart objects (helm-controller
-applies those itself and stamps no kustomize labels) — which keeps kube-system
-and Azure-managed add-ons out. The workloads exist for one field the Flux CRs
+The `apps` workloads are mirrored only when a deployer labeled them — the
+kustomize controller's `kustomize.toolkit.fluxcd.io/name`, or Helm's
+`app.kubernetes.io/managed-by=Helm` on chart objects (helm-controller applies
+those itself and stamps no kustomize labels) — which keeps kube-system and
+Azure-managed add-ons out. Almost everything that matches is GitOps-applied,
+but the Helm label is applier-agnostic: a release installed outside Flux is
+still mirrored, just without an owner (below). The workloads exist for one field the Flux CRs
 cannot provide: `images` (`[{container,image}]` from
 `spec.template.spec.containers`; init containers skipped) — the app's
 *effective* version. A manifest revision or digest only names what should run,

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -44,7 +44,9 @@ For each object it extracts a small normalized shape (`ready`/`reason`/
 Every object also projects `appliedBy` (`{name,namespace}`) from the
 `kustomize.toolkit.fluxcd.io/{name,namespace}` labels — the Kustomization that
 applied it — so the list endpoint can group child HelmReleases under their
-parent app without fetching detail; roots and Arc-managed objects have none.
+parent app without fetching detail. For chart-created workloads, which carry
+no kustomize labels, `appliedBy` names the owning HelmRelease instead (see
+below); roots and Arc-managed objects have none.
 The DIS kinds add two fields the UI builds on: `azureResourceId` (the ARM id of
 the provisioned Azure resource, for Portal links — from `status.resourceId`, or
 the APIM ids `status.apiVersionSetID`/`status.backendID`) and `parent`
@@ -55,18 +57,27 @@ operators publish the same `Ready` condition; the APIM kinds publish only
 (Succeeded→True, Failed→False, transitional→Unknown).
 
 The `apps` workloads are mirrored only when GitOps-applied — carrying the
-`kustomize.toolkit.fluxcd.io/name` label — which keeps kube-system and
-Azure-managed add-ons out. They exist for one field the Flux CRs cannot
-provide: `images` (`[{container,image}]` from `spec.template.spec.containers`;
-init containers skipped) — the app's *effective* version. A manifest revision
-or digest only names what should run, and with `postBuild` substitution the
-image tag can be resolved per cluster and never exist in git. `images` rides
-the list payload (`/api/resources?kind=Deployment`), so "which image runs
-where" needs no per-row detail fetch. Readiness is per kind (they share no
-condition semantics): Deployment takes its `Available` condition (and maps
-`spec.paused` onto `suspended`); StatefulSet and DaemonSet compare
-ready/desired replica counts, synthesized into a short reason/message
-(`2/3 ready`).
+`kustomize.toolkit.fluxcd.io/name` label, or Helm's
+`app.kubernetes.io/managed-by=Helm` label for chart objects (helm-controller
+applies those itself and stamps no kustomize labels) — which keeps kube-system
+and Azure-managed add-ons out. The workloads exist for one field the Flux CRs
+cannot provide: `images` (`[{container,image}]` from
+`spec.template.spec.containers`; init containers skipped) — the app's
+*effective* version. A manifest revision or digest only names what should run,
+and with `postBuild` substitution the image tag can be resolved per cluster and
+never exist in git. `images` rides the list payload
+(`/api/resources?kind=Deployment`), so "which image runs where" needs no
+per-row detail fetch. Readiness is per kind (they share no condition
+semantics): Deployment takes its `Available` condition (and maps `spec.paused`
+onto `suspended`); StatefulSet and DaemonSet compare ready/desired replica
+counts, synthesized into a short reason/message (`2/3 ready`).
+A chart-created workload's `meta.helm.sh/release-{name,namespace}` annotations
+name its *Helm release*, which matches the HelmRelease CR only in the default
+case (`spec.releaseName` overrides it; `spec.targetNamespace` prefixes the name
+and moves the namespace), so the sweep resolves the release identity against
+the batch's HelmReleases and projects the owner as `appliedBy`; a release no
+HelmRelease accounts for (installed outside Flux) stays mirrored without an
+owner.
 
 Each kind is listed from the apiserver watch cache (`resourceVersion=0`, not a
 quorum read from etcd) and the discovery cache is refreshed only periodically,

--- a/services/dis-console/internal/flux/client.go
+++ b/services/dis-console/internal/flux/client.go
@@ -1,4 +1,4 @@
-// Package flux reads Flux and DIS custom resources — plus the GitOps-applied
+// Package flux reads Flux and DIS custom resources — plus the label-filtered
 // apps workloads — across all namespaces using the dynamic client and a
 // discovery-backed RESTMapper, and normalizes their deployment status into a
 // small, stable shape the API serves.
@@ -83,8 +83,8 @@ func isDISGroup(group string) bool {
 }
 
 // TargetKinds are the kinds the Console reads: the Flux deployment machinery,
-// the DIS platform resources, and the apps workload kinds (GitOps-applied
-// only — see Sweep). The served API version of each is resolved at runtime via
+// the DIS platform resources, and the apps workload kinds (label-filtered —
+// see Sweep). The served API version of each is resolved at runtime via
 // the discovery RESTMapper, so the same binary keeps working if Azure Flux
 // bumps a version; kinds whose CRD is not installed on a cluster are skipped
 // by Sweep (the apps kinds are built-in and always served).
@@ -181,11 +181,11 @@ const helmManagedSelector = labelManagedBy + "=" + managedByHelm
 // (RBAC, auth, apiserver outage) aborts the sweep with an error so the caller
 // keeps the previous snapshot instead of publishing a partial one.
 //
-// Workloads (the apps kinds) are mirrored only when GitOps-applied: carrying
-// the kustomize-controller ownership label, or rendered by Helm out of a
-// HelmRelease. Both filters ride the lists as server-side label selectors,
-// which keeps kube-system and Azure-managed add-ons out. A chart-created
-// workload's annotations name its Helm release — not the HelmRelease CR, whose
+// Workloads (the apps kinds) are mirrored only when a deployer labeled them:
+// the kustomize-controller ownership label, or Helm's managed-by label. Both
+// filters ride the lists as server-side label selectors, which keeps
+// kube-system and Azure-managed add-ons out. A chart-created workload's
+// annotations name its Helm release — not the HelmRelease CR, whose
 // spec.releaseName/spec.targetNamespace change the release identity — so its
 // appliedBy is resolved against the batch's HelmReleases after the loop;
 // a release no swept HelmRelease accounts for (installed outside Flux) stays
@@ -256,7 +256,7 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 				switch selector {
 				case LabelAppliedByName:
 					// The existence selector also matches a present-but-empty
-					// label; only a named applier counts as GitOps-applied.
+					// label; only a named applier counts.
 					if item.GetLabels()[LabelAppliedByName] == "" {
 						continue
 					}

--- a/services/dis-console/internal/flux/client.go
+++ b/services/dis-console/internal/flux/client.go
@@ -20,6 +20,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
@@ -165,6 +166,13 @@ func restConfig(local bool) (*rest.Config, error) {
 	return cfg, nil
 }
 
+// helmManagedSelector is the second server-side workload filter: every object
+// Helm renders carries the app.kubernetes.io/managed-by=Helm label (plus the
+// meta.helm.sh release annotations Sweep resolves ownership from), while the
+// kustomize-label selector cannot see chart objects — helm-controller applies
+// them itself and stamps no kustomize labels.
+const helmManagedSelector = labelManagedBy + "=" + managedByHelm
+
 // Sweep lists every instance of each target kind across all namespaces and
 // returns them as normalized resources. Kinds that are not installed are
 // skipped (reported as warnings) so the sweep still succeeds when only a
@@ -173,10 +181,15 @@ func restConfig(local bool) (*rest.Config, error) {
 // (RBAC, auth, apiserver outage) aborts the sweep with an error so the caller
 // keeps the previous snapshot instead of publishing a partial one.
 //
-// Workloads (the apps kinds) are mirrored only when GitOps-applied — carrying
-// the kustomize-controller ownership label — which keeps kube-system and
-// Azure-managed add-ons out and matches the console's app model (everything
-// it shows joins a Kustomization's appliedBy closure).
+// Workloads (the apps kinds) are mirrored only when GitOps-applied: carrying
+// the kustomize-controller ownership label, or rendered by Helm out of a
+// HelmRelease. Both filters ride the lists as server-side label selectors,
+// which keeps kube-system and Azure-managed add-ons out. A chart-created
+// workload's annotations name its Helm release — not the HelmRelease CR, whose
+// spec.releaseName/spec.targetNamespace change the release identity — so its
+// appliedBy is resolved against the batch's HelmReleases after the loop;
+// a release no swept HelmRelease accounts for (installed outside Flux) stays
+// mirrored without an owner.
 //
 // The discovery cache is reset at most once per discoveryTTL rather than on
 // every sweep, so a newly installed Flux CRD is detected only on the next reset
@@ -190,6 +203,16 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 
 	resources := make([]Resource, 0)
 	var warnings []error
+	// releases maps each HelmRelease's effective release identity to the CR;
+	// helmOwned remembers which mirrored workloads (by index into resources)
+	// wait for which release. Ownership is resolved after the kind loop, when
+	// both sides of the join are complete regardless of TargetKinds order.
+	releases := make(map[types.NamespacedName]AppliedBy)
+	type helmRef struct {
+		index   int
+		release types.NamespacedName
+	}
+	var helmOwned []helmRef
 
 	for _, gk := range TargetKinds {
 		mapping, err := c.mapper.RESTMapping(gk)
@@ -205,33 +228,70 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 			return nil, warnings, fmt.Errorf("resolve %s: %w", gk, err)
 		}
 		nri := c.dyn.Resource(mapping.Resource).Namespace(metav1.NamespaceAll)
-		// ResourceVersion "0" serves the list from the apiserver's watch cache
-		// instead of a quorum read from etcd. The sub-second staleness that
-		// allows is irrelevant to a status poller (the agent re-lists every poll
-		// interval and the Console marks clusters stale only after minutes), and
-		// it keeps the repeated fleet-wide lists off etcd.
-		opts := metav1.ListOptions{ResourceVersion: "0"}
+
+		selectors := []string{""}
+		// seen dedups the two workload lists by object identity: some charts
+		// hardcode the managed-by label in their templates, so a
+		// kustomize-applied object can match both selectors. The kustomize
+		// pass runs first and wins — its labels name the true GitOps applier.
+		var seen map[types.NamespacedName]bool
 		if gk.Group == GroupApps {
-			// Existence selector: the apiserver drops unlabeled workloads
-			// (kube-system, Azure add-ons) before they ride the response. The
-			// in-loop guard below owns the semantics — it also drops a
-			// present-but-empty label, which a bare selector matches.
-			opts.LabelSelector = LabelAppliedByName
+			selectors = []string{LabelAppliedByName, helmManagedSelector}
+			seen = make(map[types.NamespacedName]bool)
 		}
-		list, err := nri.List(ctx, opts)
-		if err != nil {
-			return nil, warnings, fmt.Errorf("list %s: %w", gk, err)
-		}
-		for i := range list.Items {
-			if gk.Group == GroupApps && list.Items[i].GetLabels()[LabelAppliedByName] == "" {
-				continue
-			}
-			r, err := normalize(&list.Items[i])
+		for _, selector := range selectors {
+			// ResourceVersion "0" serves the list from the apiserver's watch
+			// cache instead of a quorum read from etcd. The sub-second staleness
+			// that allows is irrelevant to a status poller (the agent re-lists
+			// every poll interval and the Console marks clusters stale only
+			// after minutes), and it keeps the repeated fleet-wide lists off
+			// etcd.
+			opts := metav1.ListOptions{ResourceVersion: "0", LabelSelector: selector}
+			list, err := nri.List(ctx, opts)
 			if err != nil {
-				warnings = append(warnings, fmt.Errorf("normalize %s: %w", gk, err))
-				continue
+				return nil, warnings, fmt.Errorf("list %s: %w", gk, err)
 			}
-			resources = append(resources, r)
+			for i := range list.Items {
+				item := &list.Items[i]
+				switch selector {
+				case LabelAppliedByName:
+					// The existence selector also matches a present-but-empty
+					// label; only a named applier counts as GitOps-applied.
+					if item.GetLabels()[LabelAppliedByName] == "" {
+						continue
+					}
+					seen[types.NamespacedName{Namespace: item.GetNamespace(), Name: item.GetName()}] = true
+				case helmManagedSelector:
+					if seen[types.NamespacedName{Namespace: item.GetNamespace(), Name: item.GetName()}] {
+						continue
+					}
+				}
+				r, err := normalize(item)
+				if err != nil {
+					warnings = append(warnings, fmt.Errorf("normalize %s: %w", gk, err))
+					continue
+				}
+				if gk.Group == GroupHelm && gk.Kind == KindHelmRelease {
+					id, err := helmReleaseIdentity(item)
+					if err != nil {
+						warnings = append(warnings, fmt.Errorf("release identity %s/%s: %w", item.GetNamespace(), item.GetName(), err))
+					} else {
+						releases[id] = AppliedBy{Name: item.GetName(), Namespace: item.GetNamespace()}
+					}
+				}
+				resources = append(resources, r)
+				if selector == helmManagedSelector && r.AppliedBy == nil {
+					if owner, ok := helmOwnerFrom(item.GetAnnotations()); ok {
+						helmOwned = append(helmOwned, helmRef{index: len(resources) - 1, release: owner})
+					}
+				}
+			}
+		}
+	}
+
+	for _, w := range helmOwned {
+		if ab, ok := releases[w.release]; ok {
+			resources[w.index].AppliedBy = &ab
 		}
 	}
 	return resources, warnings, nil

--- a/services/dis-console/internal/flux/client_test.go
+++ b/services/dis-console/internal/flux/client_test.go
@@ -9,6 +9,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
@@ -39,10 +40,13 @@ func (m *fakeMapper) RESTMapping(gk schema.GroupKind, _ ...string) (*apimeta.RES
 }
 
 // fakeDynamic is a dynamic.Interface that records the ListOptions of every
-// List and returns the items seeded for the resource (empty when none). We
-// capture the options here rather than via dynamic/fake because the fake
-// client drops ResourceVersion when building its recorded action, which is
-// exactly the field these tests assert on.
+// List and returns the items seeded for the resource (empty when none),
+// filtered by the request's label selector like the real apiserver — Sweep
+// leans on server-side selection for the workload kinds, so an unfiltering
+// fake would leak items into the wrong pass. We capture the options here
+// rather than via dynamic/fake because the fake client drops ResourceVersion
+// when building its recorded action, which is exactly the field these tests
+// assert on.
 type fakeDynamic struct {
 	dynamic.Interface
 	listOpts []metav1.ListOptions
@@ -64,7 +68,20 @@ func (r *fakeResource) Namespace(string) dynamic.ResourceInterface { return r }
 
 func (r *fakeResource) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	r.parent.listOpts = append(r.parent.listOpts, opts)
-	return &unstructured.UnstructuredList{Items: r.parent.items[r.resource]}, nil
+	selector := labels.Everything()
+	if opts.LabelSelector != "" {
+		var err error
+		if selector, err = labels.Parse(opts.LabelSelector); err != nil {
+			return nil, err
+		}
+	}
+	out := &unstructured.UnstructuredList{}
+	for _, item := range r.parent.items[r.resource] {
+		if selector.Matches(labels.Set(item.GetLabels())) {
+			out.Items = append(out.Items, item)
+		}
+	}
+	return out, nil
 }
 
 func TestSweepResetsDiscoveryOnTTL(t *testing.T) {
@@ -106,22 +123,28 @@ func TestSweepListsFromWatchCache(t *testing.T) {
 	if _, _, err := c.Sweep(context.Background()); err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
-	if len(d.listOpts) != len(TargetKinds) {
-		t.Fatalf("list calls = %d, want %d (one per target kind)", len(d.listOpts), len(TargetKinds))
+	// The apps kinds are filtered server-side and listed twice (the
+	// kustomize-applied and the Helm-rendered populations); every other kind
+	// lists once, unfiltered.
+	var wantSelectors []string
+	for _, gk := range TargetKinds {
+		if gk.Group == GroupApps {
+			wantSelectors = append(wantSelectors, LabelAppliedByName, helmManagedSelector)
+			continue
+		}
+		wantSelectors = append(wantSelectors, "")
+	}
+	if len(d.listOpts) != len(wantSelectors) {
+		t.Fatalf("list calls = %d, want %d (one per target kind, two per apps kind)",
+			len(d.listOpts), len(wantSelectors))
 	}
 	for i, opts := range d.listOpts {
 		if opts.ResourceVersion != "0" {
 			t.Errorf("list[%d] ResourceVersion = %q, want %q (served from the watch cache)",
 				i, opts.ResourceVersion, "0")
 		}
-		// The apps kinds are filtered to GitOps-applied objects server-side;
-		// every other kind lists unfiltered.
-		wantSelector := ""
-		if TargetKinds[i].Group == GroupApps {
-			wantSelector = LabelAppliedByName
-		}
-		if opts.LabelSelector != wantSelector {
-			t.Errorf("list[%d] LabelSelector = %q, want %q", i, opts.LabelSelector, wantSelector)
+		if opts.LabelSelector != wantSelectors[i] {
+			t.Errorf("list[%d] LabelSelector = %q, want %q", i, opts.LabelSelector, wantSelectors[i])
 		}
 	}
 }
@@ -131,10 +154,10 @@ func TestSweepListsFromWatchCache(t *testing.T) {
 // Azure-managed add-ons) is dropped before normalize, while the labeled one is
 // mirrored — and non-workload kinds are never filtered, labeled or not.
 func TestSweepMirrorsOnlyGitOpsAppliedWorkloads(t *testing.T) {
-	workload := func(name string, labels map[string]any) unstructured.Unstructured {
+	workload := func(name string, objLabels map[string]any) unstructured.Unstructured {
 		meta := map[string]any{"namespace": "ns", "name": name}
-		if labels != nil {
-			meta["labels"] = labels
+		if objLabels != nil {
+			meta["labels"] = objLabels
 		}
 		return unstructured.Unstructured{Object: map[string]any{
 			"apiVersion": "apps/v1",
@@ -175,6 +198,131 @@ func TestSweepMirrorsOnlyGitOpsAppliedWorkloads(t *testing.T) {
 	}
 }
 
+// TestSweepResolvesHelmWorkloadOwnership pins the Helm side of the workload
+// sweep: chart-created workloads (managed-by label + release annotations, no
+// kustomize labels) are mirrored with appliedBy resolved to the HelmRelease
+// deploying that release — through the default identity, a releaseName
+// override, and targetNamespace prefix defaulting. A kustomize-applied object
+// whose chart hardcodes the managed-by label is mirrored exactly once and
+// keeps the kustomize appliedBy; a release no HelmRelease accounts for stays
+// mirrored without an owner.
+func TestSweepResolvesHelmWorkloadOwnership(t *testing.T) {
+	deployment := func(ns, name string, objLabels, annotations map[string]any) unstructured.Unstructured {
+		meta := map[string]any{"namespace": ns, "name": name}
+		if objLabels != nil {
+			meta["labels"] = objLabels
+		}
+		if annotations != nil {
+			meta["annotations"] = annotations
+		}
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   meta,
+		}}
+	}
+	helmRelease := func(ns, name string, spec map[string]any) unstructured.Unstructured {
+		obj := map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]any{"namespace": ns, "name": name},
+		}
+		if spec != nil {
+			obj["spec"] = spec
+		}
+		return unstructured.Unstructured{Object: obj}
+	}
+	helmLabel := map[string]any{labelManagedBy: managedByHelm}
+
+	d := &fakeDynamic{items: map[string][]unstructured.Unstructured{
+		"helmreleases": {
+			helmRelease("team-one", "app-default", nil),
+			helmRelease("team-two", "app-target", map[string]any{"targetNamespace": "team-two-apps"}),
+			helmRelease("team-three", "app-renamed", map[string]any{"releaseName": "custom-release"}),
+		},
+		"deployments": {
+			// Default identity: release name = CR name, namespace = CR's own.
+			deployment("team-one", "worker-default", helmLabel, map[string]any{
+				annotationReleaseName:      "app-default",
+				annotationReleaseNamespace: "team-one",
+			}),
+			// targetNamespace defaulting: the release is named
+			// <targetNamespace>-<name> and lives in the target namespace, but
+			// appliedBy must name the CR (app-target in team-two).
+			deployment("team-two-apps", "worker-target", helmLabel, map[string]any{
+				annotationReleaseName:      "team-two-apps-app-target",
+				annotationReleaseNamespace: "team-two-apps",
+			}),
+			// spec.releaseName overrides the release name outright.
+			deployment("team-three", "worker-renamed", helmLabel, map[string]any{
+				annotationReleaseName:      "custom-release",
+				annotationReleaseNamespace: "team-three",
+			}),
+			// Matches both selectors (chart-hardcoded managed-by label on a
+			// kustomize-applied object): mirrored once, kustomize wins.
+			deployment("product-team-a", "both", map[string]any{
+				LabelAppliedByName:      "team-a-app",
+				LabelAppliedByNamespace: "product-team-a",
+				labelManagedBy:          managedByHelm,
+			}, nil),
+			// A release no HelmRelease accounts for (helm install by hand).
+			deployment("tools", "hand-rolled", helmLabel, map[string]any{
+				annotationReleaseName:      "toolbox",
+				annotationReleaseNamespace: "tools",
+			}),
+			// Hardcoded label, no release annotations: nothing to resolve.
+			deployment("misc", "label-only", helmLabel, nil),
+		},
+	}}
+	c := &Client{dyn: d, mapper: &fakeMapper{}}
+
+	resources, warnings, err := c.Sweep(context.Background())
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	byName := make(map[string]Resource, len(resources))
+	for _, r := range resources {
+		if prev, dup := byName[r.Name]; dup {
+			t.Fatalf("resource %q mirrored twice: %+v and %+v", r.Name, prev, r)
+		}
+		byName[r.Name] = r
+	}
+	if len(resources) != 9 {
+		t.Fatalf("resources = %d, want 9 (3 HelmReleases + 6 deployments, each once)", len(resources))
+	}
+
+	// Every appliedBy names the HelmRelease CR, never the helm release —
+	// worker-renamed's release is custom-release but its owner is the
+	// app-renamed CR.
+	wantOwner := map[string]*AppliedBy{
+		"worker-default": {Name: "app-default", Namespace: "team-one"},
+		"worker-target":  {Name: "app-target", Namespace: "team-two"},
+		"worker-renamed": {Name: "app-renamed", Namespace: "team-three"},
+		"both":           {Name: "team-a-app", Namespace: "product-team-a"},
+		"hand-rolled":    nil,
+		"label-only":     nil,
+	}
+	for name, want := range wantOwner {
+		got, ok := byName[name]
+		if !ok {
+			t.Fatalf("workload %q not mirrored", name)
+		}
+		switch {
+		case want == nil:
+			if got.AppliedBy != nil {
+				t.Errorf("%s appliedBy = %+v, want none", name, got.AppliedBy)
+			}
+		case got.AppliedBy == nil:
+			t.Errorf("%s appliedBy = nil, want %+v", name, want)
+		case *got.AppliedBy != *want:
+			t.Errorf("%s appliedBy = %+v, want %+v", name, got.AppliedBy, want)
+		}
+	}
+}
+
 func TestSweepSkipsUninstalledKinds(t *testing.T) {
 	// Mark one optional source kind as not installed.
 	missing := schema.GroupKind{Group: GroupSource, Kind: KindHelmChart}
@@ -188,7 +336,10 @@ func TestSweepSkipsUninstalledKinds(t *testing.T) {
 	if len(warnings) != 1 {
 		t.Fatalf("warnings = %d, want 1 (the skipped kind)", len(warnings))
 	}
-	if len(d.listOpts) != len(TargetKinds)-1 {
-		t.Fatalf("list calls = %d, want %d (skipped kind is not listed)", len(d.listOpts), len(TargetKinds)-1)
+	// One list per kind minus the skipped one, plus a second list for each of
+	// the three apps kinds.
+	want := len(TargetKinds) - 1 + 3
+	if len(d.listOpts) != want {
+		t.Fatalf("list calls = %d, want %d (skipped kind is not listed)", len(d.listOpts), want)
 	}
 }

--- a/services/dis-console/internal/flux/normalize.go
+++ b/services/dis-console/internal/flux/normalize.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Ready condition status values, mirroring meta.fluxcd.io condition semantics.
@@ -47,9 +48,12 @@ type Resource struct {
 	Parent *ParentRef `json:"parent,omitempty"`
 	// AppliedBy is the Kustomization that applied this object, projected from
 	// the kustomize.toolkit.fluxcd.io/{name,namespace} labels the kustomize
-	// controller stamps on everything it applies, so the list endpoint (which
-	// omits Raw) can group child resources under their parent app. Empty for
-	// roots and Arc-managed objects, which carry no such labels.
+	// controller stamps on everything it applies — or, for chart-created
+	// workloads (which carry no kustomize labels), the owning HelmRelease,
+	// resolved by Sweep from the object's Helm release annotations. Lets the
+	// list endpoint (which omits Raw) group child resources under their parent
+	// app. Empty for roots, Arc-managed objects, and Helm releases installed
+	// outside Flux.
 	AppliedBy *AppliedBy `json:"appliedBy,omitempty"`
 	// SourceRef is the Flux source a Kustomization builds from — the join key
 	// from a Kustomization row to the OCIRepository row holding the base-layer
@@ -104,6 +108,17 @@ type ParentRef struct {
 const (
 	LabelAppliedByName      = "kustomize.toolkit.fluxcd.io/name"
 	LabelAppliedByNamespace = "kustomize.toolkit.fluxcd.io/namespace"
+)
+
+// Metadata Helm stamps on every object it renders: the managed-by label the
+// sweep's second workload list selects on, and the release annotations naming
+// the owning Helm release. Chart objects carry these instead of the kustomize
+// labels — helm-controller applies them itself, not via kustomize-controller.
+const (
+	labelManagedBy             = "app.kubernetes.io/managed-by"
+	managedByHelm              = "Helm"
+	annotationReleaseName      = "meta.helm.sh/release-name"
+	annotationReleaseNamespace = "meta.helm.sh/release-namespace"
 )
 
 // AppliedBy identifies the Kustomization that applied a resource. The JSON
@@ -323,6 +338,35 @@ func appliedByFrom(labels map[string]string) *AppliedBy {
 		return nil
 	}
 	return &AppliedBy{Name: name, Namespace: ns}
+}
+
+// helmReleaseIdentity is the effective Helm release identity a HelmRelease
+// deploys as — the exact values Helm stamps into the meta.helm.sh release
+// annotations of every object it renders. The typed helpers encode Flux's
+// defaulting: the name is spec.releaseName when set, else
+// <targetNamespace>-<name> when spec.targetNamespace is set, else the CR's
+// name; the namespace is spec.targetNamespace defaulting to the CR's own.
+// (spec.storageNamespace moves only the release secrets: helm-controller
+// hands Helm the release namespace, not the storage namespace, so the latter
+// never reaches object metadata.)
+func helmReleaseIdentity(u *unstructured.Unstructured) (types.NamespacedName, error) {
+	var o helmv2.HelmRelease
+	if err := fromUnstructured(u, &o); err != nil {
+		return types.NamespacedName{}, err
+	}
+	return types.NamespacedName{Namespace: o.GetReleaseNamespace(), Name: o.GetReleaseName()}, nil
+}
+
+// helmOwnerFrom reads the meta.helm.sh release annotations naming the Helm
+// release an object belongs to. ok is false when they are absent — an object
+// that merely carries a chart-hardcoded managed-by label but was applied by
+// something other than Helm.
+func helmOwnerFrom(annotations map[string]string) (types.NamespacedName, bool) {
+	name, ns := annotations[annotationReleaseName], annotations[annotationReleaseNamespace]
+	if name == "" || ns == "" {
+		return types.NamespacedName{}, false
+	}
+	return types.NamespacedName{Namespace: ns, Name: name}, true
 }
 
 // disObject is the minimal projection of a DIS custom resource — just the

--- a/services/dis-console/internal/flux/normalize_test.go
+++ b/services/dis-console/internal/flux/normalize_test.go
@@ -309,6 +309,95 @@ func TestNormalizeAppliedByEmptyWithoutLabels(t *testing.T) {
 	}
 }
 
+// TestHelmReleaseIdentity pins the release-identity defaulting the typed Flux
+// helpers encode — the exact values Helm stamps into the meta.helm.sh
+// annotations of every rendered object: spec.releaseName wins outright; a bare
+// targetNamespace prefixes the name and becomes the namespace; and
+// storageNamespace moves only the release secrets, never the identity.
+func TestHelmReleaseIdentity(t *testing.T) {
+	hr := func(spec map[string]any) *unstructured.Unstructured {
+		obj := map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]any{"namespace": "team-a", "name": "app-one"},
+		}
+		if spec != nil {
+			obj["spec"] = spec
+		}
+		return &unstructured.Unstructured{Object: obj}
+	}
+
+	cases := []struct {
+		name          string
+		spec          map[string]any
+		wantName      string
+		wantNamespace string
+	}{
+		{
+			name:          "default: the CR's own name and namespace",
+			spec:          nil,
+			wantName:      "app-one",
+			wantNamespace: "team-a",
+		},
+		{
+			name:          "releaseName override wins",
+			spec:          map[string]any{"releaseName": "custom-release"},
+			wantName:      "custom-release",
+			wantNamespace: "team-a",
+		},
+		{
+			name:          "targetNamespace prefixes the name and becomes the namespace",
+			spec:          map[string]any{"targetNamespace": "team-a-apps"},
+			wantName:      "team-a-apps-app-one",
+			wantNamespace: "team-a-apps",
+		},
+		{
+			name:          "releaseName beats targetNamespace prefixing",
+			spec:          map[string]any{"releaseName": "custom-release", "targetNamespace": "team-a-apps"},
+			wantName:      "custom-release",
+			wantNamespace: "team-a-apps",
+		},
+		{
+			name:          "storageNamespace does not change the identity",
+			spec:          map[string]any{"storageNamespace": "storage-ns"},
+			wantName:      "app-one",
+			wantNamespace: "team-a",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := helmReleaseIdentity(hr(tc.spec))
+			if err != nil {
+				t.Fatalf("helmReleaseIdentity: %v", err)
+			}
+			if id.Name != tc.wantName || id.Namespace != tc.wantNamespace {
+				t.Fatalf("identity = %s/%s, want %s/%s", id.Namespace, id.Name, tc.wantNamespace, tc.wantName)
+			}
+		})
+	}
+}
+
+// The meta.helm.sh annotations resolve only as a pair; an object missing
+// either (a chart-hardcoded managed-by label without Helm's adoption
+// metadata) has no release to resolve.
+func TestHelmOwnerFrom(t *testing.T) {
+	if owner, ok := helmOwnerFrom(map[string]string{
+		annotationReleaseName:      "app-one",
+		annotationReleaseNamespace: "team-a",
+	}); !ok || owner.Name != "app-one" || owner.Namespace != "team-a" {
+		t.Fatalf("owner = %v ok=%v, want team-a/app-one", owner, ok)
+	}
+	for name, annotations := range map[string]map[string]string{
+		"no annotations": nil,
+		"name only":      {annotationReleaseName: "app-one"},
+		"namespace only": {annotationReleaseNamespace: "team-a"},
+	} {
+		if _, ok := helmOwnerFrom(annotations); ok {
+			t.Fatalf("%s: expected no owner", name)
+		}
+	}
+}
+
 // The base-layer projections: a Kustomization's sourceRef (namespace
 // defaulted to its own) and its applied-object inventory, kept in Flux's
 // compact entry shape.


### PR DESCRIPTION
## Problem

The schema-v5 workload sweep (#3836) mirrors apps/v1 workloads via an existence selector on the `kustomize.toolkit.fluxcd.io/name` label. helm-controller applies chart objects itself and stamps no kustomize labels, so Helm-created workloads (azure-service-operator, cert-manager, linkerd, …) were never swept and HelmRelease apps show **No workloads mirrored** in the console UI.

## Fix

- Sweep lists the three workload kinds a second time with the server-side selector `app.kubernetes.io/managed-by=Helm`; the two lists are deduped by object identity (some charts hardcode the managed-by label, and the kustomize labels name the true GitOps applier, so that pass wins).
- A chart workload's `meta.helm.sh/release-{name,namespace}` annotations name its *Helm release*, which matches the HelmRelease CR only in the default case. Sweep resolves the release identity against the batch's HelmReleases using the typed `GetReleaseName()`/`GetReleaseNamespace()` helpers (`spec.releaseName` override, `<targetNamespace>-<name>` defaulting) and projects the owning CR as `appliedBy`. Note the annotation carries the release (target) namespace, not the storage namespace — verified against helm-controller v1.6.0 (`install.Namespace = obj.GetReleaseNamespace()`) and helm v4.2.1 (`setMetadataVisitor(rel.Name, rel.Namespace, …)`).
- A release no swept HelmRelease accounts for (installed outside Flux) stays mirrored without an owner.
- No schema bump: reuses the v5 `appliedBy` + `images` fields; the UI already joins workloads to HelmRelease apps via `appliedBy`.

## Rollout

Agent-only change riding the v5 schema window — the server needs nothing, apps RBAC is already granted. After merge: patch release, then bump agent refs (deploy/admin + deploy/common + tenant template) as in #3839.

## Verification

`make run-checks-ci-cache` and `make test-e2e-kind-ci` pass (AGENTS.md required checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Helm-managed workloads are now discovered and associated with their owning Helm releases.
  - Workload mirroring supports both GitOps-applied and Helm-managed resources, including duplicate handling.

- **Bug Fixes**
  - Corrected parent app resolution for chart-created workloads without GitOps labels.
  - Improved handling of Helm release names and target namespaces.

- **Documentation**
  - Clarified workload ownership, mirroring rules, readiness behavior, and effective image reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->