### PR TITLE
feat(gh-runners): allow per-repository runner image override

### DIFF
--- a/infrastructure/gh-runners/info.altinn.no.tf
+++ b/infrastructure/gh-runners/info.altinn.no.tf
@@ -10,6 +10,11 @@ module "gh_runners_info_altinn_no" {
   altinn_app_install_id         = var.altinn_app_install_id
   altinn_app_key                = var.altinn_app_key
   host_ip                       = var.host_ip
+
+  # Staged rollout of v0.10.0 (adds yq, needed by Altinn/info.altinn.no#695).
+  # Remove this override once proven here and the module default is moved up.
+  runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.10.0"
+
   tags = merge(local.tags, {
     finops_product = "infoportal"
     product        = "infoportal"

--- a/infrastructure/modules/gh-runners/main.tf
+++ b/infrastructure/modules/gh-runners/main.tf
@@ -41,8 +41,7 @@ module "container_apps_gh_runners" {
   resource_group_name      = var.resource_group_name
   runner_cpu               = var.runner_cpu
   runner_memory            = var.runner_memory
-  # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
-  runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.8.0"
+  runner_image             = var.runner_image
   additional_tags = merge(
     var.tags,
     { submodule = "${var.repository_name}-github-runners" }

--- a/infrastructure/modules/gh-runners/variables.tf
+++ b/infrastructure/modules/gh-runners/variables.tf
@@ -58,3 +58,10 @@ variable "runner_memory" {
   description = "Memory allocated to a runner"
   default     = "4Gi"
 }
+
+variable "runner_image" {
+  type        = string
+  description = "Runner image. Override per repository to roll a new image out to one repository at a time before changing this default."
+  # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
+  default = "ghcr.io/altinn/altinn-platform/gh-runner:v0.8.0"
+}


### PR DESCRIPTION
Makes `runner_image` overridable per repository, and uses it to roll `v0.10.0` out to **info.altinn.no only**.

Supersedes #3895 (which bumped all eight repos at once).
Refs #3838

## Why

`runner_image` was hardcoded in the shared module, so every bump hit all eight repositories simultaneously with no way to try it in one place first. That's the blast-radius problem I flagged on #3895.

## What

- `runner_image` becomes a module variable, defaulting to the current `v0.8.0` — same pattern as the existing `runner_cpu` / `runner_memory`
- `info.altinn.no.tf` overrides it to `v0.10.0`
- The other seven repos (altinn-broker, altinn-correspondence, altinn-platform, altinn-studio-docs, dialogporten, dialogporten-frontend, dialogporten-manifests) keep `v0.8.0` — no change to them at all

Once v0.10.0 is proven on infoportal, the follow-up is a one-liner: move the default up and delete the override.

## Why v0.10.0 for infoportal

It adds `yq` (#3893), which unblocks Altinn/info.altinn.no#695 — that workflow calls `yq` in three steps. It also picks up `corepack` from 0.9.0.

The version jump is purely additive. I diffed the Dockerfile at both release tags:

| | ghrunner-0.8.0 | ghrunner-0.10.0 |
|---|---|---|
| Base image | `actions-runner:2.334.0@sha256:b6614fce…` | **identical** |
| Node | 24 | 24 |
| corepack | – | added |
| yq | – | added |

Same base digest, same runner version, nothing removed.

## Note: this pin is not renovate-managed

I kept the existing `# renovate:` annotation on the new default, but it does not work and never has:

- `v0.8.0` was set by hand in #3492 on 2026-05-21
- 0.9.0 (May 27) and 0.9.1 (May 31) shipped within ten days and were never picked up — ~3 months stale

I ran this repo's own `customManagers[0].matchStrings` against the file: no match. All three patterns require `packageName=` (the annotation only has `depName=`), and pattern 2 additionally expects a `*_VERSION =` line. Left out of this PR deliberately to keep it focused — the fix is either a new `customManagers` pattern for terraform image pins, or restructuring to a `_VERSION` local (which would need a non-idiomatic uppercase local name). Happy to open that separately.

## Verification

```
$ terraform fmt -check -recursive infrastructure/modules/gh-runners/ infrastructure/gh-runners/
(clean)
$ terraform init -backend=false && terraform validate
Success! The configuration is valid.
```

`validate` matters here beyond syntax — it resolves the upstream `github_runner_container_app_jobs` module and confirms `runner_image` is a real input on it, not just valid HCL.

Also verified the released image itself has the tool this is all for:

```
$ docker run --rm ghcr.io/altinn/altinn-platform/gh-runner:v0.10.0 \
    bash -c 'whoami; command -v yq && yq --version'
user: runner
/usr/local/bin/yq
yq (https://github.com/mikefarah/yq/) version v4.53.3
```

Current deployed state is `v0.8.0` across the board (checked via `az containerapp job show`), so on merge only the `infoportal-*` job should change.

## After merge

The 11 Terraform workflows in info.altinn.no already run on these runners and pass, so they act as a free canary for v0.10.0 on the next PR that touches them. Then Altinn/info.altinn.no#695 can merge and be dispatched against at22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
