### PR TITLE
Add dedicated namespaces for access-management and access-management-bff

### DIFF
--- a/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
+++ b/infrastructure/adminservices-test/altinn-monitor-test-rg/k6_tests_rg_rbac.tf
@@ -163,6 +163,17 @@ variable "k8s_rbac" {
       dev_group = "dcf337f1-f1ba-428e-b101-642d9d619c73"
       sp_group  = "447482ce-de4b-4081-b611-e510252c3120"
     },
+    "access-management-bff" = { # TODO: Create dedicated groups
+      namespace = "access-management-bff"
+      dev_group = "5c42ac79-86e2-46d0-85d3-ae751dd5f057"
+      sp_group  = "328cbe61-aeb1-4782-bb36-d288c69b4f15"
+    },
+    "access-management" = { # TODO: Create dedicated groups
+      namespace = "access-management"
+      dev_group = "5c42ac79-86e2-46d0-85d3-ae751dd5f057"
+      sp_group  = "328cbe61-aeb1-4782-bb36-d288c69b4f15"
+    },
+
     register = {
       namespace = "register"
       dev_group = "cd36f41f-fc41-4f07-92f3-ce7f4db7caee"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added role-based access configuration for the access management services in the monitoring test environment.
  * Enabled existing authentication developer and service-principal groups to access the relevant service namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->