### PR TITLE
feat: support custom runner labels

### DIFF
--- a/infrastructure/modules/gh-runners/main.tf
+++ b/infrastructure/modules/gh-runners/main.tf
@@ -41,6 +41,7 @@ module "container_apps_gh_runners" {
   resource_group_name      = var.resource_group_name
   runner_cpu               = var.runner_cpu
   runner_memory            = var.runner_memory
+  runner_labels            = var.runner_labels
   # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
   runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.8.0"
   additional_tags = merge(

--- a/infrastructure/modules/gh-runners/variables.tf
+++ b/infrastructure/modules/gh-runners/variables.tf
@@ -58,3 +58,9 @@ variable "runner_memory" {
   description = "Memory allocated to a runner"
   default     = "4Gi"
 }
+
+variable "runner_labels" {
+  default     = "default"
+  type        = string
+  description = "Additional labels to add to the runner"
+}


### PR DESCRIPTION
labels makes it possible to have multiple self-hosted runners with different spec in the same repo.

support-private repo leverages runner labels so we need to add a custom label for their existing workflows to work

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
Preparations for issue #3899 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable labels for GitHub Actions runners.
  * Runners now receive the specified label value, with `"default"` used when no custom label is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->