### PR TITLE
chore(actions): deprecate the actions moving to dis-way/actions

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -1,0 +1,83 @@
+# Actions
+
+Reusable GitHub Actions for the Altinn platform.
+
+> [!WARNING]
+> **The actions that other repositories consume are being moved to
+> [`dis-way/actions`](https://github.com/dis-way/actions).**
+> They have been duplicated there under the `altinn/` namespace and are
+> deprecated here. Each deprecated action emits a `::warning::` annotation when
+> it runs. Nothing has been removed yet — existing workflows keep working — but
+> update `uses:` references to the new location when convenient.
+
+## Migration status
+
+| Action | Status | New location |
+| --- | --- | --- |
+| `terraform/plan` | Deprecated | `dis-way/actions/altinn/terraform/plan` |
+| `terraform/apply` | Deprecated | `dis-way/actions/altinn/terraform/apply` |
+| `terraform/init` | Deprecated | `dis-way/actions/altinn/terraform/init` |
+| `terraform/write-terraform-summary` | Deprecated | `dis-way/actions/altinn/terraform/write-terraform-summary` |
+| `flux/build-push-image` | Deprecated | `dis-way/actions/altinn/flux/build-push-image` |
+| `flux/retag-image` | Deprecated | `dis-way/actions/altinn/flux/retag-image` |
+| `flux/verify-syncroot` | Deprecated | `dis-way/actions/altinn/flux/verify-syncroot` |
+| `flux/setup-flux-acr` | Deprecated | `dis-way/actions/altinn/flux/setup-flux-acr` |
+| `terraform/plan-only` | **Stays here** | — |
+| `terraform/apply-only` | **Stays here** | — |
+| `generate-k6-manifests` | **Stays here** | — |
+| `terraform/azure-app-token` | **Stays here** (unused) | — |
+
+Only the actions consumed by repositories *outside* this one are moving —
+`terraform/plan`, `terraform/apply`, `flux/build-push-image`,
+`flux/retag-image` and `flux/verify-syncroot` — together with the three they
+call internally (`terraform/init`, `terraform/write-terraform-summary`,
+`flux/setup-flux-acr`).
+
+`flux/setup-flux-acr` is deprecated but does not emit a runtime warning: it has
+no direct consumers, so the annotation would only ever fire transitively and
+would double up the warning already emitted by `flux/build-push-image` and
+`flux/retag-image`.
+
+## Why four actions stay
+
+**`terraform/plan-only`** and **`terraform/apply-only`** are used only by this
+repository's own [`k6tests-rg-deploy`](../.github/workflows/k6tests-rg-deploy.yml)
+workflow. Nothing outside `altinn-platform` references them, so there is no
+migration to do.
+
+**`generate-k6-manifests`** cannot move cleanly. The `generate-k6-manifests`
+binary is not built from the sources in this folder at action runtime — it is
+compiled into `ghcr.io/altinn/altinn-platform/k6-action-image` by
+[`infrastructure/images/k6-action/Dockerfile`](../infrastructure/images/k6-action/Dockerfile),
+whose build context is this repository's root. The action's own `Dockerfile`
+only layers `generate.sh` on top of that image. The generator also resolves
+`ghcr.io/altinn/altinn-platform/k6-image` as the k6 runner and reads cluster
+config baked into the image at `/actions/generate-k6-manifests/infra/`.
+
+Moving the action without also moving `infrastructure/images/k6-action/` would
+produce a repository where editing the Go sources changes nothing at runtime —
+a trap rather than a migration. Its only consumer is
+`Altinn/altinn-platform-validation-tests`.
+
+**`terraform/azure-app-token`** has no consumers — not in this repository and
+not in any other repository that references
+`Altinn/altinn-platform/actions`. `dis-way/actions` already has its own copy.
+Duplicating it would carry dead code across; it should be kept or deleted here
+on its own merits.
+
+## Migrating a workflow
+
+Replace the `uses:` path and keep the `with:` block unchanged:
+
+```diff
+-  uses: Altinn/altinn-platform/actions/terraform/plan@<hash>
++  uses: dis-way/actions/altinn/terraform/plan@<hash>
+```
+
+> [!CAUTION]
+> Do **not** repoint at `dis-way/actions/terraform/plan` (without `altinn/`).
+> That is a different, independently developed action: it uses a different Azure
+> storage account, resource group and subscription for Terraform state, and a
+> different state-key format. Unknown inputs are only a warning in GitHub
+> Actions, not an error, so a wrong path silently falls back to defaults and
+> plans against an empty state.

--- a/actions/flux/build-push-image/README.md
+++ b/actions/flux/build-push-image/README.md
@@ -1,7 +1,10 @@
+# Build and Push Flux OCI Image
 
 > [!WARNING]
 > **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
 >
-> It now lives at `dis-way/actions/altinn/terraform/write-terraform-summary`. Update your workflow to the new
+> It now lives at `dis-way/actions/altinn/flux/build-push-image`. Update your workflow to the new
 > location; this copy will be removed once all consumers have migrated.
 > See [the migration notes](../../README.md) for status and the full action list.
+
+See [`action.yaml`](action.yaml) for the full list of inputs.

--- a/actions/flux/build-push-image/action.yaml
+++ b/actions/flux/build-push-image/action.yaml
@@ -36,6 +36,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/flux/build-push-image has moved to dis-way/actions/altinn/flux/build-push-image. Update your workflow to the new location - this copy will be removed."
+
     - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
       uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@e095eaa67ba630897e9b488a933c8ebb82b36732 # main
       id: setup_flux_acr

--- a/actions/flux/retag-image/README.md
+++ b/actions/flux/retag-image/README.md
@@ -1,7 +1,10 @@
+# Retag Flux OCI Image
 
 > [!WARNING]
 > **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
 >
-> It now lives at `dis-way/actions/altinn/terraform/write-terraform-summary`. Update your workflow to the new
+> It now lives at `dis-way/actions/altinn/flux/retag-image`. Update your workflow to the new
 > location; this copy will be removed once all consumers have migrated.
 > See [the migration notes](../../README.md) for status and the full action list.
+
+See [`action.yaml`](action.yaml) for the full list of inputs.

--- a/actions/flux/retag-image/action.yaml
+++ b/actions/flux/retag-image/action.yaml
@@ -37,6 +37,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/flux/retag-image has moved to dis-way/actions/altinn/flux/retag-image. Update your workflow to the new location - this copy will be removed."
+
     - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
       uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@e095eaa67ba630897e9b488a933c8ebb82b36732 # main
       id: setup_flux_acr

--- a/actions/flux/setup-flux-acr/README.md
+++ b/actions/flux/setup-flux-acr/README.md
@@ -1,7 +1,10 @@
+# Setup Flux + ACR
 
 > [!WARNING]
 > **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
 >
-> It now lives at `dis-way/actions/altinn/terraform/write-terraform-summary`. Update your workflow to the new
+> It now lives at `dis-way/actions/altinn/flux/setup-flux-acr`. Update your workflow to the new
 > location; this copy will be removed once all consumers have migrated.
 > See [the migration notes](../../README.md) for status and the full action list.
+
+See [`action.yaml`](action.yaml) for the full list of inputs.

--- a/actions/flux/verify-syncroot/README.md
+++ b/actions/flux/verify-syncroot/README.md
@@ -1,7 +1,10 @@
+# Verify Flux Syncroot
 
 > [!WARNING]
 > **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
 >
-> It now lives at `dis-way/actions/altinn/terraform/write-terraform-summary`. Update your workflow to the new
+> It now lives at `dis-way/actions/altinn/flux/verify-syncroot`. Update your workflow to the new
 > location; this copy will be removed once all consumers have migrated.
 > See [the migration notes](../../README.md) for status and the full action list.
+
+See [`action.yaml`](action.yaml) for the full list of inputs.

--- a/actions/flux/verify-syncroot/action.yaml
+++ b/actions/flux/verify-syncroot/action.yaml
@@ -13,6 +13,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/flux/verify-syncroot has moved to dis-way/actions/altinn/flux/verify-syncroot. Update your workflow to the new location - this copy will be removed."
+
     - name: Validate folder structure
       shell: bash
       env:

--- a/actions/terraform/apply/README.md
+++ b/actions/terraform/apply/README.md
@@ -1,5 +1,12 @@
 # Introduction
 
+> [!WARNING]
+> **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
+>
+> It now lives at `dis-way/actions/altinn/terraform/apply`. Update your workflow to the new
+> location; this copy will be removed once all consumers have migrated.
+> See [the migration notes](../../README.md) for status and the full action list.
+
 This GitHub Action downloads the previously generated Terraform plan from GitHub artifacts and executes `terraform apply` with the downloaded plan. This action will not run unless the `altinn/altinn-platform/actions/terraform/plan` action has been executed first.
 
 ## Sample

--- a/actions/terraform/apply/action.yaml
+++ b/actions/terraform/apply/action.yaml
@@ -52,6 +52,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/terraform/apply has moved to dis-way/actions/altinn/terraform/apply. Update your workflow to the new location - this copy will be removed."
+
     - name: Terraform Init
       uses: Altinn/altinn-platform/actions/terraform/init@main
       with:

--- a/actions/terraform/init/README.md
+++ b/actions/terraform/init/README.md
@@ -1,7 +1,10 @@
+# Terraform Init
 
 > [!WARNING]
 > **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
 >
-> It now lives at `dis-way/actions/altinn/terraform/write-terraform-summary`. Update your workflow to the new
+> It now lives at `dis-way/actions/altinn/terraform/init`. Update your workflow to the new
 > location; this copy will be removed once all consumers have migrated.
 > See [the migration notes](../../README.md) for status and the full action list.
+
+See [`action.yaml`](action.yaml) for the full list of inputs.

--- a/actions/terraform/init/action.yaml
+++ b/actions/terraform/init/action.yaml
@@ -74,6 +74,14 @@ outputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/terraform/init has moved to dis-way/actions/altinn/terraform/init. Update your workflow to the new location - this copy will be removed."
+
     - name: Terraform Install
       id: install
       uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4

--- a/actions/terraform/plan/README.md
+++ b/actions/terraform/plan/README.md
@@ -1,5 +1,12 @@
 # Description
 
+> [!WARNING]
+> **Deprecated — this action has moved to [`dis-way/actions`](https://github.com/dis-way/actions).**
+>
+> It now lives at `dis-way/actions/altinn/terraform/plan`. Update your workflow to the new
+> location; this copy will be removed once all consumers have migrated.
+> See [the migration notes](../../README.md) for status and the full action list.
+
 This GitHub Action executes `terraform plan` against a specified environment and publishes the plan as a GitHub artifact. In addition, this action runs `terraform fmt` and `terraform validate`, and includes the results of all three (`fmt`, `validate`, and `plan`) in the GitHub Action Summary. If this action is triggered by a pull request, it will also post a comment with the summary.
 
 

--- a/actions/terraform/plan/action.yaml
+++ b/actions/terraform/plan/action.yaml
@@ -53,6 +53,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/terraform/plan has moved to dis-way/actions/altinn/terraform/plan. Update your workflow to the new location - this copy will be removed."
+
     - name: Terraform Init
       id: terraform_init
       uses: Altinn/altinn-platform/actions/terraform/init@main

--- a/actions/terraform/write-terraform-summary/action.yaml
+++ b/actions/terraform/write-terraform-summary/action.yaml
@@ -20,6 +20,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # DEPRECATED: this action has moved to dis-way/actions.
+    # Remove this step together with the rest of the action once all
+    # consumers have migrated to the new location.
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::Altinn/altinn-platform/actions/terraform/write-terraform-summary has moved to dis-way/actions/altinn/terraform/write-terraform-summary. Update your workflow to the new location - this copy will be removed."
+
     - name: generate random delimiter
       shell: bash
       run: echo "DELIMITER=$(uuidgen)" >> $GITHUB_ENV


### PR DESCRIPTION
Marks the reusable actions that repositories **outside this one** consume as deprecated. They have been duplicated into [`dis-way/actions`](https://github.com/dis-way/actions) under an `altinn/` namespace in dis-way/actions#68.

Nothing is removed and no behaviour changes — existing workflows keep working. This is purely a signal so consumers can migrate.

## Scope

Five actions have external consumers, found via GitHub code search across all repos referencing `Altinn/altinn-platform/actions`:

| Action | External consumer repos |
| --- | --- |
| `flux/build-push-image` | 8 — `altinn-correspondence`, `dialogporten-manifests`, `dialogporten-frontend-manifests`, `altinn-dashboards-grafana`, `digdir/ki.norge.no`, `dis-demo-aalma`, `dis-demo-vgauk`, `info.altinn.no` |
| `terraform/plan` | 5 — `info.altinn.no` (×11), `altinn-authorization-tmp`, `dd-infrastructure`, `altinn-authorization`, `digdir/dis-syncroots` |
| `terraform/apply` | 4 — same cluster, 16 refs |
| `flux/verify-syncroot` | 3 — `dis-demo-aalma`, `altinn-correspondence`, `dis-demo-vgauk` |
| `flux/retag-image` | 1 — `altinn-correspondence` |

Plus the three they call internally, which have no external consumers of their own but must move for the above to work: `terraform/init`, `terraform/write-terraform-summary`, `flux/setup-flux-acr`.

## What each deprecated action gets

- A **`::warning::` annotation** as its first step, naming the new location. This is what actually reaches the external repos — they won't read a README.
- A **README banner**. Five of them had no README, so those were created.
- An entry in the new [`actions/README.md`](actions/README.md), which carries the migration table and the reasoning below.

`flux/setup-flux-acr` gets the banner but **no** runtime warning: it has no direct consumers, so the annotation would only ever fire transitively and would double up the warning already emitted by `flux/build-push-image` and `flux/retag-image`. Its `action.yaml` is unchanged.

## Four actions are not moving, and are untouched here

- **`terraform/plan-only`** and **`terraform/apply-only`** — used only by this repository's own `k6tests-rg-deploy` workflow. Nothing outside `altinn-platform` references them.
- **`terraform/azure-app-token`** — no consumers anywhere, in this repo or any other. `dis-way/actions` already has its own copy.
- **`generate-k6-manifests`** — its binary is not built from the sources in that folder at action runtime. It is compiled into `ghcr.io/altinn/altinn-platform/k6-action-image` by `infrastructure/images/k6-action/Dockerfile`, whose build context is this repository's root; the action's own `Dockerfile` only layers `generate.sh` on top. The generator also resolves `ghcr.io/altinn/altinn-platform/k6-image` as the k6 runner and reads cluster config baked into the image at `/actions/generate-k6-manifests/infra/`. Moving it without `infrastructure/images/k6-action/` would produce a repo where editing the Go sources changes nothing at runtime — a trap rather than a migration.

## Migrating a workflow

Replace the `uses:` path and keep the `with:` block unchanged:

```diff
-  uses: Altinn/altinn-platform/actions/terraform/plan@<hash>
+  uses: dis-way/actions/altinn/terraform/plan@<hash>
```

> [!CAUTION]
> Do **not** repoint at `dis-way/actions/terraform/plan` (without `altinn/`). That is a different, independently developed action — different Azure storage account, resource group and subscription for Terraform state, and a different state-key format. Unknown inputs are only a warning in GitHub Actions, not an error, so a wrong path silently falls back to defaults and plans against an empty state. `actions/README.md` spells this out.

## Sequencing

dis-way/actions#68 should merge first, and its internal action references bumped to the merged SHA, before anyone acts on these warnings — the `dis-way/actions/altinn/...` paths do not resolve until then.

## Verification

- All 12 action files still parse; the four non-moving ones are byte-identical to `main`
- `actionlint` reports 0 findings under `actions/`
- All relative links in the new and edited READMEs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
