### PR TITLE
chore(dis-console): Update dis-console image version to v1.7.2

### DIFF
--- a/deploy/admin/base/dis-console-agent-deployment.yaml
+++ b/deploy/admin/base/dis-console-agent-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
           args:
             - agent
           ports:

--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
           args:
             - server
           ports:

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
           args:
             - agent
           ports:

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
           args:
             - agent
           ports:

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.1
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
           args:
             - agent
           ports:


### PR DESCRIPTION
Rolls out dis-console v1.7.2 (#3845: project workload revision from the primary container's image tag) to the admin cluster, at22/at23, and the tenant app template — same five manifests as #3843.

Agent-side change in effect; the manifests pin one image for agent and server, so both move together (no server-side impact, no schema bump).

Merge order: after #3846 (release 1.7.2) has merged and its tag build has published the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)