### PR TITLE
feat(gh-runners): add info.altinn.no runners

### DIFF
--- a/infrastructure/gh-runners/info.altinn.no.tf
+++ b/infrastructure/gh-runners/info.altinn.no.tf
@@ -1,0 +1,17 @@
+# GitHub: Altinn/info.altinn.no (product: infoportal)
+module "gh_runners_info_altinn_no" {
+  source = "../modules/gh-runners"
+
+  resource_group_name           = azurerm_resource_group.gh_runners.name
+  repository_name               = "info.altinn.no"
+  private_runners_address_space = "172.17.135.0/24"
+  private_runners_prefix        = "infoportal"
+  altinn_app_id                 = var.altinn_app_id
+  altinn_app_install_id         = var.altinn_app_install_id
+  altinn_app_key                = var.altinn_app_key
+  host_ip                       = var.host_ip
+  tags = merge(local.tags, {
+    finops_product = "infoportal"
+    product        = "infoportal"
+  })
+}


### PR DESCRIPTION
Closes #3838

Adds self-hosted GitHub Actions runners for [Altinn/info.altinn.no](https://github.com/Altinn/info.altinn.no), following the existing per-repository pattern in `infrastructure/gh-runners`.

## Configuration

| Setting | Value | Rationale |
|---|---|---|
| `repository_name` | `info.altinn.no` | |
| `private_runners_address_space` | `172.17.135.0/24` | Next free `/24`; `.128`–`.134` are taken |
| `private_runners_prefix` | `infoportal` | 10 chars, within the module's 11-char limit |
| `finops_product` / `product` | `infoportal` | Matches the product key already used in `infrastructure/syncroots/terraform.tfvars.json` |

## Runner sizing

`runner_cpu` / `runner_memory` are currently left at the module defaults (2.0 / 4Gi).

Worth a reviewer opinion: #3838 states the team's most important workflows are *"Docker build and publish"* and *"Publish Syncroot artifacts"*. Docker builds are the heavier of the two, and every other non-docs repo here is provisioned at 4.0 / 8Gi. Happy to bump this before merge if team-platform prefers.

## Note on the repository name

This is the first onboarded repo whose name contains periods, so the naming path was checked explicitly:

- The repo name only reaches the VNet and subnet names (`info.altinn.no-runners`) — Azure permits periods in both.
- Key Vault, Container App Environment and Container App Job names all derive from `resource_prefix`, not the repo name. The Key Vault resolves to `infoportal` + 6 random chars + `acaghr` = 22 chars, within the 24-char limit.
- Elsewhere the repo name is only a `for_each` key and the `REPO_NAME` env value.

## Verification

- `terraform fmt -check` — clean
- `terraform validate` — `Success! The configuration is valid.`

Plan output on this PR should show only additive resources.

## Follow-up (not in this PR)

Switching the workflows in `Altinn/info.altinn.no` over to `runs-on: self-hosted` happens in that repo. The runners register as **ephemeral** (one job per runner) with the label `default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
