### PR TITLE
feat(dis-common): shared Go module with RFC 0007 platformtags package

### DIFF
--- a/.github/workflows/dis-common-lint-test.yml
+++ b/.github/workflows/dis-common-lint-test.yml
@@ -1,0 +1,70 @@
+name: Dis Common Lint and Test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - services/dis-common/**
+      - .github/workflows/dis-common-lint-test.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - services/dis-common/**
+      - .github/workflows/dis-common-lint-test.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Run linter on Ubuntu
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: services/dis-common
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "services/dis-common/go.mod"
+          cache: false
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          version: v2.12.2
+          working-directory: services/dis-common
+
+  test:
+    name: Run tests on Ubuntu
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: services/dis-common
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "services/dis-common/go.mod"
+          cache: false
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test

--- a/services/dis-common/.gitignore
+++ b/services/dis-common/.gitignore
@@ -1,0 +1,3 @@
+bin/
+.cache/
+cover.out

--- a/services/dis-common/.golangci.yml
+++ b/services/dis-common/.golangci.yml
@@ -1,0 +1,61 @@
+version: "2"
+run:
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - copyloopvar
+    - dupl
+    - errcheck
+    - ginkgolinter
+    - goconst
+    - gocyclo
+    - govet
+    - ineffassign
+    - lll
+    - modernize
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+    modernize:
+      disable:
+        - omitzero
+        - newexpr
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+      - linters:
+          - staticcheck
+        path: api/v1alpha1/groupversion_info.go
+        text: SA1019
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/services/dis-common/AGENTS.md
+++ b/services/dis-common/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Project goals
+- Shared Go library for the DIS operators and services in this monorepo.
+- Keep it small and dependency-free where possible: packages here define cross-service contracts (for example the finops tag set), so changes must stay deliberate and backwards compatible.
+
+## How it is consumed
+- Consumers depend on `github.com/Altinn/altinn-platform/services/dis-common` pinned to a pseudo-version, like the operators depend on each other.
+- No `replace` directives: operator container builds copy only their own service directory and fetch dependencies from the module proxy.
+- A change here only reaches an operator when its `go.mod` is bumped to a newer pseudo-version.
+
+## Required verification for code changes
+If you modify any Go file, you MUST run before producing a final answer/patch:
+
+1. `make test-cache`
+2. `make lint-cache`
+
+You can run both with `make run-checks-ci-cache`.
+
+In the final response, include the command(s) you ran and whether they passed.
+If you cannot run them, you MUST say so explicitly and explain why.
+
+## Non-negotiable
+Do not claim checks passed unless you actually ran them.

--- a/services/dis-common/Makefile
+++ b/services/dis-common/Makefile
@@ -1,0 +1,58 @@
+CACHE_DIR ?= $(CURDIR)/.cache
+GOCACHE ?= $(CACHE_DIR)/go-build
+GOLANGCI_LINT_CACHE ?= $(CACHE_DIR)/golangci-lint
+
+LOCALBIN ?= $(CURDIR)/bin
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+GOLANGCI_LINT_VERSION ?= v2.12.2
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.PHONY: fmt
+fmt: ## Run go fmt against code.
+	go fmt ./...
+
+.PHONY: vet
+vet: ## Run go vet against code.
+	go vet ./...
+
+.PHONY: test
+test: fmt vet ## Run tests.
+	go test ./... -coverprofile cover.out
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter.
+	$(GOLANGCI_LINT) run
+
+.PHONY: run-checks-ci
+run-checks-ci: test lint ## Run all CI checks.
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+.PHONY: cache-setup
+cache-setup: ## Create local build caches for sandboxed runs.
+	@mkdir -p "$(GOCACHE)" "$(GOLANGCI_LINT_CACHE)"
+
+CACHE_TARGETS := fmt-cache vet-cache test-cache lint-cache run-checks-ci-cache
+$(CACHE_TARGETS): export GOCACHE := $(GOCACHE)
+$(CACHE_TARGETS): export GOLANGCI_LINT_CACHE := $(GOLANGCI_LINT_CACHE)
+
+.PHONY: $(CACHE_TARGETS)
+fmt-cache: cache-setup ## fmt with repository-local caches.
+	$(MAKE) fmt
+vet-cache: cache-setup ## vet with repository-local caches.
+	$(MAKE) vet
+test-cache: cache-setup ## test with repository-local caches.
+	$(MAKE) test
+lint-cache: cache-setup ## lint with repository-local caches.
+	$(MAKE) lint
+run-checks-ci-cache: cache-setup ## Run all CI checks with repository-local caches.
+	$(MAKE) run-checks-ci

--- a/services/dis-common/README.md
+++ b/services/dis-common/README.md
@@ -1,0 +1,9 @@
+# dis-common
+
+Shared Go library for the DIS operators and services in this repository.
+
+Consumers import it as a normal module dependency (`github.com/Altinn/altinn-platform/services/dis-common`) pinned to a pseudo-version, the same way the operators depend on each other. There are no `replace` directives: operator images fetch dependencies from the module proxy.
+
+Packages:
+
+- `platformtags`: the RFC 0007 finops base tag set applied to Azure resources created by the DIS operators (see `rfcs/0007-finops-resource-tags.md`).

--- a/services/dis-common/go.mod
+++ b/services/dis-common/go.mod
@@ -1,0 +1,3 @@
+module github.com/Altinn/altinn-platform/services/dis-common
+
+go 1.26.0

--- a/services/dis-common/platformtags/platformtags.go
+++ b/services/dis-common/platformtags/platformtags.go
@@ -1,0 +1,81 @@
+// Package platformtags computes the platform-owned Azure resource tags — the
+// RFC 0007 finops base tag set — for Azure resources created by this operator.
+package platformtags
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+)
+
+// RepositoryURL is the value of the RFC 0007 `repository` tag: the source
+// repository of the code that creates the tags.
+const RepositoryURL = "https://github.com/Altinn/altinn-platform"
+
+// productNamespacePrefix is the fleet naming convention for tenant product
+// namespaces; the remainder of the namespace name is the product identifier.
+const productNamespacePrefix = "product-"
+
+const (
+	keyFinopsProduct = "finops_product"
+	keyProduct       = "product"
+	keyRepository    = "repository"
+)
+
+// ParseBase parses the operator's base-tags configuration: a JSON object of
+// tag key/value pairs. An empty value disables platform tagging and yields
+// (nil, nil). An unsubstituted Flux placeholder (e.g. "${SOME_VAR}") is not
+// valid JSON and returns an error; callers are expected to log it and
+// continue without platform tags rather than fail startup.
+func ParseBase(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var base map[string]string
+	if err := json.Unmarshal([]byte(raw), &base); err != nil {
+		return nil, fmt.Errorf("base tags must be a JSON object of string values: %w", err)
+	}
+	for key := range base {
+		if strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("base tags contain an empty key")
+		}
+	}
+	if len(base) == 0 {
+		return nil, nil
+	}
+	return base, nil
+}
+
+// ForNamespace returns the platform tag set for a resource reconciled in the
+// given namespace: the base tags with finops_product/product overridden by
+// the product namespace name (when the namespace follows the product-<name>
+// convention) and repository pinned to this codebase. Returns nil when no
+// base tags are configured, keeping the operator's pre-rollout behavior.
+func ForNamespace(base map[string]string, namespace string) map[string]string {
+	if len(base) == 0 {
+		return nil
+	}
+	tags := maps.Clone(base)
+	if product, ok := strings.CutPrefix(namespace, productNamespacePrefix); ok && product != "" {
+		tags[keyFinopsProduct] = product
+		tags[keyProduct] = product
+	}
+	tags[keyRepository] = RepositoryURL
+	return tags
+}
+
+// Merge overlays platform tags onto tags from other sources (tenant-provided
+// or resource-specific). Platform keys win: finops tag values are cost data
+// owned by the platform, never tenant input. Returns nil when both maps are
+// empty.
+func Merge(other, platform map[string]string) map[string]string {
+	if len(other) == 0 && len(platform) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(other)+len(platform))
+	maps.Copy(merged, other)
+	maps.Copy(merged, platform)
+	return merged
+}

--- a/services/dis-common/platformtags/platformtags_test.go
+++ b/services/dis-common/platformtags/platformtags_test.go
@@ -1,0 +1,102 @@
+package platformtags
+
+import (
+	"maps"
+	"testing"
+)
+
+const (
+	keyEnv             = "env"
+	testEnv            = "at22"
+	testClusterProduct = "dis-core"
+	testProduct        = "dialogporten"
+)
+
+func TestParseBase(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParseBase(`{"finops_environment":"at22","env":"at22"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{"finops_environment": testEnv, keyEnv: testEnv}
+	if !maps.Equal(got, want) {
+		t.Fatalf("want %#v, got %#v", want, got)
+	}
+
+	for name, raw := range map[string]string{"empty": "", "empty object": "{}"} {
+		if got, err := ParseBase(raw); err != nil || got != nil {
+			t.Fatalf("%s: expected tagging disabled (nil, nil), got %#v, %v", name, got, err)
+		}
+	}
+
+	for name, raw := range map[string]string{
+		"unsubstituted flux placeholder": "${DISPG_BASE_TAGS}",
+		"not a JSON object":              `["env"]`,
+	} {
+		if got, err := ParseBase(raw); err == nil {
+			t.Fatalf("%s: expected error, got %#v", name, got)
+		}
+	}
+}
+
+func TestForNamespace(t *testing.T) {
+	t.Parallel()
+
+	if got := ForNamespace(nil, "product-"+testProduct); got != nil {
+		t.Fatalf("expected nil platform tags when base is unset, got %#v", got)
+	}
+
+	base := map[string]string{
+		keyEnv:           testEnv,
+		keyFinopsProduct: testClusterProduct,
+		keyProduct:       testClusterProduct,
+	}
+	baseBefore := maps.Clone(base)
+
+	got := ForNamespace(base, "product-"+testProduct)
+	want := map[string]string{
+		keyEnv:           testEnv,
+		keyFinopsProduct: testProduct,
+		keyProduct:       testProduct,
+		keyRepository:    RepositoryURL,
+	}
+	if !maps.Equal(got, want) {
+		t.Fatalf("product namespace: want %#v, got %#v", want, got)
+	}
+	if !maps.Equal(base, baseBefore) {
+		t.Fatalf("base tags map was mutated: %#v", base)
+	}
+
+	got = ForNamespace(base, "platform-system")
+	want = map[string]string{
+		keyEnv:           testEnv,
+		keyFinopsProduct: testClusterProduct,
+		keyProduct:       testClusterProduct,
+		keyRepository:    RepositoryURL,
+	}
+	if !maps.Equal(got, want) {
+		t.Fatalf("non-product namespace: want %#v, got %#v", want, got)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	if got := Merge(nil, nil); got != nil {
+		t.Fatalf("expected nil for empty inputs, got %#v", got)
+	}
+
+	tenant := map[string]string{"team": "dp-backend", keyFinopsProduct: "not-my-product"}
+	platform := map[string]string{keyFinopsProduct: testProduct}
+
+	got := Merge(tenant, platform)
+
+	want := map[string]string{"team": "dp-backend", keyFinopsProduct: testProduct}
+	if !maps.Equal(got, want) {
+		t.Fatalf("expected platform keys to win: want %#v, got %#v", want, got)
+	}
+	if tenant[keyFinopsProduct] != "not-my-product" {
+		t.Fatalf("tenant map was mutated: %#v", tenant)
+	}
+}


### PR DESCRIPTION
## Problem
Shared Go code was starting to get copied between the dis operators — the finops `platformtags` package would have landed as three identical copies.

## Fix
Add `services/dis-common`, a shared library module consumed by pseudo-version exactly like dis-pgsql already consumes dis-identity: no `replace` directives, operator images keep fetching dependencies from the module proxy. First resident: `platformtags` — the RFC 0007 finops base tag set (JSON parsing of the operator config value, per-namespace product derivation, platform-wins merge) for Azure resources created by the dis operators. Placement follows the repo's `services/<name>` module convention (same shape as Azure SDK's `sdk/internal`: a library module next to its consumers). Comes with its own lint+test workflow.

## Rollout
Inert until consumed. A follow-up PR wires dis-pgsql/dis-vault/dis-identity to it (pinning the pseudo-version of this PR's merge commit) and adds the `*_BASE_TAGS` plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)