### PR TITLE
chore(makefile-common): safe deploy + test-e2e hooks

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -129,9 +129,14 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 	@mkdir -p "$(LOCALBIN)"
 	@$(KIND) export kubeconfig --name "$(KIND_CLUSTER)" --kubeconfig "$(KIND_KUBECONFIG)"
 
+# Extra env and go-test flags for the e2e run; projects override before the
+# include (e.g. E2E_ENV := CERT_MANAGER_INSTALL_SKIP=true, E2E_GOTEST_FLAGS := -timeout=10m).
+E2E_ENV ?=
+E2E_GOTEST_FLAGS ?=
+
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	@rc=0; KUBECONFIG="$(KIND_KUBECONFIG)" KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v || rc=$$?; \
+	@rc=0; $(E2E_ENV) KUBECONFIG="$(KIND_KUBECONFIG)" KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v $(E2E_GOTEST_FLAGS) || rc=$$?; \
 	$(MAKE) cleanup-test-e2e; \
 	exit $$rc
 
@@ -214,7 +219,12 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
+	@set -e; \
+	kustomize_file="config/manager/kustomization.yaml"; \
+	kustomize_backup="$$(mktemp)"; \
+	cp "$$kustomize_file" "$$kustomize_backup"; \
+	trap 'cp "$$kustomize_backup" "$$kustomize_file"; rm -f "$$kustomize_backup"' EXIT; \
+	( cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
 
 .PHONY: undeploy


### PR DESCRIPTION
## What
Two small, backward-compatible improvements to the shared root `Makefile.common`, so the remaining operators (dis-vault, dis-pgsql) can adopt it **without overriding `deploy`/`test-e2e`** (which would emit `overriding recipe` warnings).

**1. `deploy` no longer dirties the working tree.** It now backs up `config/manager/kustomization.yaml`, runs `kustomize edit set image`, and restores the file via a `trap ... EXIT`. Previously the image mutation was left in the tree. Strict improvement for every consumer.

**2. `test-e2e` gains two hooks:**
- `E2E_ENV` — extra environment prepended to the `go test` (e.g. `CERT_MANAGER_INSTALL_SKIP=true`)
- `E2E_GOTEST_FLAGS` — extra flags appended (e.g. `-timeout=10m`)

Both default empty, so the recipe is unchanged for current consumers.

## Behavior-preserving
Verified by dry-run: with the hooks unset, `make -n test-e2e` expands identically to before; with them set, the env/flags are injected. `make help` is warning-free. dis-console (a plain service) doesn't use `deploy`/`test-e2e`, so it's unaffected.

## Why now
Enables the clean, override-free migration of dis-vault and dis-pgsql onto `Makefile.common` (both customize exactly these two targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for passing extra environment variables and Go test flags to end-to-end test runs.

* **Bug Fixes**
  * Improved deployment safety by ensuring configuration files are restored to their original state after deployment, including when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->