### PR TITLE
fix(flux): repin setup-flux-acr so build-push-image picks up the ACR login fix

### DIFF
--- a/actions/flux/build-push-image/action.yaml
+++ b/actions/flux/build-push-image/action.yaml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
-      uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@e095eaa67ba630897e9b488a933c8ebb82b36732 # main
+      uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@b0c9762442f2f97346d8b115c30903df903fc010 # main
       id: setup_flux_acr
       with:
         azure_app_id: ${{ inputs.azure_app_id }}

--- a/actions/flux/retag-image/action.yaml
+++ b/actions/flux/retag-image/action.yaml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - name: Prepare Job for Pushing Flux OCI Artifacts to Azure Container Registry
-      uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@e095eaa67ba630897e9b488a933c8ebb82b36732 # main
+      uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@b0c9762442f2f97346d8b115c30903df903fc010 # main
       id: setup_flux_acr
       with:
         azure_app_id: ${{ inputs.azure_app_id }}


### PR DESCRIPTION
#3912 fixed `flux --provider=azure` on the self-hosted runners, but the fix cannot reach any consumer, because `build-push-image` and `retag-image` pin `setup-flux-acr` **by SHA**:

```yaml
uses: Altinn/altinn-platform/actions/flux/setup-flux-acr@e095eaa67ba630897e9b488a933c8ebb82b36732 # main
```

`e095eaa` is from 2026-06-09 — two months before #3912 landed on 2026-08-20. Neither wrapper's `action.yaml` has been touched since, so `main` still carries the pre-fix pin today, and consumers bumping their own `build-push-image` digest (as `dialogporten-manifests` did in #61) get a byte-identical action. This repins both to `b0c9762`, the commit that carries the fix.

## Why the renovate PR hasn't done this

#3677 makes the same repin — to `4dc0424`, which also contains the fix — but it has been open since 2026-06-11 and is stuck: `renovate/stability-days` is PENDING, and renovate re-targets the branch at the newest `main` SHA as this repo advances, restarting the timer. A perpetually-active `main` means that check plausibly never settles. This PR is deliberately narrow — two lines, no workflow digest bumps — so it can be reviewed and merged on its own.

## Impact today

`Altinn/dialogporten-manifests` has had both `Publish Flux artifacts` jobs failing since moving to self-hosted runners, with the exact failure from #3912:

```
✗ error during login with provider: ... DefaultAzureCredential: failed to acquire a token
    ManagedIdentityCredential authentication failed.
    GET http://localhost:12356/msi/token
    RESPONSE 400: Unable to load the proper Managed Identity
```

It is unblocked for now by clearing `IDENTITY_ENDPOINT`/`MSI_ENDPOINT` per job (Altinn/dialogporten-manifests#73, the same workaround as Altinn/info.altinn.no#706). Both of those can be reverted once this lands. Per #3926, `flux/build-push-image` has 8 external consumer repos, so anyone else moving a flux workflow onto these runners hits the same wall until then.

## Relationship to the dis-way migration

Independent, and this does not conflict with it. dis-way/actions#68 copies these actions under `altinn/`, and its copy of `setup-flux-acr` already embeds the #3912 fix — so the bug does not follow consumers to the new home. But that PR and #3926 are both still open, and consumers are on the `Altinn/altinn-platform` paths until they migrate. This closes the gap in the meantime.

## Verification

- `setup-flux-acr/action.yaml@b0c9762` contains the `Expose federated credentials to the Azure SDK` step; `@e095eaa` does not.
- `b0c9762` is the most recent commit touching that file, so this pins the current state of the action rather than an arbitrary intermediate.
- Diff is two lines, one per wrapper. No behaviour change on GitHub-hosted runners: `WorkloadIdentityCredential` simply resolves before the CLI credential the chain reaches there today, as the same application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)