### PR TITLE
chore(makefile-common): make build-installer kustomize-safe

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -197,8 +197,13 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
-	mkdir -p dist
-	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
+	@set -e; \
+	kustomize_file="config/manager/kustomization.yaml"; \
+	kustomize_backup="$$(mktemp)"; \
+	cp "$$kustomize_file" "$$kustomize_backup"; \
+	trap 'cp "$$kustomize_backup" "$$kustomize_file"; rm -f "$$kustomize_backup"' EXIT; \
+	mkdir -p dist; \
+	( cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
 	"$(KUSTOMIZE)" build config/default > dist/install.yaml
 
 ##@ Deployment


### PR DESCRIPTION
Follow-up to the safe-`deploy` change (#3855). `build-installer` has the same problem `deploy` had: `kustomize edit set image` mutates `config/manager/kustomization.yaml` and left it modified in the working tree.

This applies the identical backup/restore-via-`trap` pattern to `build-installer`, so it never dirties the tree.

## Why
- Strict improvement for all consumers (apim/identity already inherit `Makefile.common`).
- Lets dis-vault and dis-pgsql — which already made `build-installer` safe locally — adopt `Makefile.common` without overriding it (an override would emit a `make` warning).

## Verification
Dry-run confirms the backup/restore/`trap` wrapper around `kustomize edit`; `make help` is warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)