### PR TITLE
fix(dis-console): attribute helm workloads via origin labels with release-claim tie-break

### DIFF
--- a/services/dis-console/AGENTS.md
+++ b/services/dis-console/AGENTS.md
@@ -71,8 +71,10 @@ Do not claim checks passed unless you actually ran them.
 - `internal/flux` — version-agnostic dynamic-client reader for the Flux and DIS
   kinds plus the label-filtered `apps` workloads (Deployment/StatefulSet/
   DaemonSet, filtered in Sweep on the kustomize-controller label or Helm's
-  managed-by label, the latter resolved to the owning HelmRelease via the
-  `meta.helm.sh` release annotations — or kept unowned when none matches);
+  managed-by label, the latter resolved to the owning HelmRelease via
+  helm-controller's origin labels, falling back to the `meta.helm.sh` release
+  annotations with duplicate release claims tie-broken on Ready state — or
+  kept unowned when none matches);
   `normalize.go` decodes the projected status into the typed Flux `api`
   structs (kustomize/helm/source `api` + `pkg/apis/meta`) via runtime
   conversion — for the DIS kinds into a minimal local struct (never the

--- a/services/dis-console/README.md
+++ b/services/dis-console/README.md
@@ -78,13 +78,21 @@ per-row detail fetch. Readiness is per kind (they share no condition
 semantics): Deployment takes its `Available` condition (and maps `spec.paused`
 onto `suspended`); StatefulSet and DaemonSet compare ready/desired replica
 counts, synthesized into a short reason/message (`2/3 ready`).
-A chart-created workload's `meta.helm.sh/release-{name,namespace}` annotations
-name its *Helm release*, which matches the HelmRelease CR only in the default
-case (`spec.releaseName` overrides it; `spec.targetNamespace` prefixes the name
-and moves the namespace), so the sweep resolves the release identity against
-the batch's HelmReleases and projects the owner as `appliedBy`; a release no
-HelmRelease accounts for (installed outside Flux) stays mirrored without an
-owner.
+A chart-created workload's `appliedBy` is taken from helm-controller's origin
+labels (`helm.toolkit.fluxcd.io/{name,namespace}`) when present — the
+controller's builtin post-renderer stamps them on everything it applies, and
+they name the HelmRelease CR exactly. Without them the workload's
+`meta.helm.sh/release-{name,namespace}` annotations name only its *Helm
+release*, which matches the HelmRelease CR in the default case
+(`spec.releaseName` overrides it; `spec.targetNamespace` prefixes the name and
+moves the namespace), so the sweep resolves the release identity against the
+batch's HelmReleases instead. Two HelmReleases can declare the same release
+identity (a duplicate CR pointing at another CR's release); the sweep then
+attributes to the Ready claimant — a CR that never installed the release
+cannot own its live objects — and reports claims of equal readiness as a
+warning, preferring the CR whose own namespace is the release namespace. A
+release no HelmRelease accounts for (installed outside Flux) stays mirrored
+without an owner.
 
 Each kind is listed from the apiserver watch cache (`resourceVersion=0`, not a
 quorum read from etcd) and the discovery cache is refreshed only periodically,

--- a/services/dis-console/internal/flux/client.go
+++ b/services/dis-console/internal/flux/client.go
@@ -168,9 +168,9 @@ func restConfig(local bool) (*rest.Config, error) {
 
 // helmManagedSelector is the second server-side workload filter: every object
 // Helm renders carries the app.kubernetes.io/managed-by=Helm label (plus the
-// meta.helm.sh release annotations Sweep resolves ownership from), while the
-// kustomize-label selector cannot see chart objects — helm-controller applies
-// them itself and stamps no kustomize labels.
+// origin labels and meta.helm.sh release annotations Sweep resolves ownership
+// from), while the kustomize-label selector cannot see chart objects —
+// helm-controller applies them itself and stamps no kustomize labels.
 const helmManagedSelector = labelManagedBy + "=" + managedByHelm
 
 // Sweep lists every instance of each target kind across all namespaces and
@@ -185,10 +185,14 @@ const helmManagedSelector = labelManagedBy + "=" + managedByHelm
 // the kustomize-controller ownership label, or Helm's managed-by label. Both
 // filters ride the lists as server-side label selectors, which keeps
 // kube-system and Azure-managed add-ons out. A chart-created workload's
-// annotations name its Helm release — not the HelmRelease CR, whose
-// spec.releaseName/spec.targetNamespace change the release identity — so its
-// appliedBy is resolved against the batch's HelmReleases after the loop;
-// a release no swept HelmRelease accounts for (installed outside Flux) stays
+// appliedBy is taken from helm-controller's origin labels when present — they
+// name the HelmRelease CR exactly. Without them the workload's annotations
+// name only its Helm release — not the CR, whose spec.releaseName/
+// spec.targetNamespace change the release identity — so appliedBy is resolved
+// against the batch's HelmReleases after the loop. Two HelmReleases can claim
+// the same release identity (a duplicate CR pointing at another CR's
+// release); resolveClaim decides which one owns the release's objects. A
+// release no swept HelmRelease accounts for (installed outside Flux) stays
 // mirrored without an owner.
 //
 // The discovery cache is reset at most once per discoveryTTL rather than on
@@ -203,11 +207,12 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 
 	resources := make([]Resource, 0)
 	var warnings []error
-	// releases maps each HelmRelease's effective release identity to the CR;
+	// releases maps each HelmRelease's effective release identity to the
+	// winning claim on it (duplicates are tie-broken by resolveClaim);
 	// helmOwned remembers which mirrored workloads (by index into resources)
 	// wait for which release. Ownership is resolved after the kind loop, when
 	// both sides of the join are complete regardless of TargetKinds order.
-	releases := make(map[types.NamespacedName]AppliedBy)
+	releases := make(map[types.NamespacedName]releaseClaim)
 	type helmRef struct {
 		index   int
 		release types.NamespacedName
@@ -276,12 +281,25 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 					if err != nil {
 						warnings = append(warnings, fmt.Errorf("release identity %s/%s: %w", item.GetNamespace(), item.GetName(), err))
 					} else {
-						releases[id] = AppliedBy{Name: item.GetName(), Namespace: item.GetNamespace()}
+						claim := releaseClaim{
+							cr:    AppliedBy{Name: item.GetName(), Namespace: item.GetNamespace()},
+							ready: r.Ready == ReadyTrue,
+						}
+						if cur, contested := releases[id]; contested {
+							winner, warn := resolveClaim(id, cur, claim)
+							if warn != nil {
+								warnings = append(warnings, warn)
+							}
+							claim = winner
+						}
+						releases[id] = claim
 					}
 				}
 				resources = append(resources, r)
 				if selector == helmManagedSelector && r.AppliedBy == nil {
-					if owner, ok := helmOwnerFrom(item.GetAnnotations()); ok {
+					if ab := helmAppliedByFrom(item.GetLabels()); ab != nil {
+						resources[len(resources)-1].AppliedBy = ab
+					} else if owner, ok := helmOwnerFrom(item.GetAnnotations()); ok {
 						helmOwned = append(helmOwned, helmRef{index: len(resources) - 1, release: owner})
 					}
 				}
@@ -290,9 +308,41 @@ func (c *Client) Sweep(ctx context.Context) ([]Resource, []error, error) {
 	}
 
 	for _, w := range helmOwned {
-		if ab, ok := releases[w.release]; ok {
+		if claim, ok := releases[w.release]; ok {
+			ab := claim.cr
 			resources[w.index].AppliedBy = &ab
 		}
 	}
 	return resources, warnings, nil
+}
+
+// releaseClaim is one HelmRelease CR's claim on an effective release identity:
+// the CR ownership resolves to, and whether the CR was Ready at sweep time —
+// the tie-breaker between duplicate claims.
+type releaseClaim struct {
+	cr    AppliedBy
+	ready bool
+}
+
+// resolveClaim decides which of two HelmRelease CRs claiming the same
+// effective release identity owns the release's objects. Helm storage holds
+// one release per identity, so only one claimant can have installed it: a
+// Ready claimant beats one that is not (a CR that never installed the release
+// cannot own its live objects). Claims of equal readiness cannot be separated
+// safely — the default-layout CR (own namespace equal to the release
+// namespace) is preferred, the incumbent kept otherwise, and the contest is
+// reported as a warning either way.
+func resolveClaim(id types.NamespacedName, cur, next releaseClaim) (releaseClaim, error) {
+	if cur.ready != next.ready {
+		if next.ready {
+			return next, nil
+		}
+		return cur, nil
+	}
+	winner := cur
+	if next.cr.Namespace == id.Namespace && cur.cr.Namespace != id.Namespace {
+		winner = next
+	}
+	return winner, fmt.Errorf("release %s claimed by HelmRelease %s/%s and %s/%s: attributing to %s/%s",
+		id, cur.cr.Namespace, cur.cr.Name, next.cr.Namespace, next.cr.Name, winner.cr.Namespace, winner.cr.Name)
 }

--- a/services/dis-console/internal/flux/client_test.go
+++ b/services/dis-console/internal/flux/client_test.go
@@ -198,14 +198,14 @@ func TestSweepMirrorsOnlyGitOpsAppliedWorkloads(t *testing.T) {
 	}
 }
 
-// TestSweepResolvesHelmWorkloadOwnership pins the Helm side of the workload
-// sweep: chart-created workloads (managed-by label + release annotations, no
-// kustomize labels) are mirrored with appliedBy resolved to the HelmRelease
-// deploying that release — through the default identity, a releaseName
-// override, and targetNamespace prefix defaulting. A kustomize-applied object
-// whose chart hardcodes the managed-by label is mirrored exactly once and
-// keeps the kustomize appliedBy; a release no HelmRelease accounts for stays
-// mirrored without an owner.
+// TestSweepResolvesHelmWorkloadOwnership pins the annotation-fallback side of
+// the Helm join: chart-created workloads without origin labels (managed-by
+// label + release annotations, no kustomize labels) are mirrored with
+// appliedBy resolved to the HelmRelease deploying that release — through the
+// default identity, a releaseName override, and targetNamespace prefix
+// defaulting. A kustomize-applied object whose chart hardcodes the managed-by
+// label is mirrored exactly once and keeps the kustomize appliedBy; a release
+// no HelmRelease accounts for stays mirrored without an owner.
 func TestSweepResolvesHelmWorkloadOwnership(t *testing.T) {
 	deployment := func(ns, name string, objLabels, annotations map[string]any) unstructured.Unstructured {
 		meta := map[string]any{"namespace": ns, "name": name}
@@ -320,6 +320,207 @@ func TestSweepResolvesHelmWorkloadOwnership(t *testing.T) {
 		case *got.AppliedBy != *want:
 			t.Errorf("%s appliedBy = %+v, want %+v", name, got.AppliedBy, want)
 		}
+	}
+}
+
+// TestSweepPrefersHelmOriginLabels pins the label-first ownership path: when
+// a chart-created workload carries helm-controller's origin labels, appliedBy
+// comes straight from them — they name the CR exactly, and only the CR that
+// actually installed the release stamps them — even when the release
+// annotations would resolve to a different CR, and even when no swept
+// HelmRelease matches (the labels are trusted like the kustomize ones). An
+// object carrying only one of the two labels falls back to the annotation
+// join.
+func TestSweepPrefersHelmOriginLabels(t *testing.T) {
+	deployment := func(ns, name string, objLabels, annotations map[string]any) unstructured.Unstructured {
+		meta := map[string]any{"namespace": ns, "name": name, "labels": objLabels}
+		if annotations != nil {
+			meta["annotations"] = annotations
+		}
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   meta,
+		}}
+	}
+	originLabels := map[string]any{
+		labelManagedBy:           managedByHelm,
+		labelHelmOriginName:      "app-one",
+		labelHelmOriginNamespace: "team-one",
+	}
+	otherRelease := map[string]any{
+		annotationReleaseName:      "other-app",
+		annotationReleaseNamespace: "team-two",
+	}
+
+	d := &fakeDynamic{items: map[string][]unstructured.Unstructured{
+		"helmreleases": {{Object: map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]any{"namespace": "team-two", "name": "other-app"},
+		}}},
+		"deployments": {
+			// Full origin labels, no annotations, and no swept HelmRelease
+			// named app-one: the labels are trusted as-is.
+			deployment("team-one", "labeled-direct", originLabels, nil),
+			// Origin labels beat the annotation join — the annotations resolve
+			// to the swept other-app CR, but the labels name the installer.
+			deployment("team-two", "labeled-wins", originLabels, otherRelease),
+			// One label without the other: fall back to the annotation join.
+			deployment("team-two", "half-labeled", map[string]any{
+				labelManagedBy:      managedByHelm,
+				labelHelmOriginName: "app-one",
+			}, otherRelease),
+		},
+	}}
+	c := &Client{dyn: d, mapper: &fakeMapper{}}
+
+	resources, warnings, err := c.Sweep(context.Background())
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	wantOwner := map[string]AppliedBy{
+		"labeled-direct": {Name: "app-one", Namespace: "team-one"},
+		"labeled-wins":   {Name: "app-one", Namespace: "team-one"},
+		"half-labeled":   {Name: "other-app", Namespace: "team-two"},
+	}
+	for _, r := range resources {
+		want, ok := wantOwner[r.Name]
+		if !ok {
+			continue
+		}
+		delete(wantOwner, r.Name)
+		if r.AppliedBy == nil || *r.AppliedBy != want {
+			t.Errorf("%s appliedBy = %+v, want %+v", r.Name, r.AppliedBy, want)
+		}
+	}
+	for name := range wantOwner {
+		t.Errorf("workload %q not mirrored", name)
+	}
+}
+
+// TestSweepTieBreaksDuplicateReleaseClaims pins resolveClaim through Sweep:
+// when two HelmReleases declare the same effective release identity, the
+// Ready claimant owns the release's workloads regardless of list order and
+// without a warning; claims of equal readiness are warned about, with the
+// default-layout CR (own namespace == release namespace) preferred and the
+// first-listed claim kept when neither matches.
+func TestSweepTieBreaksDuplicateReleaseClaims(t *testing.T) {
+	helmRelease := func(ns, name, ready string, spec map[string]any) unstructured.Unstructured {
+		obj := map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]any{"namespace": ns, "name": name},
+			"status": map[string]any{
+				"conditions": []any{map[string]any{
+					"type":               "Ready",
+					"status":             ready,
+					"reason":             "TestSeed",
+					"lastTransitionTime": "2026-07-01T10:00:00Z",
+				}},
+			},
+		}
+		if spec != nil {
+			obj["spec"] = spec
+		}
+		return unstructured.Unstructured{Object: obj}
+	}
+	// Every HelmRelease below claims the identity app-system/app-one, which
+	// the workload's release annotations name.
+	claimSpec := map[string]any{"releaseName": "app-one", "targetNamespace": "app-system"}
+	healthy := helmRelease("app-system", "app-one", "True", nil)
+	blocked := helmRelease("platform-system", "app-one", "False", claimSpec)
+	duplicate := helmRelease("platform-system", "app-one", "True", claimSpec)
+	remoteOne := helmRelease("team-one", "claim-one", "True", claimSpec)
+	remoteTwo := helmRelease("team-two", "claim-two", "True", claimSpec)
+	workload := unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"namespace": "app-system",
+			"name":      "app-one-worker",
+			"labels":    map[string]any{labelManagedBy: managedByHelm},
+			"annotations": map[string]any{
+				annotationReleaseName:      "app-one",
+				annotationReleaseNamespace: "app-system",
+			},
+		},
+	}}
+
+	cases := []struct {
+		name      string
+		hrs       []unstructured.Unstructured
+		wantOwner AppliedBy
+		wantWarn  string // "" means no warning at all
+	}{
+		{
+			name:      "ready beats blocked, blocked listed last",
+			hrs:       []unstructured.Unstructured{healthy, blocked},
+			wantOwner: AppliedBy{Name: "app-one", Namespace: "app-system"},
+		},
+		{
+			name:      "ready beats blocked, blocked listed first",
+			hrs:       []unstructured.Unstructured{blocked, healthy},
+			wantOwner: AppliedBy{Name: "app-one", Namespace: "app-system"},
+		},
+		{
+			name:      "both ready: default layout wins, listed first",
+			hrs:       []unstructured.Unstructured{healthy, duplicate},
+			wantOwner: AppliedBy{Name: "app-one", Namespace: "app-system"},
+			wantWarn:  "attributing to app-system/app-one",
+		},
+		{
+			name:      "both ready: default layout wins, listed last",
+			hrs:       []unstructured.Unstructured{duplicate, healthy},
+			wantOwner: AppliedBy{Name: "app-one", Namespace: "app-system"},
+			wantWarn:  "attributing to app-system/app-one",
+		},
+		{
+			name:      "neither separable: first claim kept",
+			hrs:       []unstructured.Unstructured{remoteOne, remoteTwo},
+			wantOwner: AppliedBy{Name: "claim-one", Namespace: "team-one"},
+			wantWarn:  "attributing to team-one/claim-one",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &fakeDynamic{items: map[string][]unstructured.Unstructured{
+				"helmreleases": tc.hrs,
+				"deployments":  {workload},
+			}}
+			c := &Client{dyn: d, mapper: &fakeMapper{}}
+
+			resources, warnings, err := c.Sweep(context.Background())
+			if err != nil {
+				t.Fatalf("sweep: %v", err)
+			}
+			switch {
+			case tc.wantWarn == "":
+				if len(warnings) != 0 {
+					t.Errorf("unexpected warnings: %v", warnings)
+				}
+			case len(warnings) != 1:
+				t.Errorf("warnings = %v, want exactly one naming the contested release", warnings)
+			default:
+				got := warnings[0].Error()
+				if !strings.Contains(got, "release app-system/app-one") || !strings.Contains(got, tc.wantWarn) {
+					t.Errorf("warning = %q, want the contested identity and %q", got, tc.wantWarn)
+				}
+			}
+			for _, r := range resources {
+				if r.Name != "app-one-worker" {
+					continue
+				}
+				if r.AppliedBy == nil || *r.AppliedBy != tc.wantOwner {
+					t.Errorf("appliedBy = %+v, want %+v", r.AppliedBy, tc.wantOwner)
+				}
+				return
+			}
+			t.Fatal("workload app-one-worker not mirrored")
+		})
 	}
 }
 

--- a/services/dis-console/internal/flux/normalize.go
+++ b/services/dis-console/internal/flux/normalize.go
@@ -56,8 +56,9 @@ type Resource struct {
 	// the kustomize.toolkit.fluxcd.io/{name,namespace} labels the kustomize
 	// controller stamps on everything it applies — or, for chart-created
 	// workloads (which carry no kustomize labels), the owning HelmRelease,
-	// resolved by Sweep from the object's Helm release annotations. Lets the
-	// list endpoint (which omits Raw) group child resources under their parent
+	// taken by Sweep from helm-controller's origin labels when present, else
+	// resolved from the object's Helm release annotations. Lets the list
+	// endpoint (which omits Raw) group child resources under their parent
 	// app. Empty for roots, Arc-managed objects, and Helm releases installed
 	// outside Flux.
 	AppliedBy *AppliedBy `json:"appliedBy,omitempty"`
@@ -125,6 +126,18 @@ const (
 	managedByHelm              = "Helm"
 	annotationReleaseName      = "meta.helm.sh/release-name"
 	annotationReleaseNamespace = "meta.helm.sh/release-namespace"
+)
+
+// Labels helm-controller's builtin post-renderer stamps on every object it
+// applies, naming the HelmRelease CR itself (name and the CR's own namespace).
+// Unlike the meta.helm.sh annotations — which name the Helm release, an
+// identity any CR can claim via spec.releaseName/spec.targetNamespace — these
+// identify the CR exactly, and only the CR that actually installed the release
+// stamps them. Absent on releases installed outside Flux and on objects not
+// re-applied since the controller gained the post-renderer.
+const (
+	labelHelmOriginName      = GroupHelm + "/name"
+	labelHelmOriginNamespace = GroupHelm + "/namespace"
 )
 
 // AppliedBy identifies the Kustomization that applied a resource. The JSON
@@ -361,6 +374,18 @@ func helmReleaseIdentity(u *unstructured.Unstructured) (types.NamespacedName, er
 		return types.NamespacedName{}, err
 	}
 	return types.NamespacedName{Namespace: o.GetReleaseNamespace(), Name: o.GetReleaseName()}, nil
+}
+
+// helmAppliedByFrom projects helm-controller's origin labels into an
+// AppliedBy naming the HelmRelease CR directly. Nil when either label is
+// missing; the caller then falls back to resolving the meta.helm.sh release
+// annotations against the swept HelmReleases.
+func helmAppliedByFrom(labels map[string]string) *AppliedBy {
+	name, ns := labels[labelHelmOriginName], labels[labelHelmOriginNamespace]
+	if name == "" || ns == "" {
+		return nil
+	}
+	return &AppliedBy{Name: name, Namespace: ns}
 }
 
 // helmOwnerFrom reads the meta.helm.sh release annotations naming the Helm


### PR DESCRIPTION
## Problem

On admin_test two HelmRelease CRs declare the same effective release identity `azureserviceoperator-system/azure-service-operator`: the healthy CR and an orphaned duplicate in `platform-system` (explicit `releaseName` + `targetNamespace`, blocked `DependencyNotReady`, never installed). The `meta.helm.sh` annotations on a chart workload name the *Helm release*, not the CR — any CR in any namespace can claim that identity — and the sweep's release map was last-writer-wins over an unordered batch, so the ASO Deployment's `appliedBy` could land on the dead CR and the console showed it as a standalone app.

## Fix

- **Origin labels first:** when a workload carries `helm.toolkit.fluxcd.io/{name,namespace}`, take `appliedBy` straight from them. helm-controller's builtin post-renderer stamps them on everything it applies, they name the CR exactly, and only the CR that actually installed the release stamps them. Verified present on the live ASO Deployment on admin_test, naming the healthy CR.
- **Tie-break the annotation fallback:** duplicate claims on one release identity go through `resolveClaim` — a Ready claimant wins (a CR that never installed cannot own live objects); equal readiness prefers the default-layout CR (own namespace == release namespace), keeps the first otherwise, and emits a sweep warning naming both CRs and the contested identity.

Unit tests cover the label-first path (trusted without existence check, beats a conflicting annotation resolution, half-labeled falls back) and the tie-break in both list orders; a mutation check confirmed they fail against the old last-writer-wins insert. `make run-checks-ci-cache` and `make test-e2e-kind-ci` pass.

## Rollout

Agent-only patch: after release, bump the admin + TE agents and the template like the previous v1.7.x patches. The orphaned `platform-system` HR on admin_test is a separate cleanup — this change makes attribution correct wherever duplicates exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Helm workload ownership detection using origin labels, with annotation-based fallback.
  * Added deterministic handling when multiple Helm releases claim the same workload.

* **Bug Fixes**
  * Ready Helm releases now take precedence during ownership resolution.
  * Added namespace-aware tie-breaking and warnings for unresolved duplicate claims.
  * Workloads without a matching Helm release remain unowned.

* **Documentation**
  * Updated ownership-resolution guidance for Helm-managed workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->