### PR TITLE
chore(dis-pgsql): adopt shared Makefile.common

### DIFF
--- a/.github/workflows/dis-pgsql-lint-test.yml
+++ b/.github/workflows/dis-pgsql-lint-test.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - services/dis-pgsql-operator/**
       - .github/workflows/dis-pgsql-lint-test.yml
+      - Makefile.common
   pull_request:
     branches:
       - main
     paths:
       - services/dis-pgsql-operator/**
       - .github/workflows/dis-pgsql-lint-test.yml
+      - Makefile.common
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/services/dis-pgsql-operator/Makefile
+++ b/services/dis-pgsql-operator/Makefile
@@ -1,67 +1,44 @@
-# Image URL to use for build/deploy targets.
+APP_NAME ?= dis-pgsql-operator
 # Keep the localhost/ prefix: in local Kind flows we load this image directly,
 # and this avoids accidental registry lookups when the image name is overridden.
 IMG ?= localhost/controller:latest
+CONTAINER_TOOL ?= podman
+
+# e2e: skip cert-manager install and set the go test timeout; injected into
+# Makefile.common's test-e2e via the E2E_ENV / E2E_GOTEST_FLAGS hooks.
+CERT_MANAGER_INSTALL_SKIP ?= true
+E2E_TEST_TIMEOUT ?= 30m
+E2E_ENV := CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP)
+E2E_GOTEST_FLAGS := -timeout=$(E2E_TEST_TIMEOUT)
+
+# Consumed by Makefile.common: operator CI check suite and local tooling bootstrap.
+RUN_CHECKS := fmt generate manifests test-ci lint
+SETUP_TOOLS := golangci-lint kustomize controller-gen setup-envtest
+
+include ../../Makefile.common
+
+##@ Pgsql-specific
+
+WORKSPACE_ROOT ?= $(abspath $(CURDIR)/../..)
 KIND_IMAGE_ARCHIVE := bin/dis-pgsql-operator_image.tar
 
-# Local Go cache settings for CI check runs
-CACHE_DIR ?= $(CURDIR)/.cache
-GOCACHE ?= $(CACHE_DIR)/go-build
-GOLANGCI_LINT_CACHE ?= $(CACHE_DIR)/golangci-lint
-CACHE_GOWORK ?= off
-WORKSPACE_ROOT ?= $(abspath $(CURDIR)/../..)
-
-# Operator config test defaults
+# Operator config defaults (overridable via the environment for local runs).
 WRITE_NAMESPACE ?= default
-
 AZURE_SUBSCRIPTION_ID ?= 00000000-0000-0000-0000-000000000000
 AZURE_TENANT_ID ?= 00000000-0000-0000-0000-000000000000
 AZURE_VNET_RESOURCE_GROUP ?= rg-dis-dev-network
 AZURE_VNET_NAME ?= dis-dev-vnet
-
 DB_VNET_NAME ?= dis-dev-vnet
 AKS_VNET_NAME ?= dis-dev-aks-vnet
-
 USE_AZ_FAKES ?= true
-CERT_MANAGER_INSTALL_SKIP ?= true
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+# The envtest controller suite needs the ASO and ApplicationIdentity CRDs on
+# disk. These recipe-less rules add them as prerequisites of the shared
+# setup-envtest target without overriding its recipe.
+setup-envtest: aso-crds dis-identity-crd
 
-# CONTAINER_TOOL defines the container tool to be used for building images.
-# Be aware that the target commands are only tested with Docker which is
-# scaffolded by default. However, you might want to replace it to use other
-# tools. (i.e. podman)
-CONTAINER_TOOL ?= podman
-
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
-
-.PHONY: all
-all: build
-
-##@ General
-
-# The help target prints out all targets with their descriptions organized
-# beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk command is responsible for reading the
-# entire set of makefiles included in this invocation, looking for lines of the
-# file as xyz: ## something, and then pretty-format the target and help. Then,
-# if there's a line with ##@ something, that gets pretty-printed as a category.
-# More info on the usage of ANSI control characters for terminal formatting:
-# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
-# More info on the awk command:
-# http://linuxcommand.org/lc3_adv_awk.php
-
-.PHONY: help
-help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+# Local dev also initialises the go.work workspace (pgsql + identity).
+setup-local-env: workspace
 
 .PHONY: workspace
 workspace: ## Create local go.work for dev across dis-pgsql-operator and dis-identity-operator (not committed).
@@ -78,115 +55,18 @@ workspace: ## Create local go.work for dev across dis-pgsql-operator and dis-ide
 workspace-clean: ## Remove local go.work/go.work.sum (dev only).
 	@rm -f "$(WORKSPACE_ROOT)/go.work" "$(WORKSPACE_ROOT)/go.work.sum"
 
-.PHONY: setup-local-env
-setup-local-env: ## Bootstrap local dev environment (shared by Codex/Claude/Gemini).
-	$(MAKE) workspace
-	$(MAKE) cache-setup
-	$(MAKE) kustomize
-	$(MAKE) controller-gen
-	$(MAKE) golangci-lint
-	$(MAKE) setup-envtest
-	@mkdir -p "$(CACHE_DIR)/golangci-lint"
-	@echo "Local environment bootstrap completed."
-
 .PHONY: clean
 clean: restore-kustomize workspace-clean tidy test ## Clean local dev artifacts before pushing.
 
-.PHONY: tidy
-tidy: ## Run go mod tidy.
-	go mod tidy
-
-##@ Cache
-
-CACHE_TARGETS := run-checks-ci
-
-.PHONY: cache-setup
-cache-setup:
-	@mkdir -p "$(GOCACHE)"
-	@mkdir -p "$(GOLANGCI_LINT_CACHE)"
-
-$(CACHE_TARGETS): export GOCACHE := $(GOCACHE)
-$(CACHE_TARGETS): export GOLANGCI_LINT_CACHE := $(GOLANGCI_LINT_CACHE)
-$(CACHE_TARGETS): export GOWORK := $(CACHE_GOWORK)
-$(CACHE_TARGETS): cache-setup
-
-%-cache: export GOCACHE := $(GOCACHE)
-%-cache: export GOLANGCI_LINT_CACHE := $(GOLANGCI_LINT_CACHE)
-%-cache: export GOWORK := $(CACHE_GOWORK)
-%-cache: cache-setup
-	$(MAKE) $*
-
-##@ Development
-
-.PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-
-.PHONY: generate
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
-
-.PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
-
-.PHONY: vet
-vet: ## Run go vet against code.
-	go vet ./...
-
-.PHONY: test
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$$("$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+.PHONY: restore-kustomize
+restore-kustomize: ## Restore kustomize edits made by deploy-kind.
+	git restore --source=HEAD --staged --worktree -- config/manager/kustomization.yaml
 
 .PHONY: test-ci
 test-ci: manifests generate fmt vet envtest ## Run tests (envtest disabled).
 	DISPG_SKIP_ENVTEST=1 KUBEBUILDER_ASSETS="$$("$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
-.PHONY: run-checks-ci
-run-checks-ci: ## Run CI checks with local Go caches.
-	$(MAKE) fmt
-	$(MAKE) generate
-	$(MAKE) manifests
-	$(MAKE) test-ci
-	$(MAKE) lint
-
-# TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
-# The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
-KIND_CLUSTER ?= dis-pgsql-operator-test-e2e
-E2E_TEST_TIMEOUT ?= 30m
-
-# Dedicated kubeconfig for the Kind e2e cluster. The whole e2e flow points KUBECONFIG
-# here so every kubectl/make step targets the Kind cluster this Makefile created, never
-# the caller's current context (which would otherwise silently apply to the wrong cluster).
-KIND_KUBECONFIG ?= $(LOCALBIN)/kind-$(KIND_CLUSTER).kubeconfig
-
-.PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
-	@command -v $(KIND) >/dev/null 2>&1 || { \
-		echo "Kind is not installed. Please install Kind manually."; \
-		exit 1; \
-	}
-	@if $(KIND) get clusters | grep -qx "$(KIND_CLUSTER)"; then \
-		if $(KUBECTL) --context "kind-$(KIND_CLUSTER)" get nodes >/dev/null 2>&1; then \
-			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation."; \
-		else \
-			echo "Kind cluster '$(KIND_CLUSTER)' exists but is not reachable. Recreating..."; \
-			$(KIND) delete cluster --name $(KIND_CLUSTER); \
-			$(KIND) create cluster --name $(KIND_CLUSTER); \
-		fi; \
-	else \
-		echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-		$(KIND) create cluster --name $(KIND_CLUSTER); \
-	fi
-	@mkdir -p "$(LOCALBIN)"
-	@$(KIND) export kubeconfig --name "$(KIND_CLUSTER)" --kubeconfig "$(KIND_KUBECONFIG)"
-
-.PHONY: test-e2e
-test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KUBECONFIG="$(KIND_KUBECONFIG)" CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout=$(E2E_TEST_TIMEOUT)
-	$(MAKE) cleanup-test-e2e
+##@ Kind e2e
 
 .PHONY: test-e2e-kind
 test-e2e-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
@@ -198,10 +78,6 @@ test-e2e-kind: cleanup-test-e2e setup-test-e2e docker-build kind-load install in
 test-e2e-kind-ci: cleanup-test-e2e setup-test-e2e manifests generate fmt vet install-aso-crds-kind install-dis-identity-crd-kind ## Run the e2e tests on Kind and cleanup (CI).
 	KUBECONFIG="$(KIND_KUBECONFIG)" CERT_MANAGER_INSTALL_SKIP=$(CERT_MANAGER_INSTALL_SKIP) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v -timeout=$(E2E_TEST_TIMEOUT)
 	$(MAKE) cleanup-test-e2e
-
-.PHONY: cleanup-test-e2e
-cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
-	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: install-aso-crds-kind
 install-aso-crds-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
@@ -256,92 +132,10 @@ seed-dis-identity-kind: ## Apply ApplicationIdentity stubs and patch status for 
 		--subresource=status --type=merge \
 		-p '{"status":{"managedIdentityName":"user2","principalId":"user2-principal-id"}}'
 
-.PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
-	"$(GOLANGCI_LINT)" run
-
-.PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	"$(GOLANGCI_LINT)" run --fix
-
-.PHONY: lint-config
-lint-config: golangci-lint ## Verify golangci-lint linter configuration
-	"$(GOLANGCI_LINT)" config verify
-
-##@ Build
-
-.PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
-
-.PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
-
-# If you wish to build the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: docker-build
-docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
-
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	$(CONTAINER_TOOL) push ${IMG}
-
-# PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
-# - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
-# - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
-# To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
-.PHONY: docker-buildx
-docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name dis-pgsql-operator-builder
-	$(CONTAINER_TOOL) buildx use dis-pgsql-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm dis-pgsql-operator-builder
-	rm Dockerfile.cross
-
-.PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
-	@set -e; \
-		trap '$(MAKE) -C "$(CURDIR)" restore-kustomize >/dev/null' EXIT; \
-		mkdir -p dist; \
-		( cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
-		"$(KUSTOMIZE)" build config/default > dist/install.yaml
-
-##@ Deployment
-
-# Kind load target to load the controller image into a kind cluster.
 .PHONY: kind-load
 kind-load:
 	$(CONTAINER_TOOL) save -o $(KIND_IMAGE_ARCHIVE) $(IMG)
 	kind load image-archive --name $(KIND_CLUSTER) $(KIND_IMAGE_ARCHIVE)
-
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
-
-.PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	@out="$$( "$(KUSTOMIZE)" build config/crd 2>/dev/null || true )"; \
-	if [ -n "$$out" ]; then echo "$$out" | "$(KUBECTL)" apply -f -; else echo "No CRDs to install; skipping."; fi
-
-.PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	@out="$$( "$(KUSTOMIZE)" build config/crd 2>/dev/null || true )"; \
-	if [ -n "$$out" ]; then echo "$$out" | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
-
-.PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	@set -e; \
-		trap '$(MAKE) -C "$(CURDIR)" restore-kustomize >/dev/null' EXIT; \
-		( cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
-		"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
 
 .PHONY: deploy-kind
 deploy-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
@@ -351,91 +145,7 @@ deploy-kind: manifests kustomize ## Deploy controller to a Kind cluster (IfNotPr
 		( cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG} ); \
 		"$(KUSTOMIZE)" build config/kind | "$(KUBECTL)" apply -f -
 
-.PHONY: undeploy
-undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
-
-.PHONY: restore-kustomize
-restore-kustomize: ## Restore kustomize edits made by deploy/build targets.
-	git restore --source=HEAD --staged --worktree -- config/manager/kustomization.yaml
-
-##@ Dependencies
-
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p "$(LOCALBIN)"
-
-## Tool Binaries
-KUBECTL ?= kubectl
-KIND ?= kind
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v5.7.1
-CONTROLLER_TOOLS_VERSION ?= v0.20.0
-
-#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
-ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \
-  [ -n "$$v" ] || { echo "Set ENVTEST_VERSION manually (controller-runtime replace has no tag)" >&2; exit 1; }; \
-  printf '%s\n' "$$v" | sed -E 's/^v?([0-9]+)\.([0-9]+).*/release-\1.\2/')
-
-#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
-ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
-  [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
-  printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
-
-GOLANGCI_LINT_VERSION ?= v2.12.2
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
-
-.PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
-
-.PHONY: setup-envtest
-setup-envtest: aso-crds dis-identity-crd envtest ## Download the binaries required for ENVTEST in the local bin directory.
-	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."
-	@"$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path || { \
-		echo "Error: Failed to set up envtest binaries for version $(ENVTEST_K8S_VERSION)."; \
-		exit 1; \
-	}
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
-
-.PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
-
-# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
-# $1 - target path with name of binary
-# $2 - package url which can be installed
-# $3 - specific version of package
-define go-install-tool
-@[ -f "$(1)-$(3)" ] && [ "$$(readlink -- "$(1)" 2>/dev/null)" = "$(1)-$(3)" ] || { \
-set -e; \
-package=$(2)@$(3) ;\
-echo "Downloading $${package}" ;\
-rm -f "$(1)" ;\
-GOBIN="$(LOCALBIN)" go install $${package} ;\
-mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
-} ;\
-ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"
-endef
-
-define gomodver
-$(shell GOWORK=off go list -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' $(1) 2>/dev/null)
-endef
+##@ CRD downloads
 
 ASO_CRD_VERSION ?= v2.17.0
 DIS_IDENTITY_CRD_NAME ?= application.dis.altinn.cloud_applicationidentities.yaml


### PR DESCRIPTION
## What
Migrates `services/dis-pgsql-operator/Makefile` onto the shared root `Makefile.common` — the last of the four kubebuilder operators. The standard boilerplate, the now-kustomize-safe `deploy`/`build-installer`, and `test-e2e` come from the shared file; pgsql's customizations are expressed via **hooks and recipe-less prerequisite rules — no target overrides** (`make help` is warning-free).

- **Hooks:** `E2E_ENV := CERT_MANAGER_INSTALL_SKIP=…`, `E2E_GOTEST_FLAGS := -timeout=$(E2E_TEST_TIMEOUT)` (30m), `RUN_CHECKS := fmt generate manifests test-ci lint`, `SETUP_TOOLS := golangci-lint kustomize controller-gen setup-envtest`.
- **Recipe-less prereq rules:** `setup-envtest: aso-crds dis-identity-crd`, `setup-local-env: workspace`.
- **Kept as operator extras:** the Kind e2e apparatus (`test-e2e-kind`, `install-*-kind`, `deploy-kind`, `kind-load`, `seed-*`), `restore-kustomize` (used by `deploy-kind`/`clean`), the CRD fetchers, `workspace`, `test-ci`, and the operator config defaults (`AZURE_*`, `USE_AZ_FAKES`, …).

## No version churn
pgsql is already at the canonical tool versions (`controller-tools v0.20.0`, `golangci-lint v2.12.2`), so `make manifests generate` produces **no diff** — pure Makefile refactor.

## Verification
`make help` warning-free; `make -n` confirms the CRD prereqs, the `E2E_ENV`/`-timeout` injection, the inherited safe `deploy`/`build-installer`, and the `run-checks-ci` order; `make manifests generate` yields no change. `Makefile.common` added to the lint-test workflow paths (not release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test workflow triggers to run when shared build configuration changes.
  * Streamlined local development and CI setup by centralizing shared commands.
  * Improved operator test setup with required environment variables, CRDs, and timeout defaults.
  * Refined container image loading for Kind-based testing.
  * Organized CRD download commands for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->