### PR TITLE
chore: remove DNS record task from APP cluster establishment template

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-cluster-establishment.yml
+++ b/.github/ISSUE_TEMPLATE/app-cluster-establishment.yml
@@ -55,8 +55,6 @@ body:
           required: false
         - label: "Run pipeline with apply"
           required: false
-        - label: "Add DNS record for cluster"
-          required: false
         - label: "Assign CRM ticket to \"Altinn servicedesk\""
           required: false
 


### PR DESCRIPTION
Removes the "Add DNS record for cluster" checklist item from the APP cluster establishment issue template.

DNS records for new APP clusters are created as part of the pipeline apply step, so the manual task is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)