### PR TITLE
chore(dis-vault): re-add modernize linter

### DIFF
--- a/services/dis-vault-operator/.golangci.yml
+++ b/services/dis-vault-operator/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - modernize
     - nakedret
     - prealloc
     - revive
@@ -26,6 +27,10 @@ linters:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    modernize:
+      disable:
+        - omitzero
+        - newexpr
   exclusions:
     generated: lax
     rules:

--- a/services/dis-vault-operator/test/utils/utils.go
+++ b/services/dis-vault-operator/test/utils/utils.go
@@ -167,8 +167,8 @@ func LoadImageToKindClusterWithName(name string) error {
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {
 	var res []string
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
+	elements := strings.SplitSeq(output, "\n")
+	for element := range elements {
 		if element != "" {
 			res = append(res, element)
 		}


### PR DESCRIPTION
## What
Re-enables the `modernize` linter in `dis-vault-operator/.golangci.yml`, aligning it with dis-apim/identity/pgsql (same `omitzero`/`newexpr` disables). vault was the only operator missing it.

Applying it surfaced one finding, auto-fixed via `golangci-lint run --fix`:

```diff
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
+	elements := strings.SplitSeq(output, "\n")
+	for element := range elements {
```

in the e2e test helper `test/utils/utils.go` — ranges the `iter.Seq` directly instead of allocating an intermediate slice (Go 1.24+ idiom).

## Why
Follow-up to the `Makefile.common` rollout, kept separate so a potential lint finding wouldn't block the vault migration. `make lint` is now clean (0 issues) with `modernize` enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)