### PR TITLE
chore(dis-console): Update dis-console image version to v1.7.3

### DIFF
--- a/deploy/admin/base/dis-console-agent-deployment.yaml
+++ b/deploy/admin/base/dis-console-agent-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.3
           args:
             - agent
           ports:

--- a/deploy/admin/base/dis-console-deployment.yaml
+++ b/deploy/admin/base/dis-console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.3
           args:
             - server
           ports:

--- a/deploy/common/at22/dis-console.yaml
+++ b/deploy/common/at22/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.3
           args:
             - agent
           ports:

--- a/deploy/common/at23/dis-console.yaml
+++ b/deploy/common/at23/dis-console.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.3
           args:
             - agent
           ports:

--- a/deploy/templates/dis-console-tenant-app-template/deployment.yaml
+++ b/deploy/templates/dis-console-tenant-app-template/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dis-console
-          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.2
+          image: ghcr.io/altinn/altinn-platform/dis-console:v1.7.3
           args:
             - agent
           ports:


### PR DESCRIPTION
## Why
dis-console v1.7.2 resolves duplicate Helm release claims last-writer-wins, so on admin_test the ASO chart Deployment gets attributed to the orphaned `platform-system/azure-service-operator` HelmRelease and the console UI shows no workloads under the healthy `azureserviceoperator-system` entry. v1.7.3 carries the fix (#3848): origin labels first, Ready tie-break in the annotation fallback.

## What
Pin all five dis-console images (admin agent + central server, at22/at23 agents, tenant app template) v1.7.2 → v1.7.3.

## Rollout
Merge after the v1.7.3 release PR (#3849) has published the image, then dispatch the admin + at22 + at23 syncroot publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dis-console deployment image to version v1.7.3 across all supported deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->