### PR TITLE
feat(gh-runners): allow per-repository runner image override

### DIFF
--- a/infrastructure/gh-runners/info.altinn.no.tf
+++ b/infrastructure/gh-runners/info.altinn.no.tf
@@ -10,6 +10,11 @@ module "gh_runners_info_altinn_no" {
   altinn_app_install_id         = var.altinn_app_install_id
   altinn_app_key                = var.altinn_app_key
   host_ip                       = var.host_ip
+
+  # Staged rollout of v0.10.0 (adds yq, needed by Altinn/info.altinn.no#695).
+  # Remove this override once proven here and the module default is moved up.
+  runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.10.0"
+
   tags = merge(local.tags, {
     finops_product = "infoportal"
     product        = "infoportal"

--- a/infrastructure/gh-runners/info.altinn.no.tf
+++ b/infrastructure/gh-runners/info.altinn.no.tf
@@ -10,11 +10,6 @@ module "gh_runners_info_altinn_no" {
   altinn_app_install_id         = var.altinn_app_install_id
   altinn_app_key                = var.altinn_app_key
   host_ip                       = var.host_ip
-
-  # Staged rollout of v0.10.0 (adds yq, needed by Altinn/info.altinn.no#695).
-  # Remove this override once proven here and the module default is moved up.
-  runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.10.0"
-
   tags = merge(local.tags, {
     finops_product = "infoportal"
     product        = "infoportal"

--- a/infrastructure/modules/gh-runners/main.tf
+++ b/infrastructure/modules/gh-runners/main.tf
@@ -42,8 +42,7 @@ module "container_apps_gh_runners" {
   runner_cpu               = var.runner_cpu
   runner_memory            = var.runner_memory
   runner_labels            = var.runner_labels
-  # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
-  runner_image = "ghcr.io/altinn/altinn-platform/gh-runner:v0.10.0"
+  runner_image             = var.runner_image
   additional_tags = merge(
     var.tags,
     { submodule = "${var.repository_name}-github-runners" }

--- a/infrastructure/modules/gh-runners/variables.tf
+++ b/infrastructure/modules/gh-runners/variables.tf
@@ -69,5 +69,5 @@ variable "runner_image" {
   type        = string
   description = "Runner image. Override per repository to roll a new image out to one repository at a time before changing this default."
   # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
-  default = "ghcr.io/altinn/altinn-platform/gh-runner:v0.8.0"
+  default = "ghcr.io/altinn/altinn-platform/gh-runner:v0.10.0"
 }

--- a/infrastructure/modules/gh-runners/variables.tf
+++ b/infrastructure/modules/gh-runners/variables.tf
@@ -64,3 +64,10 @@ variable "runner_labels" {
   type        = string
   description = "Additional labels to add to the runner"
 }
+
+variable "runner_image" {
+  type        = string
+  description = "Runner image. Override per repository to roll a new image out to one repository at a time before changing this default."
+  # renovate: datasource=docker depName=ghcr.io/altinn/altinn-platform/gh-runner
+  default = "ghcr.io/altinn/altinn-platform/gh-runner:v0.8.0"
+}


### PR DESCRIPTION
runner_image was hardcoded in the shared module, so every image bump rolled out to all eight repositories at once with no way to try it somewhere first.

v0.10.0 adds yq (#3893), which unblocks Altinn/info.altinn.no#695. It also picks up corepack from 0.9.0. Base image digest and runner version are unchanged between v0.8.0 and v0.10.0, so the difference is purely additive.

Refs #3838

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable GitHub Actions runner images, allowing repositories to override the default image.

* **Chores**
  * Set the default runner image to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->