### PR TITLE
fix(dis-console): grant the tenant agent ClusterRole the apps workload kinds

### DIFF
--- a/deploy/templates/dis-console-tenant-app-template/rbac.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/rbac.yaml
@@ -64,6 +64,16 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Problem

The dis-console agent v1.7.x sweeps apps/v1 workloads, and the apps kinds are core to the sweep — missing RBAC aborts the entire sweep and the agent keeps serving previous data. This is live on ttd_at23: `deployments.apps is forbidden` for the `dis-console:dis-console` ServiceAccount.

The TE pilot agents bind the `dis-console-flux-reader` ClusterRole from `deploy/templates/dis-console-tenant-app-template/rbac.yaml`, which never received the apps rule. #3836 added it only to `deploy/admin/base/dis-console-agent-rbac.yaml`, and gitops-manifests#1336 patched a different role (`dis-console-reader` in platform-system) these agents don't use.

## Fix

Append the same apps rule (deployments, statefulsets, daemonsets / get, list, watch) that `deploy/admin` already has to the tenant template's ClusterRole. Only two copies of `dis-console-flux-reader` exist under `deploy/` (admin + this template); `deploy/common/at22`/`at23` don't carry their own, so this is the only edit needed.

## Rollout

No code changes, no version bump. After merge, dispatch the syncroot publish for the tenant app template so the role lands on at22/at23; the next agent sweep then succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only visibility into Kubernetes deployments, stateful sets, and daemon sets.
  * Enables viewing workload details and status updates through the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->