### PR TITLE
fix(syncroots): align altinn-dashboards-grafana ACR prefix with its artifact path

### DIFF
--- a/infrastructure/syncroots/terraform.tfvars.json
+++ b/infrastructure/syncroots/terraform.tfvars.json
@@ -41,7 +41,7 @@
         "main"
       ]
     },
-    "dashboardsgrafana": {
+    "monitoring": {
       "repo_name": "altinn-dashboards-grafana",
       "environments": [],
       "branches": [


### PR DESCRIPTION
## Problem

`altinn-dashboards-grafana` publishes its Flux OCI artifact to **`monitoring/grafana`**, but its product key here is `dashboardsgrafana`. Since [`azure_roles.tf`](../blob/main/infrastructure/modules/syncroot-github-repo/azure_roles.tf) hard-codes the ABAC condition as `'${var.product_name}/'`, its identity is granted:

```
Container Registry Repository Writer
  @Request[...repositories:name] StringStartsWith 'dashboardsgrafana/'
```

`monitoring/grafana` does not match that prefix, so ACR issues no push scope and the publish fails:

```
✗ pushing artifact failed: POST https://altinncr.azurecr.io/v2/monitoring/grafana/blobs/uploads/:
  UNAUTHORIZED: authentication required
  [map[Action:pull Name:monitoring/grafana Type:repository] map[Action:push Name:monitoring/grafana Type:repository]]
```

This surfaced only recently because `altinncr` is now in `roleAssignmentMode: AbacRepositoryPermissions`, where [legacy `AcrPush` is not honored](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-rbac-abac-repository-permissions#effect-on-existing-role-assignments). The unconditioned `AcrPush` assignment had been covering the mismatch; once it stopped counting, the condition became the only grant. Last successful publish 2026-08-05; failing since.

Every other product publishes under its own key — `dialogporten/`, `arbeidsflate/`, `infoportal/`, `studio/`, `dis/` — so this is the only mismatched entry.

## Change

Renames the product key `dashboardsgrafana` → `monitoring`. One line; no other reference to the old key exists in this repo. The new key satisfies the `^[a-zA-Z0-9]+$` validation on `product_syncroot_source_repos`.

The alternative — repointing the artifact to `dashboardsgrafana/…` — was rejected because that URL is the published contract consumed by a Flux `OCIRepository`, and is documented in the source repo's README and publish tooling.

## Apply notes — please read before running

`product_name` is the `for_each` key, so a plain apply **destroys** `module.syncroot_github_repo["dashboardsgrafana"]` and **creates** `module.syncroot_github_repo["monitoring"]`. Most of that is intended (the UAMI is renamed, so it must be replaced, and the role assignments carry uuidv5 names derived from `product_name`).

⚠️ **The hazard is the three `github_actions_secret` resources.** Both module instances write the same `DIS_SYNCROOT_AZURE_*` secret names to the same repo, and there is no dependency edge between them — so if the destroy of the old instance is ordered after the create of the new one, it will delete the secrets that were just written, leaving the repo with none.

Suggested mitigation — move the state first so it becomes an in-place value update instead of destroy+create:

```bash
terraform state mv \
  'module.syncroot_github_repo["dashboardsgrafana"]' \
  'module.syncroot_github_repo["monitoring"]'
```

Then plan/apply. Expected: UAMI replaced (name change), federated credential and both role assignments replaced, and the three GitHub secrets **updated in place** with the new client id.

After apply:
- Allow a few minutes for RBAC propagation.
- Re-run `publish-grafana-artifact.yml` on `Altinn/altinn-dashboards-grafana` — the failed run does not retry itself.
- Old `monitoring/grafana` tags are unaffected; the cluster keeps reconciling the last good artifact meanwhile.

## Verification

Confirmed against the live registry before opening this:

| Product | Granted prefix | Publishes to | |
|---|---|---|---|
| dialogporten | `dialogporten/` | `dialogporten/syncroot`, `dialogporten/dialogporten-sync` | ✅ |
| dashboardsgrafana | `dashboardsgrafana/` | `monitoring/grafana` | ❌ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)